### PR TITLE
Restore superstar nickname after member leaves and rejoins

### DIFF
--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -29,6 +29,7 @@ INFRACTION_ICONS = {
     "Kick": Icons.sign_out,
     "Ban": Icons.user_ban
 }
+RULES_URL = "https://pythondiscord.com/about/rules"
 
 
 def proxy_user(user_id: str) -> Object:
@@ -1088,8 +1089,9 @@ class Moderation(Scheduler):
         )
 
         icon_url = INFRACTION_ICONS.get(infr_type, Icons.token_removed)
-        embed.set_author(name="Infraction Information", icon_url=icon_url)
-        embed.set_footer(text=f"Please review our rules over at https://pythondiscord.com/about/rules")
+        embed.set_author(name="Infraction Information", icon_url=icon_url, url=RULES_URL)
+        embed.title = f"Please review our rules over at {RULES_URL}"
+        embed.url = RULES_URL
 
         await self.send_private_embed(user, embed)
 

--- a/bot/cogs/modlog.py
+++ b/bot/cogs/modlog.py
@@ -614,10 +614,10 @@ class ModLog:
 
     async def on_message_edit(self, before: Message, after: Message):
         if (
-                not before.guild
-                or before.guild.id != GuildConstant.id
-                or before.channel.id in GuildConstant.ignored
-                or before.author.bot
+            not before.guild
+            or before.guild.id != GuildConstant.id
+            or before.channel.id in GuildConstant.ignored
+            or before.author.bot
         ):
             return
 
@@ -680,10 +680,10 @@ class ModLog:
             return
 
         if (
-                not message.guild
-                or message.guild.id != GuildConstant.id
-                or message.channel.id in GuildConstant.ignored
-                or message.author.bot
+            not message.guild
+            or message.guild.id != GuildConstant.id
+            or message.channel.id in GuildConstant.ignored
+            or message.author.bot
         ):
             return
 

--- a/bot/cogs/modlog.py
+++ b/bot/cogs/modlog.py
@@ -10,11 +10,16 @@ from discord import (
     CategoryChannel, Colour, Embed, File, Guild,
     Member, Message, NotFound, RawBulkMessageDeleteEvent,
     RawMessageDeleteEvent, RawMessageUpdateEvent, Role,
-    TextChannel, User, VoiceChannel)
+    TextChannel, User, VoiceChannel
+)
 from discord.abc import GuildChannel
 from discord.ext.commands import Bot
 
-from bot.constants import Channels, Colours, Emojis, Event, Guild as GuildConstant, Icons, Keys, Roles, URLs
+from bot.constants import (
+    Channels, Colours, Emojis,
+    Event, Guild as GuildConstant, Icons,
+    Keys, Roles, URLs
+)
 from bot.utils.time import humanize_delta
 
 log = logging.getLogger(__name__)
@@ -608,8 +613,12 @@ class ModLog:
         )
 
     async def on_message_edit(self, before: Message, after: Message):
-        if not before.guild or before.guild.id != GuildConstant.id \
-                or before.channel.id in GuildConstant.ignored or before.author.bot:
+        if (
+                not before.guild
+                or before.guild.id != GuildConstant.id
+                or before.channel.id in GuildConstant.ignored
+                or before.author.bot
+        ):
             return
 
         self._cached_edits.append(before.id)
@@ -670,8 +679,12 @@ class ModLog:
         except NotFound:  # Was deleted before we got the event
             return
 
-        if not message.guild or message.guild.id != GuildConstant.id \
-                or message.channel.id in GuildConstant.ignored or message.author.bot:
+        if (
+                not message.guild
+                or message.guild.id != GuildConstant.id
+                or message.channel.id in GuildConstant.ignored
+                or message.author.bot
+        ):
             return
 
         await asyncio.sleep(1)  # Wait here in case the normal event was fired

--- a/bot/cogs/modlog.py
+++ b/bot/cogs/modlog.py
@@ -14,8 +14,7 @@ from discord import (
 from discord.abc import GuildChannel
 from discord.ext.commands import Bot
 
-from bot.constants import Channels, Colours, Emojis, Event, Icons, Keys, Roles, URLs
-from bot.constants import Guild as GuildConstant
+from bot.constants import Channels, Colours, Emojis, Event, Guild as GuildConstant, Icons, Keys, Roles, URLs
 from bot.utils.time import humanize_delta
 
 log = logging.getLogger(__name__)
@@ -609,7 +608,8 @@ class ModLog:
         )
 
     async def on_message_edit(self, before: Message, after: Message):
-        if before.guild.id != GuildConstant.id or before.channel.id in GuildConstant.ignored or before.author.bot:
+        if not before.guild or before.guild.id != GuildConstant.id \
+                or before.channel.id in GuildConstant.ignored or before.author.bot:
             return
 
         self._cached_edits.append(before.id)
@@ -670,7 +670,8 @@ class ModLog:
         except NotFound:  # Was deleted before we got the event
             return
 
-        if message.guild.id != GuildConstant.id or message.channel.id in GuildConstant.ignored or message.author.bot:
+        if not message.guild or message.guild.id != GuildConstant.id \
+                or message.channel.id in GuildConstant.ignored or message.author.bot:
             return
 
         await asyncio.sleep(1)  # Wait here in case the normal event was fired


### PR DESCRIPTION
Fixes #205 by listening on member join events and restoring any superstar nicks, if the user left and rejoined while in superstar prison.

Additional changes:
- adds some minor visual improvements to the superstar-reated modlog embeds
- converts footer in DM Infraction Information embeds to title so that the rules link is clickable
- fixes exceptions on message edits in DM channels (where guild is None)