### PR TITLE
Add team creation command

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -78,6 +78,7 @@ bot.load_extension("bot.cogs.token_remover")
 bot.load_extension("bot.cogs.utils")
 bot.load_extension("bot.cogs.wolfram")
 bot.load_extension("bot.cogs.free")
+bot.load_extension("bot.cogs.jams")
 
 if has_rmq:
     bot.load_extension("bot.cogs.rmq")

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -38,11 +38,11 @@ else:
     log.warning("Timed out while waiting for RabbitMQ")
 
 # Internal/debug
-bot.load_extension("bot.cogs.logging")
-bot.load_extension("bot.cogs.security")
 bot.load_extension("bot.cogs.events")
 bot.load_extension("bot.cogs.filtering")
+bot.load_extension("bot.cogs.logging")
 bot.load_extension("bot.cogs.modlog")
+bot.load_extension("bot.cogs.security")
 
 # Commands, etc
 bot.load_extension("bot.cogs.antispam")
@@ -60,12 +60,13 @@ if not DEBUG_MODE:
 
 # Feature cogs
 bot.load_extension("bot.cogs.alias")
-bot.load_extension("bot.cogs.deployment")
 bot.load_extension("bot.cogs.defcon")
+bot.load_extension("bot.cogs.deployment")
 bot.load_extension("bot.cogs.eval")
+bot.load_extension("bot.cogs.free")
 bot.load_extension("bot.cogs.fun")
-bot.load_extension("bot.cogs.superstarify")
 bot.load_extension("bot.cogs.information")
+bot.load_extension("bot.cogs.jams")
 bot.load_extension("bot.cogs.moderation")
 bot.load_extension("bot.cogs.off_topic_names")
 bot.load_extension("bot.cogs.reddit")
@@ -73,12 +74,11 @@ bot.load_extension("bot.cogs.reminders")
 bot.load_extension("bot.cogs.site")
 bot.load_extension("bot.cogs.snakes")
 bot.load_extension("bot.cogs.snekbox")
+bot.load_extension("bot.cogs.superstarify")
 bot.load_extension("bot.cogs.tags")
 bot.load_extension("bot.cogs.token_remover")
 bot.load_extension("bot.cogs.utils")
 bot.load_extension("bot.cogs.wolfram")
-bot.load_extension("bot.cogs.free")
-bot.load_extension("bot.cogs.jams")
 
 if has_rmq:
     bot.load_extension("bot.cogs.rmq")

--- a/bot/cogs/jams.py
+++ b/bot/cogs/jams.py
@@ -1,0 +1,72 @@
+import logging
+
+from discord import PermissionOverwrite, Member, utils
+from discord.ext import commands
+
+from bot.decorators import with_role
+from bot.constants import Roles
+
+log = logging.getLogger(__name__)
+
+class CodeJams:
+    """
+    A cog for managing the code-jam related parts of our server
+    """
+
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+
+    @commands.command()
+    @with_role(Roles.admin)
+    async def createteam(
+        self, ctx: commands.Context,
+        team_name: str, members: commands.Greedy[Member]
+    ):
+        code_jam_category = utils.get(ctx.guild.categories, name="Code Jam")
+
+        if code_jam_category is None:
+            log.info("Code Jam category not found, creating it.")
+
+            category_overwrites = {
+                ctx.guild.default_role: PermissionOverwrite(read_messages=False),
+                ctx.guild.me: PermissionOverwrite(read_messages=True)
+            }
+
+            code_jam_category = await ctx.guild.create_category_channel(
+                "Code Jam",
+                overwrites=category_overwrites,
+                reason="It's code jam time!"
+            )
+        
+        # First member is always the team leader
+        team_channel_overwrites = {
+            members[0]: PermissionOverwrite(manage_messages=True, read_messages=True, manage_webhooks=True),
+            ctx.guild.default_role: PermissionOverwrite(read_messages=False),
+            ctx.guild.get_role(Roles.developer): PermissionOverwrite(read_messages=False)
+        }
+
+        # Rest of members should just have read_messages
+        for member in members[1:]:
+            team_channel_overwrites[member] = PermissionOverwrite(read_messages=True)
+
+        # Create a channel for the team
+        team_channel = await ctx.guild.create_text_channel(
+            team_name,
+            overwrites=team_channel_overwrites,
+            category=code_jam_category
+        )
+
+        # Assign team leader role
+        await members[0].add_roles(ctx.guild.get_role(Roles.team_leader))
+
+        # Assign rest of roles
+        jammer_role = ctx.guild.get_role(Roles.jammer)
+        for member in members:
+            await member.add_roles(jammer_role)
+
+        await ctx.send(f":ok_hand: Team created: {team_channel.mention}")
+
+
+def setup(bot):
+    bot.add_cog(CodeJams(bot))
+    log.info("Cog loaded: CodeJams")

--- a/bot/cogs/jams.py
+++ b/bot/cogs/jams.py
@@ -1,12 +1,13 @@
 import logging
 
-from discord import PermissionOverwrite, Member, utils
+from discord import Member, PermissionOverwrite, utils
 from discord.ext import commands
 
-from bot.decorators import with_role
 from bot.constants import Roles
+from bot.decorators import with_role
 
 log = logging.getLogger(__name__)
+
 
 class CodeJams:
     """
@@ -43,7 +44,7 @@ class CodeJams:
                 overwrites=category_overwrites,
                 reason="It's code jam time!"
             )
-        
+
         # First member is always the team leader
         team_channel_overwrites = {
             members[0]: PermissionOverwrite(

--- a/bot/cogs/jams.py
+++ b/bot/cogs/jams.py
@@ -22,6 +22,12 @@ class CodeJams:
         self, ctx: commands.Context,
         team_name: str, members: commands.Greedy[Member]
     ):
+        """
+        Create a team channel in the Code Jams category, assign roles and then add
+        overwrites for the team.
+
+        The first user passed will always be the team leader.
+        """
         code_jam_category = utils.get(ctx.guild.categories, name="Code Jam")
 
         if code_jam_category is None:

--- a/bot/cogs/jams.py
+++ b/bot/cogs/jams.py
@@ -46,7 +46,11 @@ class CodeJams:
         
         # First member is always the team leader
         team_channel_overwrites = {
-            members[0]: PermissionOverwrite(manage_messages=True, read_messages=True, manage_webhooks=True),
+            members[0]: PermissionOverwrite(
+                manage_messages=True,
+                read_messages=True,
+                manage_webhooks=True
+            ),
             ctx.guild.default_role: PermissionOverwrite(read_messages=False),
             ctx.guild.get_role(Roles.developer): PermissionOverwrite(read_messages=False)
         }

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -372,6 +372,7 @@ class Roles(metaclass=YAMLGetter):
     owner: int
     verified: int
     helpers: int
+    team_leader: int
 
 
 class Guild(metaclass=YAMLGetter):

--- a/config-default.yml
+++ b/config-default.yml
@@ -134,6 +134,7 @@ guild:
         verified:                           352427296948486144
         helpers:                            267630620367257601
         rockstars:         &ROCKSTARS_ROLE  458226413825294336
+        team_leader:                        501324292341104650
 
 
 filter:


### PR DESCRIPTION
This PR adds a `!createteam` command to create a team channel for the code jam.

<img width="357" alt="image" src="https://user-images.githubusercontent.com/20439493/52901289-96e94b00-31f9-11e9-8934-630580b155f3.png">

It creates the jams category if it does not exist, adds the jammer and team leader roles and then adds overwrites to the channel so that team members can see it and team leaders can pin and add Webhooks in it.