### PR TITLE
!free help channel command

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -75,6 +75,7 @@ bot.load_extension("bot.cogs.tags")
 bot.load_extension("bot.cogs.token_remover")
 bot.load_extension("bot.cogs.utils")
 bot.load_extension("bot.cogs.wolfram")
+bot.load_extension("bot.cogs.free")
 
 if has_rmq:
     bot.load_extension("bot.cogs.rmq")

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -4,18 +4,17 @@ from datetime import datetime
 from discord import Colour, Embed, Member, utils
 from discord.ext.commands import BucketType, Context, command, cooldown
 
-from bot.constants import Categories
+from bot.constants import Categories, Free
 
 
 log = logging.getLogger(__name__)
 
+PYTHON_HELP_ID = Categories.python_help
+TIMEOUT = Free.activity_timeout
+
 
 class Free:
     """Tries to figure out which help channels are free."""
-
-    PYTHON_HELP_ID = Categories.python_help
-    TIME_INACTIVE = 300
-
     @command(name="free", aliases=('f',))
     @cooldown(1, 60.0, BucketType.channel)
     async def free(self, ctx: Context, user: Member = None, seek: int = 2):
@@ -34,7 +33,7 @@ class Free:
         in an active channel, and we want the message before that happened.
         """
         free_channels = []
-        python_help = utils.get(ctx.guild.categories, id=self.PYTHON_HELP_ID)
+        python_help = utils.get(ctx.guild.categories, id=PYTHON_HELP_ID)
 
         if user is not None and seek == 2:
             seek = 3
@@ -49,7 +48,7 @@ class Free:
                 msg = await channel.history(limit=1).next()   # noqa (False positive)
 
             inactive = (datetime.utcnow() - msg.created_at).seconds
-            if inactive > self.TIME_INACTIVE:
+            if inactive > TIMEOUT:
                 free_channels.append((inactive, channel))
 
         embed = Embed()

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -69,7 +69,7 @@ class Free:
 
             for i, (inactive, channel) in enumerate(sorted(free_channels, reverse=True), 1):
                 minutes, seconds = divmod(inactive, 60)
-                if minutes > 60:
+                if minutes > 59:
                     hours, minutes = divmod(minutes, 60)
                     embed.description += f"{i}. {channel.mention} inactive for {hours}h{minutes}m{seconds}s\n\n"
                 else:

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -119,7 +119,7 @@ class Free:
                 # return to avoid needlessly logging the error
                 return await ctx.reinvoke()
 
-        log.error(error)  # Don't ignore other errors
+        log.exception(error)  # Don't ignore other errors
 
 
 def setup(bot):

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -79,7 +79,7 @@ class Free:
             embed.description += ("**\nThese channels aren't guaranteed to be free, "
                                   "so use your best judgement and check for yourself.")
         else:
-            embed.description = ("**Doesn't look like any channels are available to me. "
+            embed.description = ("**Doesn't look like any channels are available right now. "
                                  "You're welcome to check for yourself to be sure. "
                                  "If all channels are truly busy, please be patient "
                                  "as one will likely be available soon.**")

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -43,10 +43,15 @@ class Free:
         elif not 0 < seek < 10:
             seek = 3
 
+        # Iterate through all the help channels
+        # to check latest activity
         for channel in python_help.channels:
+            # Seek further back in the help channel
+            # the command was invoked in
             if channel.id == ctx.channel.id:
                 messages = await channel.history(limit=seek).flatten()
                 msg = messages[seek-1]
+            # Otherwise get last message
             else:
                 msg = await channel.history(limit=1).next()   # noqa (False positive)
 
@@ -63,12 +68,17 @@ class Free:
         else:
             embed.description = ""
 
+        # Display all potentially inactive channels
+        # in descending order of inactivity
         if free_channels:
             embed.description += "**The following channel{0} look{1} free:**\n\n**".format(
                 's' if len(free_channels) > 1 else '',
                 '' if len(free_channels) > 1 else 's'
             )
 
+            # Sort channels in descending order by seconds
+            # Get position in list, inactivity, and channel object
+            # For each channel, add to embed.description
             for i, (inactive, channel) in enumerate(sorted(free_channels, reverse=True), 1):
                 minutes, seconds = divmod(inactive, 60)
                 if minutes > 59:

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -115,7 +115,10 @@ class Free:
                 # reset cooldown so second invocation
                 # doesn't bring us back here.
                 ctx.command.reset_cooldown(ctx)
-                await ctx.invoke(ctx.command)
+                # return to avoid needlessly logging the error
+                return await ctx.invoke(ctx.command)
+
+        log.error(error) # Don't ignore other errors
 
 
 def setup(bot):

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -118,7 +118,7 @@ class Free:
                 # return to avoid needlessly logging the error
                 return await ctx.invoke(ctx.command)
 
-        log.error(error) # Don't ignore other errors
+        log.error(error)  # Don't ignore other errors
 
 
 def setup(bot):

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -55,7 +55,7 @@ class Free:
                 free_channels.append((inactive, channel))
 
         embed = Embed()
-        embed.colour = Colour.gold()
+        embed.colour = Colour.blurple()
         embed.title = "**Looking for a free help channel?**"
 
         if user is not None:

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -29,6 +29,7 @@ class Free:
         :param seek: How far back to check the last active message.
 
         seek is used only when this command is invoked in a help channel.
+        You cannot override seek without mentioning a user first.
 
         When seek is 2, we are avoiding considering the last active message
         in a channel to be the one that invoked this command.

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -103,13 +103,11 @@ class Free:
     @free.error
     async def free_error(self, ctx: Context, error):
         """
