### PR TITLE
Add note support for bb watch, moderation API call refactor

### DIFF
--- a/bot/cogs/bigbrother.py
+++ b/bot/cogs/bigbrother.py
@@ -216,7 +216,7 @@ class BigBrother:
 
     @bigbrother_group.command(name='watch', aliases=('w',))
     @with_role(Roles.owner, Roles.admin, Roles.moderator)
-    async def watch_command(self, ctx: Context, user: User, reason: str = None):
+    async def watch_command(self, ctx: Context, user: User, *, reason: str = None):
         """
         Relay messages sent by the given `user` to the `#big-brother-logs` channel
 
@@ -251,6 +251,7 @@ class BigBrother:
                 reason = data.get('error_message', "no message provided")
                 await ctx.send(f":x: the API returned an error: {reason}")
 
+        # Add a note (shadow warning) if a reason is specified
         if reason:
             await post_infraction(ctx, user, type="warning", reason=reason, hidden=True)
 

--- a/bot/cogs/bigbrother.py
+++ b/bot/cogs/bigbrother.py
@@ -11,6 +11,7 @@ from bot.constants import BigBrother as BigBrotherConfig, Channels, Emojis, Guil
 from bot.decorators import with_role
 from bot.pagination import LinePaginator
 from bot.utils import messages
+from bot.utils.moderation import post_infraction
 
 log = logging.getLogger(__name__)
 
@@ -215,16 +216,14 @@ class BigBrother:
 
     @bigbrother_group.command(name='watch', aliases=('w',))
     @with_role(Roles.owner, Roles.admin, Roles.moderator)
-    async def watch_command(self, ctx: Context, user: User, channel: TextChannel = None):
+    async def watch_command(self, ctx: Context, user: User, reason: str = None):
         """
-        Relay messages sent by the given `user` in the given `channel`.
-        If `channel` is not specified, logs to the mod log channel.
+        Relay messages sent by the given `user` to the `#big-brother-logs` channel
+
+        If a `reason` is specified, a note is added for `user`
         """
 
-        if channel is not None:
-            channel_id = channel.id
-        else:
-            channel_id = Channels.big_brother_logs
+        channel_id = Channels.big_brother_logs
 
         post_data = {
             'user_id': str(user.id),
@@ -251,6 +250,9 @@ class BigBrother:
                 data = await response.json()
                 reason = data.get('error_message', "no message provided")
                 await ctx.send(f":x: the API returned an error: {reason}")
+
+        if reason:
+            await post_infraction(ctx, user, type="warning", reason=reason, hidden=True)
 
     @bigbrother_group.command(name='unwatch', aliases=('uw',))
     @with_role(Roles.owner, Roles.admin, Roles.moderator)

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -87,7 +87,9 @@ class Moderation(Scheduler):
             reason=reason
         )
 
-        await post_infraction(ctx, user, type="warning", reason=reason)
+        response_object = await post_infraction(ctx, user, type="warning", reason=reason)
+        if response_object is None:
+            return
 
         if reason is None:
             result_message = f":ok_hand: warned {user.mention}."
@@ -111,7 +113,9 @@ class Moderation(Scheduler):
             reason=reason
         )
 
-        await post_infraction(ctx, user, type="kick", reason=reason)
+        response_object = await post_infraction(ctx, user, type="kick", reason=reason)
+        if response_object is None:
+            return
 
         self.mod_log.ignore(Event.member_remove, user.id)
         await user.kick(reason=reason)
@@ -152,7 +156,9 @@ class Moderation(Scheduler):
             reason=reason
         )
 
-        await post_infraction(ctx, user, type="ban", reason=reason)
+        response_object = await post_infraction(ctx, user, type="ban", reason=reason)
+        if response_object is None:
+            return
 
         self.mod_log.ignore(Event.member_ban, user.id)
         self.mod_log.ignore(Event.member_remove, user.id)
@@ -194,7 +200,9 @@ class Moderation(Scheduler):
             reason=reason
         )
 
-        await post_infraction(ctx, user, type="mute", reason=reason)
+        response_object = await post_infraction(ctx, user, type="mute", reason=reason)
+        if response_object is None:
+            return
 
         # add the mute role
         self.mod_log.ignore(Event.member_update, user.id)
@@ -241,6 +249,8 @@ class Moderation(Scheduler):
         )
 
         response_object = await post_infraction(ctx, user, type="mute", reason=reason, duration=duration)
+        if response_object is None:
+            return
 
         self.mod_log.ignore(Event.member_update, user.id)
         await user.add_roles(self._muted_role, reason=reason)
@@ -291,6 +301,8 @@ class Moderation(Scheduler):
         )
 
         response_object = await post_infraction(ctx, user, type="ban", reason=reason, duration=duration)
+        if response_object is None:
+            return
 
         self.mod_log.ignore(Event.member_ban, user.id)
         self.mod_log.ignore(Event.member_remove, user.id)
@@ -337,7 +349,9 @@ class Moderation(Scheduler):
         :param reason: The reason for the warning.
         """
 
