### PR TITLE
Show when an infraction notified a user successfully via DM.

### DIFF
--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -82,7 +82,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the warning.
         """
 
-        await self.notify_infraction(
+        notified = await self.notify_infraction(
             user=user,
             infr_type="Warning",
             reason=reason
@@ -92,12 +92,13 @@ class Moderation(Scheduler):
         if response_object is None:
             return
 
-        if reason is None:
-            result_message = f":ok_hand: warned {user.mention}."
-        else:
-            result_message = f":ok_hand: warned {user.mention} ({reason})."
+        dm_result = ":incoming_envelope: " if notified else ""
+        action = f"{dm_result}:ok_hand: warned {user.mention}"
 
-        await ctx.send(result_message)
+        if reason is None:
+            await ctx.send(f"{action}.")
+        else:
+            await ctx.send(f"{action} ({reason}).")
 
     @with_role(*MODERATION_ROLES)
     @command(name="kick")
@@ -108,7 +109,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the kick.
         """
 
-        await self.notify_infraction(
+        notified = await self.notify_infraction(
             user=user,
             infr_type="Kick",
             reason=reason
@@ -121,12 +122,13 @@ class Moderation(Scheduler):
         self.mod_log.ignore(Event.member_remove, user.id)
         await user.kick(reason=reason)
 
-        if reason is None:
-            result_message = f":ok_hand: kicked {user.mention}."
-        else:
-            result_message = f":ok_hand: kicked {user.mention} ({reason})."
+        dm_result = ":incoming_envelope: " if notified else ""
+        action = f"{dm_result}:ok_hand: kicked {user.mention}"
 
-        await ctx.send(result_message)
+        if reason is None:
+            await ctx.send(f"{action}.")
+        else:
+            await ctx.send(f"{action} ({reason}).")
 
         # Send a log message to the mod log
         await self.mod_log.send_log_message(
@@ -150,7 +152,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the ban.
         """
 
-        await self.notify_infraction(
+        notified = await self.notify_infraction(
             user=user,
             infr_type="Ban",
             duration="Permanent",
@@ -165,12 +167,13 @@ class Moderation(Scheduler):
         self.mod_log.ignore(Event.member_remove, user.id)
         await ctx.guild.ban(user, reason=reason, delete_message_days=0)
 
-        if reason is None:
-            result_message = f":ok_hand: permanently banned {user.mention}."
-        else:
-            result_message = f":ok_hand: permanently banned {user.mention} ({reason})."
+        dm_result = ":incoming_envelope: " if notified else ""
+        action = f"{dm_result}:ok_hand: permanently banned {user.mention}"
 
-        await ctx.send(result_message)
+        if reason is None:
+            await ctx.send(f"{action}.")
+        else:
+            await ctx.send(f"{action} ({reason}).")
 
         # Send a log message to the mod log
         await self.mod_log.send_log_message(
@@ -194,7 +197,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the mute.
         """
 
-        await self.notify_infraction(
+        notified = await self.notify_infraction(
             user=user,
             infr_type="Mute",
             duration="Permanent",
@@ -209,12 +212,13 @@ class Moderation(Scheduler):
         self.mod_log.ignore(Event.member_update, user.id)
         await user.add_roles(self._muted_role, reason=reason)
 
-        if reason is None:
-            result_message = f":ok_hand: permanently muted {user.mention}."
-        else:
-            result_message = f":ok_hand: permanently muted {user.mention} ({reason})."
+        dm_result = ":incoming_envelope: " if notified else ""
+        action = f"{dm_result}:ok_hand: permanently muted {user.mention}"
 
-        await ctx.send(result_message)
+        if reason is None:
+            await ctx.send(f"{action}.")
+        else:
+            await ctx.send(f"{action} ({reason}).")
 
         # Send a log message to the mod log
         await self.mod_log.send_log_message(
@@ -242,7 +246,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the temporary mute.
         """
 
-        await self.notify_infraction(
+        notified = await self.notify_infraction(
             user=user,
             infr_type="Mute",
             duration=duration,
@@ -262,12 +266,13 @@ class Moderation(Scheduler):
         loop = asyncio.get_event_loop()
         self.schedule_task(loop, infraction_object["id"], infraction_object)
 
-        if reason is None:
-            result_message = f":ok_hand: muted {user.mention} until {infraction_expiration}."
-        else:
-            result_message = f":ok_hand: muted {user.mention} until {infraction_expiration} ({reason})."
+        dm_result = ":incoming_envelope: " if notified else ""
+        action = f"{dm_result}:ok_hand: muted {user.mention} until {infraction_expiration}"
 
-        await ctx.send(result_message)
+        if reason is None:
+            await ctx.send(f"{action}.")
+        else:
+            await ctx.send(f"{action} ({reason}).")
 
         # Send a log message to the mod log
         await self.mod_log.send_log_message(
@@ -294,7 +299,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the temporary ban.
         """
 
-        await self.notify_infraction(
+        notified = await self.notify_infraction(
             user=user,
             infr_type="Ban",
             duration=duration,
@@ -316,12 +321,13 @@ class Moderation(Scheduler):
         loop = asyncio.get_event_loop()
         self.schedule_task(loop, infraction_object["id"], infraction_object)
 
-        if reason is None:
-            result_message = f":ok_hand: banned {user.mention} until {infraction_expiration}."
-        else:
-            result_message = f":ok_hand: banned {user.mention} until {infraction_expiration} ({reason})."
+        dm_result = ":incoming_envelope: " if notified else ""
+        action = f"{dm_result}:ok_hand: banned {user.mention} until {infraction_expiration}"
 
-        await ctx.send(result_message)
+        if reason is None:
+            await ctx.send(f"{action}.")
+        else:
+            await ctx.send(f"{action} ({reason}).")
 
         # Send a log message to the mod log
         await self.mod_log.send_log_message(
@@ -603,7 +609,15 @@ class Moderation(Scheduler):
             if infraction_object["expires_at"] is not None:
                 self.cancel_expiration(infraction_object["id"])
 
-            await ctx.send(f":ok_hand: Un-muted {user.mention}.")
+            notified = await self.notify_pardon(
+                user=user,
+                title="You have been unmuted.",
+                content="You may now send messages in the server.",
+                icon_url=Icons.user_unmute
+            )
+
+            dm_result = ":incoming_envelope: " if notified else ""
+            await ctx.send(f"{dm_result}:ok_hand: Un-muted {user.mention}.")
 
             # Send a log message to the mod log
             await self.mod_log.send_log_message(
@@ -616,13 +630,6 @@ class Moderation(Scheduler):
                     Actor: {ctx.message.author}
                     Intended expiry: {infraction_object['expires_at']}
                 """)
-            )
-
-            await self.notify_pardon(
-                user=user,
-                title="You have been unmuted.",
-                content="You may now send messages in the server.",
-                icon_url=Icons.user_unmute
             )
         except Exception:
             log.exception("There was an error removing an infraction.")
@@ -1093,7 +1100,7 @@ class Moderation(Scheduler):
         embed.title = f"Please review our rules over at {RULES_URL}"
         embed.url = RULES_URL
 
-        await self.send_private_embed(user, embed)
+        return await self.send_private_embed(user, embed)
 
     async def notify_pardon(
             self, user: Union[User, Member], title: str, content: str, icon_url: str = Icons.user_verified
@@ -1114,7 +1121,7 @@ class Moderation(Scheduler):
 
         embed.set_author(name=title, icon_url=icon_url)
 
-        await self.send_private_embed(user, embed)
+        return await self.send_private_embed(user, embed)
 
     async def send_private_embed(self, user: Union[User, Member], embed: Embed):
         """
@@ -1129,11 +1136,13 @@ class Moderation(Scheduler):
 
         try:
             await user.send(embed=embed)
+            return True
         except (HTTPException, Forbidden):
             log.debug(
                 f"Infraction-related information could not be sent to user {user} ({user.id}). "
                 "They've probably just disabled private messages."
             )
+            return False
 
     # endregion
 

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -100,6 +100,9 @@ class Moderation(Scheduler):
         else:
             await ctx.send(f"{action} ({reason}).")
 
+        if not notified:
+            await self.log_notify_failure(user, ctx.author, "warning")
+
     @with_role(*MODERATION_ROLES)
     @command(name="kick")
     async def kick(self, ctx: Context, user: Member, *, reason: str = None):
@@ -129,6 +132,9 @@ class Moderation(Scheduler):
             await ctx.send(f"{action}.")
         else:
             await ctx.send(f"{action} ({reason}).")
+
+        if not notified:
+            await self.log_notify_failure(user, ctx.author, "kick")
 
         # Send a log message to the mod log
         await self.mod_log.send_log_message(
@@ -175,6 +181,9 @@ class Moderation(Scheduler):
         else:
             await ctx.send(f"{action} ({reason}).")
 
+        if not notified:
+            await self.log_notify_failure(user, ctx.author, "ban")
+
         # Send a log message to the mod log
         await self.mod_log.send_log_message(
             icon_url=Icons.user_ban,
@@ -219,6 +228,9 @@ class Moderation(Scheduler):
             await ctx.send(f"{action}.")
         else:
             await ctx.send(f"{action} ({reason}).")
+
+        if not notified:
+            await self.log_notify_failure(user, ctx.author, "mute")
 
         # Send a log message to the mod log
         await self.mod_log.send_log_message(
@@ -274,6 +286,9 @@ class Moderation(Scheduler):
         else:
             await ctx.send(f"{action} ({reason}).")
 
+        if not notified:
+            await self.log_notify_failure(user, ctx.author, "mute")
+
         # Send a log message to the mod log
         await self.mod_log.send_log_message(
             icon_url=Icons.user_mute,
@@ -328,6 +343,9 @@ class Moderation(Scheduler):
             await ctx.send(f"{action}.")
         else:
             await ctx.send(f"{action} ({reason}).")
+
+        if not notified:
+            await self.log_notify_failure(user, ctx.author, "ban")
 
         # Send a log message to the mod log
         await self.mod_log.send_log_message(
@@ -618,6 +636,9 @@ class Moderation(Scheduler):
 
             dm_result = ":incoming_envelope: " if notified else ""
             await ctx.send(f"{dm_result}:ok_hand: Un-muted {user.mention}.")
+
+            if not notified:
+                await self.log_notify_failure(user, ctx.author, "unmute")
 
             # Send a log message to the mod log
             await self.mod_log.send_log_message(
@@ -1143,6 +1164,15 @@ class Moderation(Scheduler):
                 "They've probably just disabled private messages."
             )
             return False
+
+    async def log_notify_failure(self, target: str, actor: Member, infraction_type: str):
+        await self.mod_log.send_log_message(
+            icon_url=Icons.token_removed,
+            content=actor.mention,
+            colour=Colour(Colours.soft_red),
+            title="Notification Failed",
+            text=f"Direct message was unable to be sent.\nUser: {target.mention}\nType: {infraction_type}"
+        )
 
     # endregion
 

--- a/bot/cogs/modlog.py
+++ b/bot/cogs/modlog.py
@@ -104,8 +104,9 @@ class ModLog:
                 self._ignored[event].append(item)
 
     async def send_log_message(
-            self, icon_url: Optional[str], colour: Colour, title: Optional[str], text: str, thumbnail: str = None,
-            channel_id: int = Channels.modlog, ping_everyone: bool = False, files: List[File] = None
+            self, icon_url: Optional[str], colour: Colour, title: Optional[str], text: str,
+            thumbnail: str = None, channel_id: int = Channels.modlog, ping_everyone: bool = False,
+            files: List[File] = None, content: str = None
     ):
         embed = Embed(description=text)
 
@@ -118,10 +119,11 @@ class ModLog:
         if thumbnail is not None:
             embed.set_thumbnail(url=thumbnail)
 
-        content = None
-
         if ping_everyone:
-            content = "@everyone"
+            if content:
+                content = f"@everyone\n{content}"
+            else:
+                content = "@everyone"
 
         await self.bot.get_channel(channel_id).send(content=content, embed=embed, files=files)
 


### PR DESCRIPTION
I've added an envelope emoji to the infraction response message that indicates if an infraction successfully notified the user.

If the emoji is present, a DM was sent.
If it failed, or the infraction doesn't attempt to notify, it won't be present.

In the example below, the infractions to myself (Scragly) successfully send a DM notification. This includes the un-mute action also. For Eevee, the notification failed and so the emoji is not present.

<img width="324" alt="dm-notification" src="https://user-images.githubusercontent.com/29337040/50449458-43821b80-0973-11e9-9d38-5edcaee79fcc.PNG">

