### PR TITLE
Changing the rich embed filter to a watchlist that ignores twitter embeds

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -201,7 +201,7 @@ class Filter(metaclass=YAMLGetter):
     filter_zalgo: bool
     filter_invites: bool
     filter_domains: bool
-    filter_rich_embeds: bool
+    watch_rich_embeds: bool
     watch_words: bool
     watch_tokens: bool
 
@@ -209,7 +209,6 @@ class Filter(metaclass=YAMLGetter):
     notify_user_zalgo: bool
     notify_user_invites: bool
     notify_user_domains: bool
-    notify_user_rich_embeds: bool
 
     ping_everyone: bool
     guild_invite_whitelist: List[int]

--- a/config-default.yml
+++ b/config-default.yml
@@ -140,7 +140,7 @@ filter:
     filter_zalgo:       false
     filter_invites:     true
     filter_domains:     true
-    filter_rich_embeds: false
+    watch_rich_embeds:  true
     watch_words:        true
     watch_tokens:       true
 
@@ -149,7 +149,6 @@ filter:
     notify_user_zalgo:       false
     notify_user_invites:     true
     notify_user_domains:     false
-    notify_user_rich_embeds: true
 
     # Filter configuration
     ping_everyone: true  # Ping @everyone when we send a mod-alert?


### PR DESCRIPTION
This PR hopefully mitigates the problem of false-positives in the rich embed detection function by ignoring Twitter embeds. Since we cannot rely on Discord not adding more special embeds that inadvertently trigger the filter, I've also turned it into a watchlist rather than a filter. That way, moderators and up will notified of a detection and can choose to take action if warranted. This ensures that if false-positives do still happen, the regular user won't even notice it.

To avoid the problem with embeds triggering the filter system twice, I've included a time delta check for this specific filter. In my tests, the edit delta always shows up as `0` microseconds, but to be sure, I'm considering every edit faster than 100 microseconds (0.001 second) after message creation as a double trigger condition.

Finally, I've left the try-except block in the code for if we ever want to turn this watchlist into a filter again. While the above mentioned double trigger system is in place, it may not be foolproof in the case of Discord lag. Therefore, we should probably leave it in the code in case we ever want to turn this into a filter again, so we don't have to reinvent the wheel.

This PR should close #270 