-        Runs if any error is raised during invocation
-        of !free command. Any error aside from
-        CommandOnCooldown is ignored.
-
         If error raised is CommandOnCooldown, and the
         user who invoked has the helper role, reset
         the cooldown and reinvoke the command.
+
+        Otherwise log the error.
         """
         helpers = ctx.guild.get_role(Roles.helpers)
 

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -46,7 +46,7 @@ class Free:
                 messages = await channel.history(limit=seek).flatten()
                 msg = messages[seek-1]
             else:
-                msg = await channel.history(limit=1).next()
+                msg = await channel.history(limit=1).next()   # noqa (False positive)
 
             inactive = (datetime.utcnow() - msg.created_at).seconds
             if inactive > self.TIME_INACTIVE:

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -10,12 +10,14 @@ from bot.constants import Categories, Free, Roles
 
 log = logging.getLogger(__name__)
 
-PYTHON_HELP_ID = Categories.python_help
 TIMEOUT = Free.activity_timeout
 
 
 class Free:
     """Tries to figure out which help channels are free."""
+
+    PYTHON_HELP_ID = Categories.python_help
+
     @command(name="free", aliases=('f',))
     @cooldown(1, 60.0, BucketType.channel)
     async def free(self, ctx: Context, user: Member = None, seek: int = 2):
@@ -34,7 +36,7 @@ class Free:
         in an active channel, and we want the message before that happened.
         """
         free_channels = []
-        python_help = utils.get(ctx.guild.categories, id=PYTHON_HELP_ID)
+        python_help = utils.get(ctx.guild.categories, id=self.PYTHON_HELP_ID)
 
         if user is not None and seek == 2:
             seek = 3

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -66,7 +66,8 @@ class Free:
         if free_channels:
             embed.description += "**The following channel{0} look{1} free:**\n\n**".format(
                 's' if len(free_channels) > 1 else '',
-                '' if len(free_channels) > 1 else 's')
+                '' if len(free_channels) > 1 else 's'
+            )
 
             for i, (inactive, channel) in enumerate(sorted(free_channels, reverse=True), 1):
                 minutes, seconds = divmod(inactive, 60)

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -36,7 +36,7 @@ class Free:
 
         if user is not None and seek == 2:
             seek = 3
