### PR TITLE
Makes generating `...:` indents faster

### DIFF
--- a/bot/cogs/eval.py
+++ b/bot/cogs/eval.py
@@ -66,9 +66,9 @@ class CodeEval:
                 # far enough to align them.
                 # we first `str()` the line number
                 # then we get the length
-                # and do a simple {:<LENGTH}
+                # and use `str.rjust()`
                 # to indent it.
-                start = f"{'':<{len(str(self.ln))+2}}...: "
+                start = "...:".rjust(len(self.ln) + 2)
 
             if i == len(lines) - 2:
                 if line.startswith("return"):


### PR DESCRIPTION
Uses `rjust` instead of an fstring. Five is arbitrary.
```py
>>> from timeit import Timer
>>> t = Timer('f"{\'\':<{5}}...:"')
>>> t2 = Timer('"...:".zfill(5)')
>>> t3 = Timer('"...:".rjust(5)')
>>> print(t.timeit(), t2.timeit(), t3.timeit())
0.2464568559998952 0.09237145299994154 0.08822837999969124
```
