### PR TITLE
Patch to make !help work outside of #bot-commands again

### DIFF
--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -9,10 +9,12 @@ from discord.ext import commands
 from fuzzywuzzy import fuzz, process
 
 from bot import constants
+from bot.decorators import InChannelCheckFailure
 from bot.pagination import (
     DELETE_EMOJI, FIRST_EMOJI, LAST_EMOJI,
     LEFT_EMOJI, LinePaginator, RIGHT_EMOJI,
 )
+
 
 REACTIONS = {
     FIRST_EMOJI: 'first',
@@ -427,7 +429,15 @@ class HelpSession:
 
                     # see if the user can run the command
                     strikeout = ''
-                    can_run = await command.can_run(self._ctx)
+
+                    # Patch to make the !help command work outside of #bot-commands again
+                    # This probably needs a proper rewrite, but this will make it work in
+                    # the mean time.
+                    try:
+                        can_run = await command.can_run(self._ctx)
+                    except InChannelCheckFailure:
+                        can_run = False
+
                     if not can_run:
                         # skip if we don't show commands they can't run
                         if self._only_can_run:


### PR DESCRIPTION
This patches `!help` not working outside of the bot-commands channel. I think a proper rewrite of the procedure may be warranted, but this will do in the mean time. See issue #262 

Basically what happened is that the `help` cog runs all the checks on the commands to see if the user requesting the help-embed is allowed to run it to determine which commands should be included. Apparently, one of those checks raises an exception when the check fails, which stops function execution, preventing the help-embed from showing up.

I'm now catching it with a `try-except` and saying that the user can't run the command if the exception was raised. That solves the bug, but creates another one that should be solved later (and is less severe, in my opinion):

If a user ask for `!help` outside of bot-commands, commands that are only allowed in bot-commands do not show up since they user is not allowed to run that command in the channel where they are requesting the help-embed. I don't think that's right, so we should probably restructure the checks.

However, I'd rather push this out first and rewrite the `can_run` check later. 