### PR TITLE
Defcon channel title auto-update

### DIFF
--- a/bot/cogs/defcon.py
+++ b/bot/cogs/defcon.py
@@ -5,13 +5,11 @@ from discord import Colour, Embed, Member
 from discord.ext.commands import Bot, Context, group
 
 from bot.cogs.modlog import ModLog
-from bot.constants import Channels, Emojis, Icons, Keys, Roles, URLs
+from bot.constants import Channels, Colours, Emojis, Icons, Keys, Roles, URLs
 from bot.decorators import with_role
 
 log = logging.getLogger(__name__)
 
-COLOUR_RED = Colour(0xcd6d6d)
-COLOUR_GREEN = Colour(0x68c290)
 
 REJECTION_MESSAGE = """
 Hi, {user} - Thanks for your interest in our server!
@@ -93,7 +91,7 @@ class Defcon:
                     message = f"{message}\n\nUnable to send rejection message via DM; they probably have DMs disabled."
 
                 await self.mod_log.send_log_message(
-                    Icons.defcon_denied, COLOUR_RED, "Entry denied",
+                    Icons.defcon_denied, Colours.soft_red, "Entry denied",
                     message, member.avatar_url_as(static_format="png")
                 )
 
@@ -134,7 +132,7 @@ class Defcon:
             )
 
             await self.mod_log.send_log_message(
-                Icons.defcon_enabled, COLOUR_GREEN, "DEFCON enabled",
+                Icons.defcon_enabled, Colours.soft_green, "DEFCON enabled",
                 f"**Staffer:** {ctx.author.name}#{ctx.author.discriminator} (`{ctx.author.id}`)\n"
                 f"**Days:** {self.days.days}\n\n"
                 "**There was a problem updating the site** - This setting may be reverted when the bot is "
@@ -145,7 +143,7 @@ class Defcon:
             await ctx.send(f"{Emojis.defcon_enabled} DEFCON enabled.")
 
             await self.mod_log.send_log_message(
-                Icons.defcon_enabled, COLOUR_GREEN, "DEFCON enabled",
+                Icons.defcon_enabled, Colours.soft_green, "DEFCON enabled",
                 f"**Staffer:** {ctx.author.name}#{ctx.author.discriminator} (`{ctx.author.id}`)\n"
                 f"**Days:** {self.days.days}\n\n"
             )
@@ -177,7 +175,7 @@ class Defcon:
             )
 
             await self.mod_log.send_log_message(
-                Icons.defcon_disabled, COLOUR_RED, "DEFCON disabled",
+                Icons.defcon_disabled, Colours.soft_red, "DEFCON disabled",
                 f"**Staffer:** {ctx.author.name}#{ctx.author.discriminator} (`{ctx.author.id}`)\n"
                 "**There was a problem updating the site** - This setting may be reverted when the bot is "
                 "restarted.\n\n"
@@ -187,7 +185,7 @@ class Defcon:
             await ctx.send(f"{Emojis.defcon_disabled} DEFCON disabled.")
 
             await self.mod_log.send_log_message(
-                Icons.defcon_disabled, COLOUR_RED, "DEFCON disabled",
+                Icons.defcon_disabled, Colours.soft_red, "DEFCON disabled",
                 f"**Staffer:** {ctx.author.name}#{ctx.author.discriminator} (`{ctx.author.id}`)"
             )
 

--- a/bot/cogs/defcon.py
+++ b/bot/cogs/defcon.py
@@ -10,7 +10,6 @@ from bot.decorators import with_role
 
 log = logging.getLogger(__name__)
 
-
 REJECTION_MESSAGE = """
 Hi, {user} - Thanks for your interest in our server!
 
