### PR TITLE
Using firmer language in the token removal message to the user

### DIFF
--- a/bot/cogs/token_remover.py
+++ b/bot/cogs/token_remover.py
@@ -16,8 +16,9 @@ log = logging.getLogger(__name__)
 
 DELETION_MESSAGE_TEMPLATE = (
     "Hey {mention}! I noticed you posted a seemingly valid Discord API "
-    "token in your message and have removed your message to prevent abuse. "
-    "We recommend regenerating your token regardless, which you can do here: "
+    "token in your message and have removed your message. "
+    "We **strongly recommend** regenerating your token as it's probably "
+    "been compromised. You can do that here: "
     "<https://discordapp.com/developers/applications/me>\n"
     "Feel free to re-post it with the token removed. "
     "If you believe this was a mistake, please let us know!"


### PR DESCRIPTION
As there seems to be someone self-botting on our server to steal API tokens and wreck servers, I feel it's better to change the removal message to something that emphasizes the need to change the token. The old message could give someone the idea that our bot deleting the message mitigated the danger of accidentally posting it.

New message in action:

![Firmer recommendation to change token](https://user-images.githubusercontent.com/33516116/51027344-eb613100-1590-11e9-8263-44a15c955e49.png)
