### PR TITLE
Unwatch reason / Nomination improvements

### DIFF
--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -74,7 +74,7 @@ class Alias:
             self, ctx: Context, user: User, *, reason: str
     ):
         """
-        Alias for invoking <prefix>bigbrother watch user [reason].
+        Alias for invoking <prefix>bigbrother watch [user] [reason].
         """
 
         await self.invoke(ctx, "bigbrother watch", user, reason=reason)
@@ -82,7 +82,7 @@ class Alias:
     @command(name="unwatch", hidden=True)
     async def bigbrother_unwatch_alias(self, ctx, user: User, *, reason: str):
         """
-        Alias for invoking <prefix>bigbrother unwatch user [reason].
+        Alias for invoking <prefix>bigbrother unwatch [user] [reason].
         """
 
         await self.invoke(ctx, "bigbrother unwatch", user, reason=reason)

--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -74,7 +74,7 @@ class Alias:
             self, ctx: Context, user: User, *, reason: str
     ):
         """
-        Alias for invoking <prefix>bigbrother watch user reason.
+        Alias for invoking <prefix>bigbrother watch user [reason].
         """
 
         await self.invoke(ctx, "bigbrother watch", user, reason=reason)
@@ -82,7 +82,7 @@ class Alias:
     @command(name="unwatch", hidden=True)
     async def bigbrother_unwatch_alias(self, ctx, user: User, *, reason: str):
         """
-        Alias for invoking <prefix>bigbrother unwatch user reason.
+        Alias for invoking <prefix>bigbrother unwatch user [reason].
         """
 
         await self.invoke(ctx, "bigbrother unwatch", user, reason=reason)
@@ -106,7 +106,7 @@ class Alias:
     @command(name="reload", hidden=True)
     async def cogs_reload_alias(self, ctx, *, cog_name: str):
         """
-        Alias for invoking <prefix>cogs reload cog_name.
+        Alias for invoking <prefix>cogs reload [cog_name].
 
         cog_name: str - name of the cog to be reloaded.
         """

--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -74,20 +74,18 @@ class Alias:
             self, ctx: Context, user: User, *, reason: str
     ):
         """
-        Alias for invoking <prefix>bigbrother watch user [text_channel].
+        Alias for invoking <prefix>bigbrother watch user reason.
         """
 
         await self.invoke(ctx, "bigbrother watch", user, reason=reason)
 
     @command(name="unwatch", hidden=True)
-    async def bigbrother_unwatch_alias(self, ctx, user: User):
+    async def bigbrother_unwatch_alias(self, ctx, user: User, *, reason: str):
         """
-        Alias for invoking <prefix>bigbrother unwatch user.
-
-        user: discord.User - A user instance to unwatch
+        Alias for invoking <prefix>bigbrother unwatch user reason.
         """
 
-        await self.invoke(ctx, "bigbrother unwatch", user)
+        await self.invoke(ctx, "bigbrother unwatch", user, reason=reason)
 
     @command(name="home", hidden=True)
     async def site_home_alias(self, ctx):

--- a/bot/cogs/bigbrother.py
+++ b/bot/cogs/bigbrother.py
@@ -9,7 +9,10 @@ from aiohttp import ClientError
 from discord import Color, Embed, Guild, Member, Message, TextChannel, User
 from discord.ext.commands import Bot, Context, command, group
 
-from bot.constants import BigBrother as BigBrotherConfig, Channels, Emojis, Guild as GuildConfig, Keys, Roles, URLs
+from bot.constants import (
+    BigBrother as BigBrotherConfig, Channels, Emojis, Guild as GuildConfig,
+    Keys, Roles, STAFF_ROLES, URLs,
+)
 from bot.decorators import with_role
 from bot.pagination import LinePaginator
 from bot.utils import messages
