### PR TITLE
Added alias for tags get traceback - !exception.

### DIFF
--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -144,9 +144,9 @@ class Alias:
         """
         Alias for invoking <prefix>tags get traceback.
         """
-        
+
         await self.invoke(ctx, "tags get traceback")
-        
+
     @group(name="get",
            aliases=("show", "g"),
            hidden=True,

--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -139,6 +139,14 @@ class Alias:
 
         await self.invoke(ctx, "defcon disable")
 
+    @command(name="exception", hidden=True)
+    async def tags_get_traceback_alias(self, ctx):
+        """
+        Alias for invoking <prefix>tags get traceback.
+        """
+        
+        await self.invoke(ctx, "tags get traceback")
+        
     @group(name="get",
            aliases=("show", "g"),
            hidden=True,


### PR DESCRIPTION
I find myself writing !exception by mistake too often and just figured i'd see if others would want this alias in.