### PR TITLE
Redirecting free command to bot-commands for regular users

### DIFF
--- a/bot/cogs/free.py
+++ b/bot/cogs/free.py
@@ -2,10 +2,10 @@ import logging
 from datetime import datetime
 
 from discord import Colour, Embed, Member, utils
-from discord.ext import commands
-from discord.ext.commands import BucketType, Context, command, cooldown
+from discord.ext.commands import Context, command
 
-from bot.constants import Categories, Free, Roles
+from bot.constants import Categories, Channels, Free, STAFF_ROLES
+from bot.decorators import redirect_output
 
 
 log = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ class Free:
     PYTHON_HELP_ID = Categories.python_help
 
     @command(name="free", aliases=('f',))
-    @cooldown(RATE, PER, BucketType.channel)
+    @redirect_output(destination_channel=Channels.bot, bypass_roles=STAFF_ROLES)
     async def free(self, ctx: Context, user: Member = None, seek: int = 2):
         """
         Lists free help channels by likeliness of availability.
@@ -99,27 +99,6 @@ class Free:
                                  "as one will likely be available soon.**")
 
         await ctx.send(embed=embed)
-
-    @free.error
-    async def free_error(self, ctx: Context, error):
-        """
-        If error raised is CommandOnCooldown, and the
-        user who invoked has the helper role, reset
-        the cooldown and reinvoke the command.
-
-        Otherwise log the error.
-        """
-        helpers = ctx.guild.get_role(Roles.helpers)
-
-        if isinstance(error, commands.CommandOnCooldown):
-            if helpers in ctx.author.roles:
-                # reset cooldown so second invocation
-                # doesn't bring us back here.
-                ctx.command.reset_cooldown(ctx)
-                # return to avoid needlessly logging the error
-                return await ctx.reinvoke()
-
-        log.exception(error)  # Don't ignore other errors
 
 
 def setup(bot):

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -10,7 +10,7 @@ from discord.ext.commands import CheckFailure
 from fuzzywuzzy import fuzz, process
 
 from bot import constants
-from bot.constants import Roles
+from bot.constants import Channels, STAFF_ROLES
 from bot.decorators import redirect_output
 from bot.pagination import (
     DELETE_EMOJI, FIRST_EMOJI, LAST_EMOJI,
@@ -25,7 +25,7 @@ REACTIONS = {
     LAST_EMOJI: 'end',
     DELETE_EMOJI: 'stop'
 }
-STAFF_ROLES = Roles.helpers, Roles.moderator, Roles.admin, Roles.owner
+
 Cog = namedtuple('Cog', ['name', 'description', 'commands'])
 
 
@@ -654,7 +654,7 @@ class Help:
     Custom Embed Pagination Help feature
     """
     @commands.command('help')
-    @redirect_output(constants.Channels.bot, STAFF_ROLES)
+    @redirect_output(destination_channel=Channels.bot, bypass_roles=STAFF_ROLES)
     async def new_help(self, ctx, *commands):
         """
         Shows Command Help.

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -496,6 +496,9 @@ DEBUG_MODE = True if 'local' in os.environ.get("SITE_URL", "local") else False
 BOT_DIR = os.path.dirname(__file__)
 PROJECT_ROOT = os.path.abspath(os.path.join(BOT_DIR, os.pardir))
 
+# Default role combinations
+STAFF_ROLES = Roles.helpers, Roles.moderator, Roles.admin, Roles.owner
+
 # Bot replies
 NEGATIVE_REPLIES = [
     "Noooooo!!",

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -122,7 +122,7 @@ def redirect_output(destination_channel: int, bypass_roles: typing.Container[int
             redirect_channel = ctx.guild.get_channel(destination_channel)
             old_channel = ctx.channel
 
-            log.trace(f"Redirecting output of {ctx.author}'s command '{ctx.command.name}'' to {redirect_channel.name}")
+            log.trace(f"Redirecting output of {ctx.author}'s command '{ctx.command.name}' to {redirect_channel.name}")
             ctx.channel = redirect_channel
             await ctx.channel.send(f"Here's the output of your command, {ctx.author.mention}")
             await func(self, ctx, *args, **kwargs)


### PR DESCRIPTION
This PR redirects the `!free` command to bot-commands for regular users. My recommendation is to move bot-commands up in the channel list as well, so it's visible and easy to find for new members. 

Changes in this PR:
- Adding redirect_output decorator to `!free`
- Changing positional arguments to kwargs for redirect_output decorator of `!help` for readability
- Correcting typo in decorator log message (double `'`)
- Removing the cooldown currently used for `!free` as it's not redundant
- Adding STAFF_ROLES container to `bot.constants` to keep it DRY

We can still look into changing the embed itself, but this will at least take care of the interruptions in help/topical channels. 

Also see the discussion in #274