-        elif seek > 10:
+        elif not 0 < seek < 10:
             seek = 3
 
         for channel in python_help.channels:

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from discord import Colour, Embed, Member, utils
 from discord.ext.commands import BucketType, Context, command, cooldown
 
+from bot.constants import Categories
+
 
 log = logging.getLogger(__name__)
 
@@ -11,7 +13,7 @@ log = logging.getLogger(__name__)
 class Free:
     """Tries to figure out which help channels are free."""
 
-    PYTHON_HELP_ID = 356013061213126657
+    PYTHON_HELP_ID = Categories.python_help
     TIME_INACTIVE = 300
 
     @command(name="free", aliases=('f',))

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -51,14 +51,14 @@ class Free:
 
             inactive = (datetime.utcnow() - msg.created_at).seconds
             if inactive > self.TIME_INACTIVE:
-                free_channels.append((inactive, channel.id))
+                free_channels.append((inactive, channel))
 
         embed = Embed()
         embed.colour = Colour.gold()
         embed.title = "**Looking for a free help channel?**"
 
         if user is not None:
-            embed.description = f"**Hey <@{user.id}>!**\n\n"
+            embed.description = f"**Hey {user.mention}!**\n\n"
         else:
             embed.description = ""
 
@@ -67,14 +67,13 @@ class Free:
                 's' if len(free_channels) > 1 else '',
                 '' if len(free_channels) > 1 else 's')
 
-            for i, channel in enumerate(sorted(free_channels, reverse=True), 1):
-                inactive, ID = channel
+            for i, (inactive, channel) in enumerate(sorted(free_channels, reverse=True), 1):
                 minutes, seconds = divmod(inactive, 60)
                 if minutes > 60:
                     hours, minutes = divmod(minutes, 60)
-                    embed.description += f"{i}. <#{ID}> inactive for {hours}h{minutes}m{seconds}s\n\n"
+                    embed.description += f"{i}. {channel.mention} inactive for {hours}h{minutes}m{seconds}s\n\n"
                 else:
-                    embed.description += f"{i}. <#{ID}> inactive for {minutes}m{seconds}s\n\n"
+                    embed.description += f"{i}. {channel.mention} inactive for {minutes}m{seconds}s\n\n"
 
             embed.description += ("**\nThese channels aren't guaranteed to be free, "
                                   "so use your best judgement and check for yourself.")

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -70,9 +70,9 @@ class Free:
                 minutes, seconds = divmod(inactive, 60)
                 if minutes > 60:
                     hours, minutes = divmod(minutes, 60)
-                    embed.description += f'{i}. <#{ID}> inactive for {hours}h{minutes}m{seconds}s\n\n'
+                    embed.description += f"{i}. <#{ID}> inactive for {hours}h{minutes}m{seconds}s\n\n"
                 else:
-                    embed.description += f'{i}. <#{ID}> inactive for {minutes}m{seconds}s\n\n'
+                    embed.description += f"{i}. <#{ID}> inactive for {minutes}m{seconds}s\n\n"
 
             embed.description += ("**\nThese channels aren't guaranteed to be free, "
                                   "so use your best judgement and check for yourself.")

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -46,8 +46,7 @@ class Free:
                 messages = await channel.history(limit=seek).flatten()
                 msg = messages[seek-1]
             else:
-                messages = await channel.history(limit=1).flatten()
-                msg = messages[0]
+                msg = await channel.history(limit=1).next()
 
             inactive = (datetime.utcnow() - msg.created_at).seconds
             if inactive > self.TIME_INACTIVE:

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -117,7 +117,7 @@ class Free:
                 # doesn't bring us back here.
                 ctx.command.reset_cooldown(ctx)
                 # return to avoid needlessly logging the error
