### PR TITLE
Hiding 'hidden infractions' from regular users user information embed

### DIFF
--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -135,10 +135,13 @@ class Information:
             if not with_role_check(ctx, *MODERATION_ROLES):
                 raise BadArgument("You do not have permission to use this command on users other than yourself.")
 
-        # Non-moderators may only do this in #bot-commands
+        # Non-moderators may only do this in #bot-commands and can't see
+        # hidden infractions.
         if not with_role_check(ctx, *MODERATION_ROLES):
             if not ctx.channel.id == Channels.bot:
                 raise MissingPermissions("You can't do that here!")
+            # Hide hidden infractions for users without a moderation role
+            hidden = False
 
         # Validates hidden input
         hidden = str(hidden)


### PR DESCRIPTION
Hides `hidden infractions` when a regular user specifies `hidden=True` when requesting their user information. In this PR, the `hidden = True` is ignored for regular users without moderation roles and it does so silently.