-        await post_infraction(ctx, user, type="warning", reason=reason, hidden=True)
+        response_object = await post_infraction(ctx, user, type="warning", reason=reason, hidden=True)
+        if response_object is None:
+            return
 
         if reason is None:
             result_message = f":ok_hand: note added for {user.mention}."
@@ -355,7 +369,9 @@ class Moderation(Scheduler):
         :param reason: The reason for the kick.
         """
 
-        await post_infraction(ctx, user, type="kick", reason=reason, hidden=True)
+        response_object = await post_infraction(ctx, user, type="kick", reason=reason, hidden=True)
+        if response_object is None:
+            return
 
         self.mod_log.ignore(Event.member_remove, user.id)
         await user.kick(reason=reason)
@@ -389,7 +405,9 @@ class Moderation(Scheduler):
         :param reason: The reason for the ban.
         """
 
-        await post_infraction(ctx, user, type="ban", reason=reason, hidden=True)
+        response_object = await post_infraction(ctx, user, type="ban", reason=reason, hidden=True)
+        if response_object is None:
+            return
 
         self.mod_log.ignore(Event.member_ban, user.id)
         self.mod_log.ignore(Event.member_remove, user.id)
@@ -424,7 +442,9 @@ class Moderation(Scheduler):
         :param reason: The reason for the mute.
         """
 
-        await post_infraction(ctx, user, type="mute", reason=reason, hidden=True)
+        response_object = await post_infraction(ctx, user, type="mute", reason=reason, hidden=True)
+        if response_object is None:
+            return
 
         # add the mute role
         self.mod_log.ignore(Event.member_update, user.id)
@@ -464,6 +484,8 @@ class Moderation(Scheduler):
         """
 
         response_object = await post_infraction(ctx, user, type="mute", reason=reason, duration=duration, hidden=True)
+        if response_object is None:
+            return
 
         self.mod_log.ignore(Event.member_update, user.id)
         await user.add_roles(self._muted_role, reason=reason)
@@ -509,6 +531,8 @@ class Moderation(Scheduler):
         """
 
         response_object = await post_infraction(ctx, user, type="ban", reason=reason, duration=duration, hidden=True)
+        if response_object is None:
+            return
 
         self.mod_log.ignore(Event.member_ban, user.id)
         self.mod_log.ignore(Event.member_remove, user.id)

--- a/bot/utils/moderation.py
+++ b/bot/utils/moderation.py
@@ -1,0 +1,41 @@
+import logging
+from typing import Union
+
+from aiohttp import ClientError
+from discord import Member, Object, User
+from discord.ext.commands import Context
+
+from bot.constants import Keys, URLs
+
+log = logging.getLogger(__name__)
+
+HEADERS = {"X-API-KEY": Keys.site_api}
+
+
+async def post_infraction(
+    ctx: Context, user: Union[Member, Object, User], type: str, reason: str, duration: str, hidden: bool = False
+):
+    try:
+        response = await ctx.bot.http_session.post(
+            URLs.site_infractions,
+            headers=HEADERS,
+            json={
+                "type": type,
+                "reason": reason,
+                "duration": duration,
+                "user_id": str(user.id),
+                "actor_id": str(ctx.message.author.id),
+                "hidden": hidden,
+            },
+        )
+    except ClientError:
+        log.exception("There was an error adding an infraction.")
+        await ctx.send(":x: There was an error adding the infraction.")
+        return
+
+    response_object = await response.json()
+    if "error_code" in response_object:
+        await ctx.send(f":x: There was an error adding the infraction: {response_object['error_message']}")
+        return
+
+    return response_object


### PR DESCRIPTION
Replace log-to channel specification with an optional moderation note.

To support this, the moderation cog infraction API calls are refactored to delegate to an external helper utility.

Resolves: #103, #200 