### PR TITLE
Detecting self-botting/unofficial client use with a rich embed filter

### DIFF
--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -133,11 +133,8 @@ class Filtering:
         )
 
         # If we're running the bot locally, ignore role whitelist and only listen to #dev-test
-        # if DEBUG_MODE:
-        #     filter_message = not msg.author.bot and msg.channel.id == Channels.devtest
-
         if DEBUG_MODE:
-            filter_message = msg.author.id != 414020331980980234 and msg.channel.id == Channels.devtest
+            filter_message = not msg.author.bot and msg.channel.id == Channels.devtest
 
         # If none of the above, we can start filtering.
         if filter_message:
@@ -199,6 +196,7 @@ class Filtering:
                             ping_everyone=Filter.ping_everyone,
                         )
 
+                        # If filtering rich embeds, also send the removed embeds to mod_alerts
                         if filter_name == "filter_rich_embeds":
                             await self.mod_log.send_log_embeds(
                                 embeds=msg.embeds,

--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -185,6 +185,8 @@ class Filtering:
 
                         log.debug(message)
 
+                        additional_embeds = msg.embeds if filter_name == "filter_rich_embeds" else None
+
                         # Send pretty mod log embed to mod-alerts
                         await self.mod_log.send_log_message(
                             icon_url=Icons.filtering,
@@ -194,16 +196,10 @@ class Filtering:
                             thumbnail=msg.author.avatar_url_as(static_format="png"),
                             channel_id=Channels.mod_alerts,
                             ping_everyone=Filter.ping_everyone,
+                            additional_embeds=additional_embeds,
                         )
 
                         # If filtering rich embeds, also send the removed embeds to mod_alerts
-                        if filter_name == "filter_rich_embeds":
-                            await self.mod_log.send_log_embeds(
-                                embeds=msg.embeds,
-                                content="The message contained the following embed(s):\n",
-                                channel_id=Channels.mod_alerts,
-                            )
-
                         break  # We don't want multiple filters to trigger
 
     @staticmethod

--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -82,8 +82,8 @@ class Filtering:
                 "notification_msg": (
                     "Your post has been removed because it contained a rich embed. "
                     "This indicates that you're either using an unofficial discord client or are using a self-bot, "
-                    "both of which violate Discord's Terms of Service.\n\n"
-                    f"Please don't use a self-bot or an unofficial Discord client on our server. {_staff_mistake_str}"
+                    f"both of which violate Discord's Terms of Service. {_staff_mistake_str}\n\n"
+                    "Please don't use a self-bot or an unofficial Discord client on our server."
                 )
             },
             "watch_words": {
@@ -140,7 +140,6 @@ class Filtering:
         if filter_message:
 
             for filter_name, _filter in self.filters.items():
-
                 # Is this specific filter enabled in the config?
                 if _filter["enabled"]:
                     # Does the filter only need the message content or the full message?
@@ -199,7 +198,6 @@ class Filtering:
                             additional_embeds=additional_embeds,
                         )
 
-                        # If filtering rich embeds, also send the removed embeds to mod_alerts
                         break  # We don't want multiple filters to trigger
 
     @staticmethod

--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -153,7 +153,7 @@ class Filtering:
                         # If this is a filter (not a watchlist), we should delete the message.
                         if _filter["type"] == "filter":
                             try:
-                                # Embeds (can) trigger both the `on_message` and `on_message_edit`
+                                # Embeds (can?) trigger both the `on_message` and `on_message_edit`
                                 # event handlers, triggering filtering twice for the same message.
                                 #
                                 # If `on_message`-triggered filtering already deleted the message

--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -138,7 +138,6 @@ class Filtering:
 
         # If none of the above, we can start filtering.
         if filter_message:
-
             for filter_name, _filter in self.filters.items():
                 # Is this specific filter enabled in the config?
                 if _filter["enabled"]:

--- a/bot/cogs/modlog.py
+++ b/bot/cogs/modlog.py
@@ -106,7 +106,7 @@ class ModLog:
     async def send_log_message(
             self, icon_url: Optional[str], colour: Colour, title: Optional[str], text: str,
             thumbnail: str = None, channel_id: int = Channels.modlog, ping_everyone: bool = False,
-            files: List[File] = None, content: str = None
+            files: List[File] = None, content: str = None, additional_embeds: List[Embed] = None,
     ):
         embed = Embed(description=text)
 
@@ -125,7 +125,14 @@ class ModLog:
             else:
                 content = "@everyone"
 
-        await self.bot.get_channel(channel_id).send(content=content, embed=embed, files=files)
+        channel = self.bot.get_channel(channel_id)
+
+        await channel.send(content=content, embed=embed, files=files)
+
+        if additional_embeds:
+            await channel.send("With the following embed(s):")
+            for additional_embed in additional_embeds:
+                await channel.send(embed=additional_embed)
 
     async def on_guild_channel_create(self, channel: GUILD_CHANNEL):
         if channel.guild.id != GuildConstant.id:

--- a/bot/cogs/modlog.py
+++ b/bot/cogs/modlog.py
@@ -127,6 +127,23 @@ class ModLog:
 
         await self.bot.get_channel(channel_id).send(content=content, embed=embed, files=files)
 
