### PR TITLE
Add charinfo command.

### DIFF
--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -94,7 +94,7 @@ class Utils:
         Shows you information on up to 25 unicode characters.
         """
 
-        match = re.match(r"<(a?):([a-zA-Z0-9\_]+):([0-9]+)>", characters)
+        match = re.match(r"<(a?):(\w+):(\d+)>", characters)
         if match:
             embed = Embed(
                 title="Non-Character Detected",

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -1,16 +1,49 @@
 import logging
 import random
+import typing
 from asyncio import Lock
 from functools import wraps
 from weakref import WeakValueDictionary
 
 from discord import Colour, Embed
 from discord.ext import commands
-from discord.ext.commands import Context
+from discord.ext.commands import CheckFailure, Context
 
 from bot.constants import ERROR_REPLIES
 
 log = logging.getLogger(__name__)
+
+
+class InChannelCheckFailure(CheckFailure):
+    pass
+
+
+def in_channel(*channels: int, bypass_roles: typing.Container[int] = None):
+    """
+    Checks that the message is in a whitelisted channel or optionally has a bypass role.
+    """
+    def predicate(ctx: Context):
+        if ctx.channel.id in channels:
+            log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
+                      f"The command was used in a whitelisted channel.")
+            return True
+
+        if bypass_roles:
+            if any(r.id in bypass_roles for r in ctx.author.roles):
+                log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
+                          f"The command was not used in a whitelisted channel, "
+                          f"but the author had a role to bypass the in_channel check.")
+                return True
+
+        log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
+                  f"The in_channel check failed.")
+
+        channels_str = ', '.join(f"<#{c_id}>" for c_id in channels)
+        raise InChannelCheckFailure(
+            f"Sorry, but you may only use this command within {channels_str}."
+        )
+
+    return commands.check(predicate)
 
 
 def with_role(*role_ids: int):
@@ -42,15 +75,6 @@ def without_role(*role_ids: int):
         check = all(role not in author_roles for role in role_ids)
         log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
                   f"The result of the without_role check was {check}.")
-        return check
-    return commands.check(predicate)
-
-
-def in_channel(channel_id):
-    async def predicate(ctx: Context):
-        check = ctx.channel.id == channel_id
-        log.debug(f"{ctx.author} tried to call the '{ctx.command.name}' command. "
-                  f"The result of the in_channel check was {check}.")
         return check
     return commands.check(predicate)
 


### PR DESCRIPTION
Adds a utility command for showing unicode character information, such as the relevant codepoints, character names, full raw output for multiple characters, and a link to more details on the web.

<img width="393" alt="charinfo" src="https://user-images.githubusercontent.com/29337040/50453372-e34ba380-098b-11e9-9600-aa05566a8f03.PNG">

It will accept up to 25 characters in one command. Multi-character emoji such as the family one above do not count as a single character, but 7 different ones. When too many characters are given, it'll give the following error:

![image](https://user-images.githubusercontent.com/29337040/50453431-3a517880-098c-11e9-911a-129a8ef548a7.png)

Sometimes users will attempt to pass custom emoji in as characters. I've added a check to ensure the command catches these instances and explains they're not able to be processed:

![image](https://user-images.githubusercontent.com/29337040/50453559-24908300-098d-11e9-8fa0-3f5faaa75a1f.png)