-                return await ctx.invoke(ctx.command)
+                return await ctx.reinvoke()
 
         log.error(error)  # Don't ignore other errors
 

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -1,0 +1,90 @@
+import logging
+from datetime import datetime
+
+from discord import Colour, Embed, Member, utils
+from discord.ext.commands import BucketType, Context, command, cooldown
+
+
+log = logging.getLogger(__name__)
+
+
+class Free:
+    """Tries to figure out which help channels are free."""
+
+    PYTHON_HELP_ID = 356013061213126657
+    TIME_INACTIVE = 300
+
+    @command(name="free", aliases=('f',))
+    @cooldown(1, 60.0, BucketType.channel)
+    async def free(self, ctx: Context, user: Member = None, seek: int = 2):
+        """
+        Lists free help channels by likeliness of availability.
+        :param user: accepts user mention, ID, etc.
+        :param seek: How far back to check the last active message.
+
+        seek is used only when this command is invoked in a help channel.
+
+        When seek is 2, we are avoiding considering the last active message
+        in a channel to be the one that invoked this command.
+
+        When seek is 3 or more, a user has been mentioned on the assumption
+        that they asked if the channel is free or they asked their question
+        in an active channel, and we want the message before that happened.
+        """
+        free_channels = []
+        python_help = utils.get(ctx.guild.categories, id=self.PYTHON_HELP_ID)
+
+        if user is not None and seek == 2:
+            seek = 3
+        elif seek > 10:
+            seek = 3
+
+        for channel in python_help.channels:
+            if channel.id == ctx.channel.id:
+                messages = await channel.history(limit=seek).flatten()
+                msg = messages[seek-1]
+            else:
+                messages = await channel.history(limit=1).flatten()
+                msg = messages[0]
+
+            inactive = (datetime.utcnow() - msg.created_at).seconds
+            if inactive > self.TIME_INACTIVE:
+                free_channels.append((inactive, channel.id))
+
+        embed = Embed()
+        embed.colour = Colour.gold()
+        embed.title = "**Looking for a free help channel?**"
+
+        if user is not None:
+            embed.description = f"**Hey <@{user.id}>!**\n\n"
+        else:
+            embed.description = ""
+
+        if free_channels:
+            embed.description += "**The following channel{0} look{1} free:**\n\n**".format(
+                's' if len(free_channels) > 1 else '',
+                '' if len(free_channels) > 1 else 's')
+
+            for i, channel in enumerate(sorted(free_channels, reverse=True), 1):
+                inactive, ID = channel
+                minutes, seconds = divmod(inactive, 60)
+                if minutes > 60:
+                    hours, minutes = divmod(minutes, 60)
+                    embed.description += f'{i}. <#{ID}> inactive for {hours}h{minutes}m{seconds}s\n\n'
+                else:
+                    embed.description += f'{i}. <#{ID}> inactive for {minutes}m{seconds}s\n\n'
+
+            embed.description += ("**\nThese channels aren't guaranteed to be free, "
+                                  "so use your best judgement and check for yourself.")
+        else:
+            embed.description = ("**Doesn't look like any channels are available to me. "
+                                 "You're welcome to check for yourself to be sure. "
+                                 "If all channels are truly busy, please be patient "
+                                 "as one will likely be available soon.**")
+
+        return await ctx.send(embed=embed)
+
+
+def setup(bot):
+    bot.add_cog(Free())
+    log.info("Cog loaded: Free")

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -11,6 +11,8 @@ from bot.constants import Categories, Free, Roles
 log = logging.getLogger(__name__)
 
 TIMEOUT = Free.activity_timeout
+RATE = Free.cooldown_rate
+PER = Free.cooldown_per
 
 
 class Free:
@@ -19,7 +21,7 @@ class Free:
     PYTHON_HELP_ID = Categories.python_help
 
     @command(name="free", aliases=('f',))
