### PR TITLE
Disable rich embed filter

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -137,7 +137,7 @@ filter:
     filter_zalgo:       false
     filter_invites:     true
     filter_domains:     true
-    filter_rich_embeds: true
+    filter_rich_embeds: false
     watch_words:        true
     watch_tokens:       true
 


### PR DESCRIPTION
Discord adding the embeds is causing a false positive. This flips the config flag until we can triage the issue.