### PR TITLE
AntiSpam Mute Infraction

### DIFF
--- a/bot/cogs/modlog.py
+++ b/bot/cogs/modlog.py
@@ -126,7 +126,7 @@ class ModLog:
                 content = "@everyone"
 
         log_message = await self.bot.get_channel(channel_id).send(content=content, embed=embed, files=files)
-        return self.bot.get_context(log_message)  # Optionally return for use with antispam
+        return await self.bot.get_context(log_message)  # Optionally return for use with antispam
 
     async def on_guild_channel_create(self, channel: GUILD_CHANNEL):
         if channel.guild.id != GuildConstant.id:

--- a/bot/cogs/modlog.py
+++ b/bot/cogs/modlog.py
@@ -123,7 +123,8 @@ class ModLog:
         if ping_everyone:
             content = "@everyone"
 
-        await self.bot.get_channel(channel_id).send(content=content, embed=embed, files=files)
+        log_message = await self.bot.get_channel(channel_id).send(content=content, embed=embed, files=files)
+        return self.bot.get_context(log_message)  # Optionally return for use with antispam
 
     async def on_guild_channel_create(self, channel: GUILD_CHANNEL):
         if channel.guild.id != GuildConstant.id:


### PR DESCRIPTION
Addresses the remaining item in #148: Utilizes a temporary mute infraction rather than having the mute be totally contained by the AntiSpam coro, preventing non-administrators from removing the muted role in the event of a false-positive.

~~Because I'm having issues getting the local site/bot deployment working, this is considered a WIP until it can be tested by either myself or another contributor.~~

Closes: #148 