### PR TITLE
Add mute infraction check to role restoration

### DIFF
--- a/bot/cogs/events.py
+++ b/bot/cogs/events.py
@@ -25,6 +25,7 @@ class Events:
 
     def __init__(self, bot: Bot):
         self.bot = bot
+        self.headers = {"X-API-KEY": Keys.site_api}
 
     @property
     def mod_log(self) -> ModLog:
@@ -102,6 +103,29 @@ class Events:
 
         resp = await response.json()
         return resp["data"]
+
+    async def has_active_mute(self, user_id: str) -> bool:
+        """
+        Check whether a user has any active mute infractions
+        """
+        response = await self.bot.http_session.get(
+            URLs.site_infractions_user.format(
+                user_id=user_id
+            ),
+            params={"hidden": "True"},
+            headers=self.headers
+        )
+        infraction_list = await response.json()
+
+        # Check for active mute infractions
+        if len(infraction_list) == 0:
+            # Short circuit
+            return False
+
+        muted_check = any(
+            [infraction["active"] for infraction in infraction_list if infraction["type"].lower() == "mute"]
+        )
+        return muted_check
 
     async def on_command_error(self, ctx: Context, e: CommandError):
         command = ctx.command
@@ -236,6 +260,10 @@ class Events:
 
                 for role in RESTORE_ROLES:
                     if role in old_roles:
+                        # Check for mute roles that were not able to be removed and skip if present
+                        if role == str(Roles.muted) and not await self.has_active_mute(str(member.id)):
+                            continue
+
                         new_roles.append(Object(int(role)))
 
                 for role in new_roles:

--- a/bot/cogs/events.py
+++ b/bot/cogs/events.py
@@ -108,6 +108,7 @@ class Events:
         """
         Check whether a user has any active mute infractions
         """
+
         response = await self.bot.http_session.get(
             URLs.site_infractions_user.format(
                 user_id=user_id

--- a/bot/cogs/events.py
+++ b/bot/cogs/events.py
@@ -123,10 +123,9 @@ class Events:
             # Short circuit
             return False
 
-        muted_check = any(
+        return any(
             infraction["active"] for infraction in infraction_list if infraction["type"].lower() == "mute"
         )
-        return muted_check
 
     async def on_command_error(self, ctx: Context, e: CommandError):
         command = ctx.command

--- a/bot/cogs/events.py
+++ b/bot/cogs/events.py
@@ -119,7 +119,7 @@ class Events:
         infraction_list = await response.json()
 
         # Check for active mute infractions
-        if len(infraction_list) == 0:
+        if not infraction_list:
             # Short circuit
             return False
 
@@ -263,6 +263,10 @@ class Events:
                     if role in old_roles:
                         # Check for mute roles that were not able to be removed and skip if present
                         if role == str(Roles.muted) and not await self.has_active_mute(str(member.id)):
+                            log.debug(
+                                f"User {member.id} has no active mute infraction, "
+                                "their leftover muted role will not be persisted"
+                            )
                             continue
 
                         new_roles.append(Object(int(role)))

--- a/bot/cogs/events.py
+++ b/bot/cogs/events.py
@@ -124,7 +124,7 @@ class Events:
             return False
 
         muted_check = any(
-            [infraction["active"] for infraction in infraction_list if infraction["type"].lower() == "mute"]
+            infraction["active"] for infraction in infraction_list if infraction["type"].lower() == "mute"
         )
         return muted_check
 


### PR DESCRIPTION
Adds a check for active mute infractions for the case when a joining user is one who left before their mute role could be removed, leaving them permamuted until an admin can remove the role. For this case, the muted role persistence is skipped if no active mute infraction is present.

Closes: #149