@@ -21,6 +20,8 @@ Even so, thanks for joining! We're very excited at the possibility of having you
 will be resolved soon. In the meantime, please feel free to peruse the resources on our site at
 <https://pythondiscord.com/>, and have a nice day!
 """
+
+BASE_CHANNEL_TOPIC = "Python Discord Defense Mechanism"
 
 
 class Defcon:
@@ -63,6 +64,8 @@ class Defcon:
                 self.enabled = False
                 self.days = timedelta(days=0)
                 log.warning(f"DEFCON disabled")
+
+            self.update_channel_topic()
 
     async def on_member_join(self, member: Member):
         if self.enabled and self.days.days > 0:
@@ -148,6 +151,8 @@ class Defcon:
                 f"**Days:** {self.days.days}\n\n"
             )
 
+        self.update_channel_topic()
+
     @defcon_group.command(name='disable', aliases=('off', 'd'))
     @with_role(Roles.admin, Roles.owner)
     async def disable_command(self, ctx: Context):
@@ -188,6 +193,8 @@ class Defcon:
                 Icons.defcon_disabled, Colours.soft_red, "DEFCON disabled",
                 f"**Staffer:** {ctx.author.name}#{ctx.author.discriminator} (`{ctx.author.id}`)"
             )
+
+        self.update_channel_topic()
 
     @defcon_group.command(name='status', aliases=('s',))
     @with_role(Roles.admin, Roles.owner)
@@ -249,6 +256,21 @@ class Defcon:
                 f"**Staffer:** {ctx.author.name}#{ctx.author.discriminator} (`{ctx.author.id}`)\n"
                 f"**Days:** {self.days.days}"
             )
+
+        self.update_channel_topic()
+
+    async def update_channel_topic(self):
+        """
+        Update the #defcon channel topic with the current DEFCON status
+        """
+
+        if self.enabled:
+            new_topic = f"{BASE_CHANNEL_TOPIC}\n(Status: Enabled, Threshold: {self.days} days)"
+        else:
+            new_topic = f"{BASE_CHANNEL_TOPIC}\n(Status: Disabled)"
+
+        defcon_channel = await self.bot.guild.get_channel(Channels.defcon)
+        await defcon_channel.edit(topic=new_topic)
 
 
 def setup(bot: Bot):

--- a/bot/cogs/defcon.py
+++ b/bot/cogs/defcon.py
@@ -265,11 +265,12 @@ class Defcon:
         """
 
         if self.enabled:
-            new_topic = f"{BASE_CHANNEL_TOPIC}\n(Status: Enabled, Threshold: {self.days} days)"
+            day_str = "days" if self.days > 1 else "day"
+            new_topic = f"{BASE_CHANNEL_TOPIC}\n(Status: Enabled, Threshold: {self.days} {day_str})"
         else:
             new_topic = f"{BASE_CHANNEL_TOPIC}\n(Status: Disabled)"
 
-        defcon_channel = await self.bot.guild.get_channel(Channels.defcon)
+        defcon_channel = self.bot.guilds[0].get_channel(Channels.defcon)
         await defcon_channel.edit(topic=new_topic)
 
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -317,6 +317,7 @@ class Channels(metaclass=YAMLGetter):
     big_brother_logs: int
     bot: int
     checkpoint_test: int
+    defcon: int
     devalerts: int
     devlog: int
     devtest: int

--- a/config-default.yml
+++ b/config-default.yml
@@ -89,6 +89,7 @@ guild:
         big_brother_logs:  &BBLOGS        468507907357409333
         bot:                              267659945086812160
         checkpoint_test:                  422077681434099723
+        defcon:                           464469101889454091
         devalerts:                        460181980097675264
         devlog:            &DEVLOG        409308876241108992
         devtest:           &DEVTEST       414574275865870337


### PR DESCRIPTION
Add a helper method to automatically update the #defcon channel topic based on the current DEFCON status.

See: #228

Enabled:
![image](https://user-images.githubusercontent.com/5323929/50526625-497e1680-0ab1-11e9-8374-208ab72a315f.png)
![image](https://user-images.githubusercontent.com/5323929/50526626-4c790700-0ab1-11e9-8be7-eea52c2c8c8d.png)

Disabled:
![image](https://user-images.githubusercontent.com/5323929/50526631-526ee800-0ab1-11e9-92a6-dbf2fd2357a8.png)
![image](https://user-images.githubusercontent.com/5323929/50526637-5864c900-0ab1-11e9-9cb5-e715e1d49efa.png)

Also swapped local color constants in favor of their related PyDis constants, where applicable