### PR TITLE
Suppressing NotFound exception when trying to delete messages

### DIFF
--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -2,10 +2,12 @@ import logging
 import random
 import typing
 from asyncio import Lock, sleep
+from contextlib import suppress
 from functools import wraps
 from weakref import WeakValueDictionary
 
 from discord import Colour, Embed
+from discord.errors import NotFound
 from discord.ext import commands
 from discord.ext.commands import CheckFailure, Context
 
@@ -134,7 +136,13 @@ def redirect_output(destination_channel: int, bypass_roles: typing.Container[int
 
             if RedirectOutput.delete_invocation:
                 await sleep(RedirectOutput.delete_delay)
-                await message.delete()
-                await ctx.message.delete()
+
+                with suppress(NotFound):
+                    await message.delete()
+                    log.trace("Redirect output: Deleted user redirection message")
+
+                with suppress(NotFound):
+                    await ctx.message.delete()
+                    log.trace("Redirect output: Deleted invocation message")
         return inner
     return wrap


### PR DESCRIPTION
As has been kindly pointed out by one of our users, I've made a slight oversight while implementing the `redirect_output` decorator: When the bot tries to delete a message that has already been deleted, either by the user or a mod, the `NotFound` exception is raised. Users will then see this:
![](https://cdn.discordapp.com/attachments/492410857205268501/540225206275538967/unknown.png)

I've fixed this by suppressing that specific exception using `contextlib.suppress`, as recommended by Volccy.