### PR TITLE
Add infraction hierarchy check

### DIFF
--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -176,7 +176,8 @@ class Moderation(Scheduler):
         :param reason: The reason for the ban.
         """
 
-        if not await self.respect_role_hierarchy(ctx, user, 'ban'):
+        member = ctx.guild.get_member(user.id)
+        if not await self.respect_role_hierarchy(ctx, member, 'ban'):
             # Ensure ctx author has a higher top role than the target user
             # Warning is sent to ctx by the helper method
             return
@@ -337,7 +338,8 @@ class Moderation(Scheduler):
         :param reason: The reason for the temporary ban.
         """
 
-        if not await self.respect_role_hierarchy(ctx, user, 'tempban'):
+        member = ctx.guild.get_member(user.id)
+        if not await self.respect_role_hierarchy(ctx, member, 'tempban'):
             # Ensure ctx author has a higher top role than the target user
             # Warning is sent to ctx by the helper method
             return
@@ -476,7 +478,8 @@ class Moderation(Scheduler):
         :param reason: The reason for the ban.
         """
 
-        if not await self.respect_role_hierarchy(ctx, user, 'shadowban'):
+        member = ctx.guild.get_member(user.id)
+        if not await self.respect_role_hierarchy(ctx, member, 'shadowban'):
             # Ensure ctx author has a higher top role than the target user
             # Warning is sent to ctx by the helper method
             return
@@ -606,7 +609,8 @@ class Moderation(Scheduler):
         :param reason: The reason for the temporary ban.
         """
 
-        if not await self.respect_role_hierarchy(ctx, user, 'shadowtempban'):
+        member = ctx.guild.get_member(user.id)
+        if not await self.respect_role_hierarchy(ctx, member, 'shadowtempban'):
             # Ensure ctx author has a higher top role than the target user
             # Warning is sent to ctx by the helper method
             return

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -1258,8 +1258,8 @@ class Moderation(Scheduler):
 
         if not hierarchy_check:
             log.info(
-                f"{actor.display_name} ({actor.id}) attempted to {infraction_type} "
-                f"{target.display_name} ({target.id}), who has a higher top role"
+                f"{actor} ({actor.id}) attempted to {infraction_type} "
+                f"{target} ({target.id}), who has a higher top role"
             )
             await ctx.send(f":x: {actor.mention}, you may not {infraction_type} someone with a higher top role")
 

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -125,7 +125,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the kick.
         """
 
-        if not self.respect_role_hierarchy(ctx, user, 'kick'):
+        if not await self.respect_role_hierarchy(ctx, user, 'kick'):
             # Ensure ctx author has a higher top role than the target user
             # Warning is sent to ctx by the helper method
             return
@@ -176,7 +176,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the ban.
         """
 
-        if not self.respect_role_hierarchy(ctx, user, 'ban'):
+        if not await self.respect_role_hierarchy(ctx, user, 'ban'):
             # Ensure ctx author has a higher top role than the target user
             # Warning is sent to ctx by the helper method
             return
@@ -337,7 +337,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the temporary ban.
         """
 
-        if not self.respect_role_hierarchy(ctx, user, 'tempban'):
+        if not await self.respect_role_hierarchy(ctx, user, 'tempban'):
             # Ensure ctx author has a higher top role than the target user
             # Warning is sent to ctx by the helper method
             return
@@ -435,7 +435,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the kick.
         """
 
-        if not self.respect_role_hierarchy(ctx, user, 'shadowkick'):
+        if not await self.respect_role_hierarchy(ctx, user, 'shadowkick'):
             # Ensure ctx author has a higher top role than the target user
             # Warning is sent to ctx by the helper method
             return
@@ -476,7 +476,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the ban.
         """
 
-        if not self.respect_role_hierarchy(ctx, user, 'shadowban'):
+        if not await self.respect_role_hierarchy(ctx, user, 'shadowban'):
             # Ensure ctx author has a higher top role than the target user
             # Warning is sent to ctx by the helper method
             return
@@ -606,7 +606,7 @@ class Moderation(Scheduler):
         :param reason: The reason for the temporary ban.
         """
 
-        if not self.respect_role_hierarchy(ctx, user, 'shadowtempban'):
+        if not await self.respect_role_hierarchy(ctx, user, 'shadowtempban'):
             # Ensure ctx author has a higher top role than the target user
             # Warning is sent to ctx by the helper method
             return
@@ -1257,7 +1257,7 @@ class Moderation(Scheduler):
                 f"{actor.display_name} ({actor.id}) attempted to {infraction_type} "
                 f"{target.display_name} ({target.id}), who has a higher top role"
             )
-            ctx.send(f":x: {actor.mention}, you may not {infraction_type} someone with a higher top role")
+            await ctx.send(f":x: {actor.mention}, you may not {infraction_type} someone with a higher top role")
 
         return hierarchy_check
 

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -1207,6 +1207,19 @@ class Moderation(Scheduler):
             if User in error.converters:
                 await ctx.send(str(error.errors[0]))
 
+    async def respect_role_hierarchy(self, guild: Guild, actor: Member, target: Member) -> bool:
+        """
+        Check if the highest role of the invoking member is less than or equal to the target member
+
+        Implement as a method rather than a check in order to avoid having to reimplement parameter
+        checks & conversions in a dedicated check decorater
+        """
+
+        # Build role hierarchy
+        role_hierarchy = {role: rank for rank, role in enumerate(reversed(guild.roles))}
+
+        return role_hierarchy[actor.top_role] <= role_hierarchy[target.top_role]
+
 
 def setup(bot):
     bot.add_cog(Moderation(bot))

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -1243,7 +1243,7 @@ class Moderation(Scheduler):
 
     async def respect_role_hierarchy(self, ctx: Context, target: Member, infraction_type: str) -> bool:
         """
-        Check if the highest role of the invoking member is less than or equal to the target member
+        Check if the highest role of the invoking member is greater than that of the target member
 
         If this check fails, a warning is sent to the invoking ctx
 
@@ -1251,19 +1251,18 @@ class Moderation(Scheduler):
         checks & conversions in a dedicated check decorater
         """
 
-        # Build role hierarchy
         actor = ctx.author
-        role_hierarchy = {role: rank for rank, role in enumerate(reversed(ctx.guild.roles))}
-        hierarchy_check = role_hierarchy[actor.top_role] <= role_hierarchy[target.top_role]
-
-        if not hierarchy_check:
+        target_is_lower = target.top_role < actor.top_role
+        if not target_is_lower:
             log.info(
                 f"{actor} ({actor.id}) attempted to {infraction_type} "
-                f"{target} ({target.id}), who has a higher top role"
+                f"{target} ({target.id}), who has an equal or higher top role"
             )
-            await ctx.send(f":x: {actor.mention}, you may not {infraction_type} someone with a higher top role")
+            await ctx.send(
+                f":x: {actor.mention}, you may not {infraction_type} someone with an equal or higher top role"
+            )
 
-        return hierarchy_check
+        return target_is_lower
 
 
 def setup(bot):


### PR DESCRIPTION
Per #134, add a hierarchy check to all permutations of the kick & ban infractions to prevent infraction of someone with a higher top role.

This is implemented as a helper method rather than a Check in order to avoid duplication of input conversion and validation, as handled by the commands extension.

Closes #134 