-    @cooldown(1, 60.0, BucketType.channel)
+    @cooldown(RATE, PER, BucketType.channel)
     async def free(self, ctx: Context, user: Member = None, seek: int = 2):
         """
         Lists free help channels by likeliness of availability.

--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -82,7 +82,7 @@ class Free:
                                  "If all channels are truly busy, please be patient "
                                  "as one will likely be available soon.**")
 
-        return await ctx.send(embed=embed)
+        await ctx.send(embed=embed)
 
 
 def setup(bot):

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -477,6 +477,8 @@ class Free(metaclass=YAMLGetter):
     section = 'free'
 
     activity_timeout: int
+    cooldown_rate: int
+    cooldown_per: float
 
 
 # Debug mode

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -471,6 +471,12 @@ class BigBrother(metaclass=YAMLGetter):
     header_message_limit: int
 
 
+class Free(metaclass=YAMLGetter):
+    section = 'free'
+
+    activity_timeout: int
+
+
 # Debug mode
 DEBUG_MODE = True if 'local' in os.environ.get("SITE_URL", "local") else False
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -315,6 +315,13 @@ class CleanMessages(metaclass=YAMLGetter):
     message_limit: int
 
 
+class Categories(metaclass=YAMLGetter):
+    section = "guild"
+    subsection = "categories"
+
+    python_help: int
+
+
 class Channels(metaclass=YAMLGetter):
     section = "guild"
     subsection = "channels"

--- a/config-default.yml
+++ b/config-default.yml
@@ -337,5 +337,11 @@ big_brother:
     header_message_limit: 15
 
 
+free:
+    # Seconds to elapse for a channel
+    # to be considered inactive.
+    activity_timeout: 300
+
+
 config:
     required_keys: ['bot.token']

--- a/config-default.yml
+++ b/config-default.yml
@@ -85,6 +85,9 @@ style:
 guild:
     id: 267624335836053506
 
+    categories:
+        python_help:                      356013061213126657
+
     channels:
         admins:            &ADMINS        365960823622991872
         announcements:                    354619224620138496

--- a/config-default.yml
+++ b/config-default.yml
@@ -343,6 +343,8 @@ free:
     # Seconds to elapse for a channel
     # to be considered inactive.
     activity_timeout: 600
+    cooldown_rate: 1
+    cooldown_per: 60.0
 
 
 config:

--- a/config-default.yml
+++ b/config-default.yml
@@ -340,7 +340,7 @@ big_brother:
 free:
     # Seconds to elapse for a channel
     # to be considered inactive.
-    activity_timeout: 300
+    activity_timeout: 600
 
 
 config:


### PR DESCRIPTION
The long overdue !free command which checks for inactivity in all the help channels, and lists them as a suggestion to users to move to a help channel, or switch to one that isn't currently in use.

## How it works

* If invoked outside of a help channel, it will check the timestamp of the last message in each of the help channels. 
* However if invoked in one of the help channels, it will do the same except for the channel it was invoked in. 
  * If no user is mentioned, it will check the second to last message to avoid considering the invocation itself as activity in the channel
  * If a user *is* mentioned, it will check the third to last message by default. The assumption here is that a user asked if the channel was free, or they asked a question in a potentially active channel, and we don't want to consider that message as activity in the channel.
  * Optionally one can override the default of 3 to a number more appropriate for the situation. (eg. if the user who asked if the channel was free or asked their question took up more than one message)

note: I really don't expect that last situation to ever be used, but I included it just in case (for you power users out there). 

## Cooldown

I've set the cooldown for this to once every minute, on a per channel basis. I felt this was the most appropriate, but I am open to other suggestions.

EDIT - Helpers are now exempt from the cooldown

## Time inactive

~~Currently a channel must be inactive for more than 5 minutes to be considered potentially free. This part I was unsure about, and welcome suggestions if it seems too short, or too long.~~

EDIT - Activity timeout is 10 minutes

## Constraints

`seek` must be less than or equal to 10. I see no point in checking the channel history any older than that.
`seek` can't be less than 1 for obvious reasons.

## Wording

Finally, any suggestions on my wording for the responses are encouraged.