### PR TITLE
Invite filter DM & DMed invite modlog

### DIFF
--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from discord import Colour, Member, Message, TextChannel
+from discord import Colour, DMChannel, Member, Message, TextChannel
 import discord.errors
 from discord.ext.commands import Bot
 
@@ -126,10 +126,15 @@ class Filtering:
                     triggered = await _filter["function"](msg.content)
 
                     if triggered:
+                        if isinstance(msg.channel, DMChannel):
+                            channel_str = "via DM"
+                        else:
+                            channel_str = f"in <#{msg.channel.id}>"
+
                         message = (
                             f"The {filter_name} {_filter['type']} was triggered "
                             f"by **{msg.author.name}#{msg.author.discriminator}** "
-                            f"(`{msg.author.id}`) in <#{msg.channel.id}> with [the "
+                            f"(`{msg.author.id}`) {channel_str} with [the "
                             f"following message]({msg.jump_url}):\n\n"
                             f"{msg.content}"
                         )

--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -130,7 +130,7 @@ class Filtering:
                         if isinstance(msg.channel, DMChannel):
                             channel_str = "via DM"
                         else:
-                            channel_str = f"in <#{msg.channel.id}>"
+                            channel_str = f"in {msg.channel.mention}"
 
                         message = (
                             f"The {filter_name} {_filter['type']} was triggered "

--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -44,14 +44,14 @@ class Filtering:
                 "enabled": Filter.filter_zalgo,
                 "function": self._has_zalgo,
                 "type": "filter",
-                "user_notification": False,
+                "user_notification": Filter.notify_user_zalgo,
                 "notification_msg": ""
             },
             "filter_invites": {
                 "enabled": Filter.filter_invites,
                 "function": self._has_invites,
                 "type": "filter",
-                "user_notification": True,
+                "user_notification": Filter.notify_user_invites,
                 "notification_msg": (
                     "Per Rule 10, your invite link has been removed. "
                     "If you believe this was a mistake, please the staff know!\n\n"
@@ -62,21 +62,21 @@ class Filtering:
                 "enabled": Filter.filter_domains,
                 "function": self._has_urls,
                 "type": "filter",
-                "user_notification": False,
+                "user_notification": Filter.notify_user_domains,
                 "notification_msg": ""
             },
             "watch_words": {
                 "enabled": Filter.watch_words,
                 "function": self._has_watchlist_words,
                 "type": "watchlist",
-                "user_notification": False,
+                "user_notification": Filter.notify_user_words,
                 "notification_msg": ""
             },
             "watch_tokens": {
                 "enabled": Filter.watch_tokens,
                 "function": self._has_watchlist_tokens,
                 "type": "watchlist",
-                "user_notification": False,
+                "user_notification": False,  # Hardcode intentional, already in token remover cog
                 "notification_msg": ""
             },
         }

--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -74,15 +74,11 @@ class Filtering:
                 "enabled": Filter.watch_words,
                 "function": self._has_watchlist_words,
                 "type": "watchlist",
-                "user_notification": False,  # Hardcode intentional for watchlist filter type
-                "notification_msg": ""
             },
             "watch_tokens": {
                 "enabled": Filter.watch_tokens,
                 "function": self._has_watchlist_tokens,
                 "type": "watchlist",
-                "user_notification": False,  # Hardcode intentional, already in token remover cog
-                "notification_msg": ""
             },
         }
 
@@ -161,9 +157,9 @@ class Filtering:
                         if _filter["type"] == "filter":
                             await msg.delete()
 
-                        # Notify the user if the filter specifies
-                        if _filter["user_notification"]:
-                            await self.notify_member(msg.author, _filter["notification_msg"], msg.channel)
+                            # Notify the user if the filter specifies
+                            if _filter["user_notification"]:
+                                await self.notify_member(msg.author, _filter["notification_msg"], msg.channel)
 
                         break  # We don't want multiple filters to trigger
 

--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -39,13 +39,17 @@ class Filtering:
     def __init__(self, bot: Bot):
         self.bot = bot
 
