### PR TITLE
Sending a stronger message to the user after removing token

### DIFF
--- a/bot/cogs/token_remover.py
+++ b/bot/cogs/token_remover.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 DELETION_MESSAGE_TEMPLATE = (
     "Hey {mention}! I noticed you posted a seemingly valid Discord API "
     "token in your message and have removed your message. "
-    "This means that your token has more than likely been **compromised**. "
+    "This means that your token has been **compromised**. "
     "Please change your token **immediately** at: "
     "<https://discordapp.com/developers/applications/me>\n\n"
     "Feel free to re-post it with the token removed. "

--- a/bot/cogs/token_remover.py
+++ b/bot/cogs/token_remover.py
@@ -17,9 +17,9 @@ log = logging.getLogger(__name__)
 DELETION_MESSAGE_TEMPLATE = (
     "Hey {mention}! I noticed you posted a seemingly valid Discord API "
     "token in your message and have removed your message. "
-    "We **strongly recommend** regenerating your token as it's probably "
-    "been compromised. You can do that here: "
-    "<https://discordapp.com/developers/applications/me>\n"
+    "This means that your token has more than likely been **compromised**. "
+    "Please change your token **immediately** at: "
+    "<https://discordapp.com/developers/applications/me>\n\n"
     "Feel free to re-post it with the token removed. "
     "If you believe this was a mistake, please let us know!"
 )


### PR DESCRIPTION
Despite the recent rewording, we've noticed that a lot of user still didn't see the urgency of changing the API token after receiving the removal message. As I've also noticed a slight delay between the leak and the subsequent bot hijack, I'm proposing to send an even stronger message to the user:

![new_token_removal_message_revision](https://user-images.githubusercontent.com/33516116/52223392-d03ec400-28a5-11e9-8043-e91a3377ad11.png)

I feel that if they still ignore this, then it's entirely on them.