### PR TITLE
Removed STAFF constant, added footer to paginated embed

### DIFF
--- a/bot/cogs/rules.py
+++ b/bot/cogs/rules.py
@@ -65,11 +65,11 @@ class Rules:
         **`rules`:** The rules a user wants to get.
         """
         rules_embed = Embed(title='Rules', color=Colour.blurple())
-        rules_embed.set_footer(text=self.footer)
 
         if not rules:
             # Rules were not submitted. Return the default description.
             rules_embed.description = self.default_desc
+            rules_embed.set_footer(text=self.footer)
             return await ctx.send(embed=rules_embed)
 
         # Split the rules input by slash, comma or space

--- a/bot/cogs/rules.py
+++ b/bot/cogs/rules.py
@@ -52,7 +52,7 @@ class Rules:
                              " our [rules page](https://pythondiscord.com/about/rules). We expect"
                              " all members of the community to have read and understood these."
                              )
-        self.footer = 'https://pythondiscord.com/about/rules'
+        self.title_link = 'https://pythondiscord.com/about/rules'
 
     @command(aliases=['r', 'rule'], name='rules')
     @redirect_output(destination_channel=Channels.bot, bypass_roles=STAFF_ROLES)
@@ -69,7 +69,7 @@ class Rules:
         if not rules:
             # Rules were not submitted. Return the default description.
             rules_embed.description = self.default_desc
-            rules_embed.set_footer(text=self.footer)
+            rules_embed.url = 'https://pythondiscord.com/about/rules'
             return await ctx.send(embed=rules_embed)
 
         # Split the rules input by slash, comma or space
@@ -94,8 +94,10 @@ class Rules:
             # No valid rules in rules input. Return the default description.
             rules_embed.description = self.default_desc
             return await ctx.send(embed=rules_embed)
-        await LinePaginator.paginate(final_rules, ctx, rules_embed, max_lines=3,
-                                     footer_text=self.footer)
+        await LinePaginator.paginate(
+            final_rules, ctx, rules_embed,
+            max_lines=3, url=self.title_link
+        )
 
 
 def setup(bot):

--- a/bot/cogs/rules.py
+++ b/bot/cogs/rules.py
@@ -4,11 +4,9 @@ from typing import Optional
 from discord import Colour, Embed
 from discord.ext.commands import Bot, Context, command
 
-from bot.constants import Channels, Roles
+from bot.constants import Channels, STAFF_ROLES
 from bot.decorators import redirect_output
 from bot.pagination import LinePaginator
-
-STAFF = Roles.admin, Roles.moderator, Roles.owner
 
 
 class Rules:
@@ -54,9 +52,10 @@ class Rules:
                              " our [rules page](https://pythondiscord.com/about/rules). We expect"
                              " all members of the community to have read and understood these."
                              )
+        self.footer = 'https://pythondiscord.com/about/rules'
 
     @command(aliases=['r', 'rule'], name='rules')
-    @redirect_output(destination_channel=Channels.bot, bypass_roles=STAFF)
+    @redirect_output(destination_channel=Channels.bot, bypass_roles=STAFF_ROLES)
     async def rules_command(self, ctx: Context, *, rules: Optional[str] = None):
         """
         Provides a link to the `rules` endpoint of the website, or displays
@@ -66,7 +65,7 @@ class Rules:
         **`rules`:** The rules a user wants to get.
         """
         rules_embed = Embed(title='Rules', color=Colour.blurple())
-        rules_embed.set_footer(text='https://pythondiscord.com/about/rules')
+        rules_embed.set_footer(text=self.footer)
 
         if not rules:
             # Rules were not submitted. Return the default description.
@@ -95,7 +94,8 @@ class Rules:
             # No valid rules in rules input. Return the default description.
             rules_embed.description = self.default_desc
             return await ctx.send(embed=rules_embed)
-        await LinePaginator.paginate(final_rules, ctx, rules_embed, max_lines=3)
+        await LinePaginator.paginate(final_rules, ctx, rules_embed, max_lines=3,
+                                     footer_text=self.footer)
 
 
 def setup(bot):

--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -100,8 +100,7 @@ class LinePaginator(Paginator):
     async def paginate(cls, lines: Iterable[str], ctx: Context, embed: Embed,
                        prefix: str = "", suffix: str = "", max_lines: Optional[int] = None, max_size: int = 500,
                        empty: bool = True, restrict_to_user: User = None, timeout: int = 300,
-                       footer_text: str = None,
-                       exception_on_empty_embed: bool = False):
+                       footer_text: str = None, url: str = None, exception_on_empty_embed: bool = False):
         """
         Use a paginator and set of reactions to provide pagination over a set of lines. The reactions are used to
         switch page, or to finish with pagination.
@@ -123,6 +122,8 @@ class LinePaginator(Paginator):
         :param max_size: The maximum number of characters on each page
         :param empty: Whether to place an empty line between each given line
         :param restrict_to_user: A user to lock pagination operations to for this message, if supplied
+        :param exception_on_empty_embed: Should there be an exception if the embed is empty?
+        :param url: the url to use for the embed headline
         :param timeout: The amount of time in seconds to disable pagination of no reaction is added
         :param footer_text: Text to prefix the page number in the footer with
         """
@@ -182,6 +183,10 @@ class LinePaginator(Paginator):
                 embed.set_footer(text=footer_text)
                 log.trace(f"Setting embed footer to '{footer_text}'")
 
+            if url:
+                embed.url = url
+                log.trace(f"Setting embed url to '{url}'")
+
             log.debug("There's less than two pages, so we won't paginate - sending single page on its own")
             return await ctx.send(embed=embed)
         else:
@@ -189,8 +194,11 @@ class LinePaginator(Paginator):
                 embed.set_footer(text=f"{footer_text} (Page {current_page + 1}/{len(paginator.pages)})")
             else:
                 embed.set_footer(text=f"Page {current_page + 1}/{len(paginator.pages)}")
-
             log.trace(f"Setting embed footer to '{embed.footer.text}'")
+
+            if url:
+                embed.url = url
+                log.trace(f"Setting embed url to '{url}'")
 
             log.debug("Sending first page to channel...")
             message = await ctx.send(embed=embed)


### PR DESCRIPTION
Removed the `STAFF` constant within the cog in favor of the `STAFF_ROLES` constant present in `bot.constants`.
Added a footer to the paginated embed that points to the Rules page of the site, as the default embed does.
Very slight refactoring: moved the `set_footer` line to the default embed instead of having it set before-hand every time.