### PR TITLE
Preventing the ot-names cycling bug

### DIFF
--- a/bot/cogs/off_topic_names.py
+++ b/bot/cogs/off_topic_names.py
@@ -50,11 +50,8 @@ async def update_names(bot: Bot, headers: dict):
     # To ensure we only cycle once per day, we increase the reference midnight point
     # by one day each time the task runs instead of relying on "the most recent"
     # midnight, since that may fail if the task is triggered early.
-    midnight = None
+    midnight = midnight = datetime.utcnow().replace(microsecond=0, second=0, minute=0, hour=0)
     while True:
-        if midnight is None:
-            midnight = datetime.utcnow().replace(microsecond=0, second=0, minute=0, hour=0)
-
         midnight += timedelta(days=1)
         seconds_to_sleep = (midnight - datetime.utcnow()).seconds
         log.debug(f"update_names: seconds to sleep {seconds_to_sleep}")

--- a/bot/cogs/off_topic_names.py
+++ b/bot/cogs/off_topic_names.py
@@ -48,8 +48,11 @@ async def update_names(bot: Bot, headers: dict):
     """
 
     while True:
+        # To prevent the bot from sleeping until one second before midnight, we aim
+        # for one minute past midnight. This should prevent the ot-names cycling bug.
+
         today_at_midnight = datetime.utcnow().replace(microsecond=0, second=0, minute=0, hour=0)
-        next_midnight = today_at_midnight + timedelta(days=1)
+        next_midnight = today_at_midnight + timedelta(days=1, minutes=1)
         seconds_to_sleep = (next_midnight - datetime.utcnow()).seconds
         await asyncio.sleep(seconds_to_sleep)
 

--- a/bot/cogs/off_topic_names.py
+++ b/bot/cogs/off_topic_names.py
@@ -47,14 +47,12 @@ async def update_names(bot: Bot, headers: dict):
             website via the bot's `http_session`.
     """
 
-    # To ensure we only cycle once per day, we increase the reference midnight point
-    # by one day each time the task runs instead of relying on "the most recent"
-    # midnight, since that may fail if the task is triggered early.
-    midnight = midnight = datetime.utcnow().replace(microsecond=0, second=0, minute=0, hour=0)
     while True:
-        midnight += timedelta(days=1)
-        seconds_to_sleep = (midnight - datetime.utcnow()).seconds
-        log.debug(f"update_names: seconds to sleep {seconds_to_sleep}")
+        # Since we truncate the compute timedelta to seconds, we add one second to ensure
+        # we go past midnight in the `seconds_to_sleep` set below.
+        today_at_midnight = datetime.utcnow().replace(microsecond=0, second=0, minute=0, hour=0)
+        next_midnight = today_at_midnight + timedelta(days=1)
+        seconds_to_sleep = (next_midnight - datetime.utcnow()).seconds + 1
         await asyncio.sleep(seconds_to_sleep)
 
         response = await bot.http_session.get(


### PR DESCRIPTION
This PR is meant to solve the bug in #351 ~~by sleeping until 1 minute after midnight instead of aiming for midnight itself. I've outlined the rationale for this in the linked issue. I'm not entirely sure if this is actually the problem, but given the evidence/audit log times we have, this may very well be the cause.~~

Since the effect of this bug is something that Discord will probably call "API abuse" (rapid API calls not triggered by user action), we should probably try to merge this soon.

**Edit: I've found the root cause of the issue**

The problem is that in this step:

```py
seconds_to_sleep = (next_midnight - datetime.utcnow()).seconds
```

We truncrate the time delta needed to reach midnight down to the seconds, which means we "wake up" slightly before midnight (`< 1 second`). This is demonstrated here:

code:
```py
from datetime import datetime, timedelta

mn = datetime.utcnow().replace(microsecond=0, second=0, minute=0, hour=0)
mn2 = mn + timedelta(days=1)
delta_seconds = (mn2 - datetime.utcnow()).seconds
delta_full = mn2 - datetime.utcnow()

print(delta_full)
print(delta_seconds)
print(delta_full - timedelta(seconds=delta_seconds))

print(datetime.utcnow() + timedelta(seconds=delta_seconds))
```

output:
```
16:50:59.998919              # Full time needed to reach midnight
60659                        # Truncated down to seconds
0:00:00.998919               # The part we're missing by truncating the delta
2019-04-15 23:59:59.001132   # When we'll wake up
```

To fix this, I'm now simply adding one second to the computed sleep time so we always go over midnight:

```py
seconds_to_sleep = (next_midnight - datetime.utcnow()).seconds + 1
```

This now closes #351, as the bug was found and fixed.