### PR TITLE
Fixed Reminder Deletion

### DIFF
--- a/bot/cogs/reminders.py
+++ b/bot/cogs/reminders.py
@@ -398,7 +398,7 @@ class Reminders(Scheduler):
         )
 
         if not failed:
-            self.cancel_reminder(response_data["reminder_id"])
+            await self._delete_reminder(response_data["reminder_id"])
 
 
 def setup(bot: Bot):


### PR DESCRIPTION
Corrected the delete_reminder() method to use the correct _delete_reminder method().

Closes: #237

Signed-off-by: Daniel Brown <browndj3@gmail.com>