### PR TITLE
CommandNotFound default to tags get before silently ignoring

### DIFF
--- a/bot/cogs/events.py
+++ b/bot/cogs/events.py
@@ -3,8 +3,8 @@ import logging
 from discord import Colour, Embed, Member, Object
 from discord.ext.commands import (
     BadArgument, Bot, BotMissingPermissions,
-    CommandError, CommandInvokeError, Context,
-    NoPrivateMessage, UserInputError
+    CommandError, CommandInvokeError, CommandNotFound,
+    Context, NoPrivateMessage, UserInputError
 )
 
 from bot.cogs.modlog import ModLog
@@ -121,7 +121,13 @@ class Events:
             log.debug(f"Command {command} has a local error handler, ignoring.")
             return
 
-        if isinstance(e, BadArgument):
+        if isinstance(e, CommandNotFound) and not hasattr(ctx, "invoked_from_error_handler"):
+            tags_get_command = self.bot.get_command("tags get")
+            ctx.invoked_from_error_handler = True
+
+            # Return to not raise the exception
+            return await ctx.invoke(tags_get_command, tag_name=ctx.invoked_with)
+        elif isinstance(e, BadArgument):
             await ctx.send(f"Bad argument: {e}\n")
             await ctx.invoke(*help_command)
         elif isinstance(e, UserInputError):

--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -180,6 +180,9 @@ class Tags:
                 if tag_data['image_url'] is not None:
                     embed.set_image(url=tag_data['image_url'])
 
+        # If its invoked from error handler just ignore it.
+        elif hasattr(ctx, "invoked_from_error_handler"):
+            return
         # If not, prepare an error message.
         else:
             embed.colour = Colour.red()


### PR DESCRIPTION
Before any CommandNotFound exceptions were completely ignored, now it will first try to find a tag by invoking `tags get` before ignoring. If it finds a tag it posts it.  

This would act as a shortcut for all tags that don't overlap with command names