### PR TITLE
!watch alias bugfix

### DIFF
--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -71,7 +71,7 @@ class Alias:
 
     @command(name="watch", hidden=True)
     async def bigbrother_watch_alias(
-            self, ctx, user: User, reason: str = None
+            self, ctx, user: User, *, reason: str = None
     ):
         """
         Alias for invoking <prefix>bigbrother watch user [text_channel].

--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 
-from discord import Colour, Embed, TextChannel, User
+from discord import Colour, Embed, User
 from discord.ext.commands import (
     Command, Context, clean_content, command, group
 )
@@ -71,13 +71,13 @@ class Alias:
 
     @command(name="watch", hidden=True)
     async def bigbrother_watch_alias(
-            self, ctx, user: User, channel: TextChannel = None
+            self, ctx, user: User, reason: str = None
     ):
         """
         Alias for invoking <prefix>bigbrother watch user [text_channel].
         """
 
-        await self.invoke(ctx, "bigbrother watch", user, channel)
+        await self.invoke(ctx, "bigbrother watch", user, reason=reason)
 
     @command(name="unwatch", hidden=True)
     async def bigbrother_unwatch_alias(self, ctx, user: User):


### PR DESCRIPTION
Fixes a bug with the watch alias introduced by our recent change of the watch command.

Closes #213 