### PR TITLE
Add commas to server command

### DIFF
--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -103,7 +103,7 @@ class Information:
                 Features: {features}
 
                 **Counts**
-                Members: {member_count}
+                Members: {member_count:,}
                 Roles: {roles}
                 Text: {text_channels}
                 Voice: {voice_channels}


### PR DESCRIPTION
So we did it guys, we reached 10,000 members. The server command returns a member count which I feel looks very ugly as `10000` so this PR just adds a comma to that to make it `10,000`. I did originally add it to the status indicators as well but it didn't look so great. Screenshots of both added below.

With commas on status indicators:
![](https://i.seph.club/mam97.png)

Without commas on status indicators:
![](https://i.seph.club/uzelk.png)