+        _staff_mistake_str = "If you believe this was a mistake, please let staff know!"
         self.filters = {
             "filter_zalgo": {
                 "enabled": Filter.filter_zalgo,
                 "function": self._has_zalgo,
                 "type": "filter",
                 "user_notification": Filter.notify_user_zalgo,
-                "notification_msg": ""
+                "notification_msg": (
+                    "Your post has been removed for abusing Unicode character rendering (aka Zalgo text). "
+                    f"{_staff_mistake_str}"
+                )
             },
             "filter_invites": {
                 "enabled": Filter.filter_invites,
@@ -53,8 +57,7 @@ class Filtering:
                 "type": "filter",
                 "user_notification": Filter.notify_user_invites,
                 "notification_msg": (
-                    "Per Rule 10, your invite link has been removed. "
-                    "If you believe this was a mistake, please the staff know!\n\n"
+                    f"Per Rule 10, your invite link has been removed. {_staff_mistake_str}\n\n"
                     r"Our server rules can be found here: <https://pythondiscord.com/about/rules>"
                 )
             },
@@ -63,13 +66,15 @@ class Filtering:
                 "function": self._has_urls,
                 "type": "filter",
                 "user_notification": Filter.notify_user_domains,
-                "notification_msg": ""
+                "notification_msg": (
+                    f"Your URL has been removed because it matched a blacklisted domain. {_staff_mistake_str}"
+                )
             },
             "watch_words": {
                 "enabled": Filter.watch_words,
                 "function": self._has_watchlist_words,
                 "type": "watchlist",
-                "user_notification": Filter.notify_user_words,
+                "user_notification": False,  # Hardcode intentional for watchlist filter type
                 "notification_msg": ""
             },
             "watch_tokens": {

--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -1,8 +1,8 @@
 import logging
 import re
 
-from discord import Colour, DMChannel, Member, Message, TextChannel
 import discord.errors
+from discord import Colour, DMChannel, Member, Message, TextChannel
 from discord.ext.commands import Bot
 
 from bot.cogs.modlog import ModLog

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -207,7 +207,7 @@ class Filter(metaclass=YAMLGetter):
     notify_user_zalgo: bool
     notify_user_invites: bool
     notify_user_domains: bool
-    notify_user_words: bool
+    # Words watch intentionally ignored since it's a watchlist
     # Token notification intentionally ignored, notification is handled by the token remover cog
 
     ping_everyone: bool

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -204,11 +204,10 @@ class Filter(metaclass=YAMLGetter):
     watch_words: bool
     watch_tokens: bool
 
+    # Notifications are not expected for "watchlist" type filters
     notify_user_zalgo: bool
     notify_user_invites: bool
     notify_user_domains: bool
-    # Words watch intentionally ignored since it's a watchlist
-    # Token notification intentionally ignored, notification is handled by the token remover cog
 
     ping_everyone: bool
     guild_invite_whitelist: List[int]

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -204,6 +204,12 @@ class Filter(metaclass=YAMLGetter):
     watch_words: bool
     watch_tokens: bool
 
+    notify_user_zalgo: bool
+    notify_user_invites: bool
+    notify_user_domains: bool
+    notify_user_words: bool
+    # Token notification intentionally ignored, notification is handled by the token remover cog
+
     ping_everyone: bool
     guild_invite_whitelist: List[int]
     domain_blacklist: List[str]

--- a/config-default.yml
+++ b/config-default.yml
@@ -144,7 +144,7 @@ filter:
     notify_user_zalgo:   false
     notify_user_invites: true
     notify_user_domains: false
-    notify_user_words:   false
+    # Words watch intentionally ignored since it's a watchlist
     # Token notification intentionally ignored, notification is handled by the token remover cog
 
     # Filter configuration

--- a/config-default.yml
+++ b/config-default.yml
@@ -141,11 +141,10 @@ filter:
     watch_tokens:   true
 
     # Notify user on filter?
+    # Notifications are not expected for "watchlist" type filters
     notify_user_zalgo:   false
     notify_user_invites: true
     notify_user_domains: false
-    # Words watch intentionally ignored since it's a watchlist
-    # Token notification intentionally ignored, notification is handled by the token remover cog
 
     # Filter configuration
     ping_everyone: true  # Ping @everyone when we send a mod-alert?

--- a/config-default.yml
+++ b/config-default.yml
@@ -139,6 +139,13 @@ filter:
     watch_words:    true
     watch_tokens:   true
 
+    # Notify user on filter?
+    notify_user_zalgo:   false
+    notify_user_invites: true
+    notify_user_domains: false
+    notify_user_words:   false
+    # Token notification intentionally ignored, notification is handled by the token remover cog
+
     # Filter configuration
     ping_everyone: true  # Ping @everyone when we send a mod-alert?
 


### PR DESCRIPTION
- Add configurable user notifications for message filter actions
  - Booleans added to server configuration, with the exception of the token filter since notification is handled by its own cog
  - If the filter's `"user_notification"` is `True`, a message is DMed to the user on filter action. This falls back to an in-channel mention if the user has DMs disabled
  - User notification message is configurable in the filter dictionary
- Adjust the mod log message to read `"via DM"` rather than `"in <#deleted-channel>"` if a filter is triggered in a DM

Closes: #243
Closes: #245 