### PR TITLE
Hopefully the final fix to the code block on-edit deletion thing

### DIFF
--- a/bot/cogs/bot.py
+++ b/bot/cogs/bot.py
@@ -383,6 +383,7 @@ class Bot:
             bot_message = await channel.get_message(self.codeblock_message_ids[payload.message_id])
             await bot_message.delete()
             del self.codeblock_message_ids[payload.message_id]
+            log.trace("User's incorrect code block has been fixed.  Removing bot formatting message.")
 
 
 def setup(bot):

--- a/bot/cogs/bot.py
+++ b/bot/cogs/bot.py
@@ -372,7 +372,7 @@ class Bot:
             return
 
         # Retrieve channel and message objects for use later
-        channel = self.bot.get_channel(payload.data.get("channel_id"))
+        channel = self.bot.get_channel(int(payload.data.get("channel_id")))
         user_message = await channel.get_message(payload.message_id)
 
         #  Checks to see if the user has corrected their codeblock.  If it's fixed, has_fixed_codeblock will be None


### PR DESCRIPTION
Thanks to Chib, it looks like the code block message deletion thing after someone fixes their code in chat should be working properly now.  For real this time.

Signed-off-by: Daniel Brown <browndj3@gmail.com>