### PR TITLE
Fix for the paginator raising IndexError when provided with an empty object to paginate

### DIFF
--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -152,7 +152,7 @@ class LinePaginator(Paginator):
         current_page = 0
 
         if not lines:
-            log.debug("No lines to add to paginator, adding empty line")
+            log.debug("No lines to add to paginator, adding '(nothing to display)' message")
             lines.append("(nothing to display)")
 
         for line in lines:
@@ -366,7 +366,7 @@ class ImagePaginator(Paginator):
         current_page = 0
 
         if not pages:
-            log.debug("No images to add to paginator, adding empty line")
+            log.debug("No images to add to paginator, adding '(no images to display)' message")
             pages.append(("(no images to display)", ""))
 
         for text, image_url in pages:

--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -151,6 +151,10 @@ class LinePaginator(Paginator):
         paginator = cls(prefix=prefix, suffix=suffix, max_size=max_size, max_lines=max_lines)
         current_page = 0
 
+        if not lines:
+            log.debug("No lines to add to paginator, adding empty line")
+            lines.append("(nothing to display)")
+
         for line in lines:
             try:
                 paginator.add_line(line, empty=empty)
@@ -360,6 +364,10 @@ class ImagePaginator(Paginator):
 
         paginator = cls(prefix=prefix, suffix=suffix)
         current_page = 0
+
+        if not pages:
+            log.debug("No images to add to paginator, adding empty line")
+            pages.append(("(no images to display)", ""))
 
         for text, image_url in pages:
             paginator.add_line(text)

--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -17,6 +17,10 @@ PAGINATION_EMOJI = [FIRST_EMOJI, LEFT_EMOJI, RIGHT_EMOJI, LAST_EMOJI, DELETE_EMO
 log = logging.getLogger(__name__)
 
 
+class EmptyPaginatorEmbed(Exception):
+    pass
+
+
 class LinePaginator(Paginator):
     """
     A class that aids in paginating code blocks for Discord messages.
@@ -96,7 +100,8 @@ class LinePaginator(Paginator):
     async def paginate(cls, lines: Iterable[str], ctx: Context, embed: Embed,
                        prefix: str = "", suffix: str = "", max_lines: Optional[int] = None, max_size: int = 500,
                        empty: bool = True, restrict_to_user: User = None, timeout: int = 300,
-                       footer_text: str = None):
+                       footer_text: str = None,
+                       exception_on_empty_embed: bool = False):
         """
         Use a paginator and set of reactions to provide pagination over a set of lines. The reactions are used to
         switch page, or to finish with pagination.
@@ -152,6 +157,10 @@ class LinePaginator(Paginator):
         current_page = 0
 
         if not lines:
+            if exception_on_empty_embed:
+                log.exception(f"Pagination asked for empty lines iterable")
+                raise EmptyPaginatorEmbed("No lines to paginate")
+
             log.debug("No lines to add to paginator, adding '(nothing to display)' message")
             lines.append("(nothing to display)")
 
@@ -319,7 +328,8 @@ class ImagePaginator(Paginator):
 
     @classmethod
     async def paginate(cls, pages: List[Tuple[str, str]], ctx: Context, embed: Embed,
-                       prefix: str = "", suffix: str = "", timeout: int = 300):
+                       prefix: str = "", suffix: str = "", timeout: int = 300,
+                       exception_on_empty_embed: bool = False):
         """
         Use a paginator and set of reactions to provide
         pagination over a set of title/image pairs.The reactions are
@@ -366,6 +376,10 @@ class ImagePaginator(Paginator):
         current_page = 0
 
         if not pages:
+            if exception_on_empty_embed:
+                log.exception(f"Pagination asked for empty image list")
+                raise EmptyPaginatorEmbed("No images to paginate")
+
             log.debug("No images to add to paginator, adding '(no images to display)' message")
             pages.append(("(no images to display)", ""))
 


### PR DESCRIPTION
Currently, both the LinePaginator and ImagePaginator will raise an unanticipated exception when called with an empty object to paginate. See #246. One way this may happen is if the bot command `!otname list` is ran, but no names were added to the name list yet:

![otname_list_before_example](https://user-images.githubusercontent.com/33516116/50646021-62853c80-0f75-11e9-8782-7494d827aa97.png)

After discussing this with @scragly and @tagptroll1 in the contrib channel, I'm proposing a two-folded fix for this:

1. Send an empty embed with "(nothing to display)" if the \_\_init\_\_ kwarq `exception_on_empty_embed = False`. **This is the default.**

LinePaginator:
![otname_list_example](https://user-images.githubusercontent.com/33516116/50646319-0969d880-0f76-11e9-9fb6-c0db8884d5d0.png)

ImagePaginator:
![imagepaginator_noimagestodisplay](https://user-images.githubusercontent.com/33516116/50646837-6e71fe00-0f77-11e9-93b7-4d4f077c8ef5.png)

2. Raise `EmptyPaginatorEmbed` exception when `exception_on_empty_embed = True`. This allows the function/command calling the paginator to handle it in some other way than an empty embed.




----
!internal eval codes to invoke the fix:

```
# LinePaginator exception_on_empty_embed=False
!internal eval
from bot.pagination import LinePaginator
from discord import Colour, Embed
embed = Embed(
    title=f"Known off-topic names (0 total)",
    colour=Colour.blue()
)
await LinePaginator.paginate([], ctx, embed, max_size=400, empty=False, exception_on_empty_embed=False)

# LinePaginator exception_on_empty_embed=True
!internal eval
from bot.pagination import LinePaginator
from discord import Colour, Embed
embed = Embed(
    title=f"Known off-topic names (0 total)",
    colour=Colour.blue()
)
await LinePaginator.paginate([], ctx, embed, max_size=400, empty=False, exception_on_empty_embed=True)

# ImagePaginator exception_on_empty_embed=False
!internal eval
from bot.pagination import ImagePaginator
from discord import Colour, Embed
embed = Embed(
    title=f"Ves Zappa's Selfie Album (0 total)",
    colour=Colour.blue()
)
await ImagePaginator.paginate([], ctx, embed, exception_on_empty_embed=False)

# ImagePaginator exception_on_empty_embed=True
!internal eval
from bot.pagination import LinePaginator
from discord import Colour, Embed
embed = Embed(
    title=f"Ves Zappa's Selfie Album (0 total)",
    colour=Colour.blue()
)
await ImagePaginator.paginate([], ctx, embed, exception_on_empty_embed=True)
```