+    async def send_log_embeds(
+            self, embeds: List[Embed], content: Optional[str],
+            channel_id: int = Channels.modlog, ping_everyone: bool = False,
+    ):
+
+        if ping_everyone:
+            if content:
+                content = f"@everyone\n{content}"
+            else:
+                content = "@everyone"
+
+        if content:
+            await self.bot.get_channel(channel_id).send(content=content)
+
+        for embed in embeds:
+            await self.bot.get_channel(channel_id).send(embed=embed)
+
     async def on_guild_channel_create(self, channel: GUILD_CHANNEL):
         if channel.guild.id != GuildConstant.id:
             return

--- a/bot/cogs/modlog.py
+++ b/bot/cogs/modlog.py
@@ -127,23 +127,6 @@ class ModLog:
 
         await self.bot.get_channel(channel_id).send(content=content, embed=embed, files=files)
 
-    async def send_log_embeds(
-            self, embeds: List[Embed], content: Optional[str],
-            channel_id: int = Channels.modlog, ping_everyone: bool = False,
-    ):
-
-        if ping_everyone:
-            if content:
-                content = f"@everyone\n{content}"
-            else:
-                content = "@everyone"
-
-        if content:
-            await self.bot.get_channel(channel_id).send(content=content)
-
-        for embed in embeds:
-            await self.bot.get_channel(channel_id).send(embed=embed)
-
     async def on_guild_channel_create(self, channel: GUILD_CHANNEL):
         if channel.guild.id != GuildConstant.id:
             return

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -201,6 +201,7 @@ class Filter(metaclass=YAMLGetter):
     filter_zalgo: bool
     filter_invites: bool
     filter_domains: bool
+    filter_rich_embeds: bool
     watch_words: bool
     watch_tokens: bool
 
@@ -208,6 +209,7 @@ class Filter(metaclass=YAMLGetter):
     notify_user_zalgo: bool
     notify_user_invites: bool
     notify_user_domains: bool
+    notify_user_rich_embeds: bool
 
     ping_everyone: bool
     guild_invite_whitelist: List[int]

--- a/config-default.yml
+++ b/config-default.yml
@@ -134,17 +134,19 @@ guild:
 filter:
 
     # What do we filter?
-    filter_zalgo:   false
-    filter_invites: true
-    filter_domains: true
-    watch_words:    true
-    watch_tokens:   true
+    filter_zalgo:       false
+    filter_invites:     true
+    filter_domains:     true
+    filter_rich_embeds: true
+    watch_words:        true
+    watch_tokens:       true
 
     # Notify user on filter?
     # Notifications are not expected for "watchlist" type filters
-    notify_user_zalgo:   false
-    notify_user_invites: true
-    notify_user_domains: false
+    notify_user_zalgo:       false
+    notify_user_invites:     true
+    notify_user_domains:     false
+    notify_user_rich_embeds: true
 
     # Filter configuration
     ping_everyone: true  # Ping @everyone when we send a mod-alert?


### PR DESCRIPTION
**Summary:**
This PR introduces embed detection as a measure against self-botting and unofficial Discord client use on our server. As the official Discord client should not be able to send embeds of type "rich" in a message, embed filtering is done by checking the type of the embed. The reason for not filtering all embeds is simple: Users can send other types of embeds, like link previews and gifv embeds, with the official Discord client. 

Visual of mod_alerts:
![Rich Embed Filter Mod Alert](https://user-images.githubusercontent.com/33516116/50789858-9d60da80-12bd-11e9-878f-5c5c39328e64.png)


This PR makes changes to three files:
**1. bot/cogs/filtering.py**
- I've adapted the current filter system to allow for filter functions that need to act on a Message object instead of solely on the Message.content. The most important change is the addition of a parameter in the filter dictionary to specify how to call the filter function: With a Message object as parameter or with Message.content;
- While implementing, I noticed that messages with rich embeds trigger both the "on_message" and "on_message_edit" events in rapid succession. This led to the problem of double log messages, double user notifications, and an Exception when the filter triggered by the "on_message_edit" event tried to delete the message (as the "on_message" triggered filter had already deleted it). To solve this, I've moved the Message.delete() coroutine to the front of the procedure with a `try-except` block. In case the exception Discord.errors.NotFound is raised, the message was apparently already deleted by a previous filter run, so we return from the function to prevent double logs/user notifications.
- As the embeds, not Message.content are the center of this filter, I'm also sending the embed to `mod_log`. See the modification of `modlog.py` for details. 

**2. bot/cogs/modlog.py**
- Our mod_log.send_log_message coroutine did not support posting the filtered embeds to the log channels, as you cannot embed an embed inside of another embed. That's why I've added an optional keyword parameter (`additional_embeds`) to the routine that will accept a list of embeds and, if set, posts them to the specified channel after the main log_message embed. This way, we will have a record of the offending embed instead of the empty log_message embed it would be in the old implementation. This function is also easy to reuse if we want to copy user-posted embeds at other places in the code. Just add `additional_embeds=Message.embeds` to the function call.

**3. bot/constants.py and config-default.yml**
- Added a filter boolean and notify_user boolean, both true.