### PR TITLE
Redirect output of help command to bot-commands for regular users

### DIFF
--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -10,6 +10,8 @@ from discord.ext.commands import CheckFailure
 from fuzzywuzzy import fuzz, process
 
 from bot import constants
+from bot.constants import Roles
+from bot.decorators import redirect_output
 from bot.pagination import (
     DELETE_EMOJI, FIRST_EMOJI, LAST_EMOJI,
     LEFT_EMOJI, LinePaginator, RIGHT_EMOJI,
@@ -23,7 +25,7 @@ REACTIONS = {
     LAST_EMOJI: 'end',
     DELETE_EMOJI: 'stop'
 }
-
+STAFF_ROLES = Roles.helpers, Roles.moderator, Roles.admin, Roles.owner
 Cog = namedtuple('Cog', ['name', 'description', 'commands'])
 
 
@@ -652,6 +654,7 @@ class Help:
     Custom Embed Pagination Help feature
     """
     @commands.command('help')
+    @redirect_output(constants.Channels.bot, STAFF_ROLES)
     async def new_help(self, ctx, *commands):
         """
         Shows Command Help.

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -481,6 +481,13 @@ class Free(metaclass=YAMLGetter):
     cooldown_per: float
 
 
+class RedirectOutput(metaclass=YAMLGetter):
+    section = 'redirect_output'
+
+    delete_invocation: bool
+    delete_delay: int
+
+
 # Debug mode
 DEBUG_MODE = True if 'local' in os.environ.get("SITE_URL", "local") else False
 

--- a/config-default.yml
+++ b/config-default.yml
@@ -347,6 +347,9 @@ free:
     cooldown_rate: 1
     cooldown_per: 60.0
 
+redirect_output:
+    delete_invocation: true
+    delete_delay: 15
 
 config:
     required_keys: ['bot.token']


### PR DESCRIPTION
This PR redirects the output of the help-command to bot-commands using a new decorator. 

The decorator works by changing `Context.channel` to the specified channel, ensuring that the whole command is ran as if it was initially invoked in the destination channel. The user gets a message with a mention that the output of their command can be found in the destination channel and receives a ping in the destination channel. If deletion is set to true in the config, the invocation message and redirection message will be deleted after the specified delay.

The decorator should be reusable.

Also see #274 

How it looks:
![redirection_message](https://user-images.githubusercontent.com/33516116/51415448-2f969780-1b76-11e9-9944-56bcac13dada.png)

![in_botcommands](https://user-images.githubusercontent.com/33516116/51415452-31f8f180-1b76-11e9-9dbc-443bdcf84d3d.png)