@@ -40,7 +43,7 @@ class BigBrother:
         self.last_log = [None, None, 0]  # [user_id, channel_id, message_count]
         self.consuming = False
         self.infraction_watch_prefix = "bb watch: "  # Please do not change or we won't be able to find old reasons
-        self.nomination_prefix = "Nomination: "
+        self.nomination_prefix = "Helper nomination: "
 
         self.bot.loop.create_task(self.get_watched_users())
 
@@ -421,6 +424,12 @@ class BigBrother:
         # Note: This function is called from HelperNomination.nominate_command so that the
         # !nominate command does not show up under "BigBrother" in the help embed, but under
         # the header HelperNomination for users with the helper role.
+
+        member = ctx.guild.get_member(user.id)
+
+        if member and any(role.id in STAFF_ROLES for role in member.roles):
+            await ctx.send(f":x: {user.mention} is already a staff member!")
+            return
 
         channel_id = Channels.talent_pool
 

--- a/bot/cogs/bigbrother.py
+++ b/bot/cogs/bigbrother.py
@@ -246,6 +246,13 @@ class BigBrother:
 
                     # Adding nomination info to author_field
                     author_field = f"{author_field} (nominated {time_delta} by {actor})"
+            else:
+                if inserted_at:
+                    # Get time delta since insertion
+                    date_time = parse_rfc1123(inserted_at).replace(tzinfo=None)
+                    time_delta = time_since(date_time, precision="minutes", max_units=1)
+
+                    author_field = f"{author_field} (added {time_delta})"
 
             embed = Embed(description=f"{message.author.mention} in [#{message.channel.name}]({message.jump_url})")
             embed.set_author(name=author_field, icon_url=message.author.avatar_url)

--- a/bot/cogs/bigbrother.py
+++ b/bot/cogs/bigbrother.py
@@ -441,7 +441,11 @@ class BigBrother:
                 prefix = "Additional nomination: "
             else:
                 # If the user is being watched in big-brother, don't add them to talent-pool
-                await ctx.send(f":x: Can't add {user.mention} to the talent-pool at this moment")
+                message = (
+                    f":x: {user.mention} can't be added to the talent-pool "
+                    "as they are currently being watched in big-brother."
+                )
+                await ctx.send(message)
                 return
         else:
             prefix = self.nomination_prefix

--- a/bot/cogs/bigbrother.py
+++ b/bot/cogs/bigbrother.py
@@ -328,6 +328,9 @@ class BigBrother:
             if not updated:
                 await ctx.send(f":x: Failed to update cache: non-200 response from the API")
                 return
+            title = "Watched users (updated cache)"
+        else:
+            title = "Watched users (from cache)"
 
         lines = tuple(
             f"• <@{user_id}> in <#{self.watched_users[user_id].id}>"
@@ -336,7 +339,7 @@ class BigBrother:
         await LinePaginator.paginate(
             lines or ("There's nothing here yet.",),
             ctx,
-            Embed(title="Watched users (cached)", color=Color.blue()),
+            Embed(title=title, color=Color.blue()),
             empty=False
         )
 


### PR DESCRIPTION
This PR is meant to do a couple of things:
- As requested by @heavysaturn, unwatching (both bb and talent-pool) a user now requires a reason; the reason will be added as a note the user's record.
- Previously, a double bb watch would overwrite the old reason; this PR prevents that and notifies the actor.
- Information on how long a user has been in BB is now added to the header
- Previously, a nomination could overwrite a bb-watch; I've added a check for that.
- If a user receives a secondary nomination, then that will no longer overwrite the initial nomination and time. Instead, additional nominations will be added as a note with the prefix "Additional nomination: "
- To ensure the cache is up to date before checking if a user is already watched/nominated, the cache is updated. To do so, I moved the updating functionality out of the `!watched` command to a separate function to keep it DRY.

This should close #290 and the in-channel request by Lemon.

**Note**: Users who are currently nominated will lose their reason, as I've updated the prefix. I'll manually edit their notes later to update them to the current prefix.