### PR TITLE
Preventing multiple OffTopicNames background tasks from spawning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,9 @@ jobs:
     PIP_SRC: ".cache/src"
 
   steps:
+  - script: sudo apt-get update
+    displayName: 'Updating package list'
+
   - script: sudo apt-get install build-essential curl docker libffi-dev libfreetype6-dev libxml2 libxml2-dev libxslt1-dev zlib1g zlib1g-dev
     displayName: 'Install base dependencies'
 

--- a/bot/cogs/off_topic_names.py
+++ b/bot/cogs/off_topic_names.py
@@ -86,7 +86,7 @@ class OffTopicNames:
     async def on_ready(self):
         if self.updater_task is None:
             coro = update_names(self.bot, self.headers)
-            self.updater_task = await self.bot.loop.create_task(coro)
+            self.updater_task = self.bot.loop.create_task(coro)
 
     @group(name='otname', aliases=('otnames', 'otn'), invoke_without_command=True)
     @with_role(*MODERATION_ROLES)


### PR DESCRIPTION
Unfortunately, the previous fix didn't prevent the bot from changing the ot names multiple times. The reason was that multiple background tasks were created.

The reason for this is that `asyncio.create_task` doesn't have to be awaited, since it's not a coroutine, but we were doing just that. Since `create_task` returns the Task is creates, this means that we will wait until the task is finished (which is never), before assigning it to `self.updater_task` here:

```py
    async def on_ready(self):
        if self.updater_task is None:
            coro = update_names(self.bot, self.headers)
            self.updater_task = await self.bot.loop.create_task(coro)    # <- This await will never finish
```

This was confirmed by debug `log.trace` messages I used (and removed, because it clutters the code):

```py
    async def on_ready(self):
        log.trace("OffTopicNames: Entering `on_ready`")
        if self.updater_task is None:
            log.trace("OffTopicNames: Started creating background task")
            coro = update_names(self.bot, self.headers)
            self.updater_task = await self.bot.loop.create_task(coro)    # <- This await will never finish
            log.trace("OffTopicNames: Finished creating background task")
```
would only ever output:
```
Apr 18 17:44:19 pd.beardfist.com Bot: |       bot.cogs.off_topic_names |    TRACE | OffTopicNames: Entering `on_ready`
Apr 18 17:44:19 pd.beardfist.com Bot: |       bot.cogs.off_topic_names |    TRACE | OffTopicNames: Started creating background task
```
but never the "Finished" trace message. Using a temporary command, I was also able to confirm that `self.updater_task` was never set to anything but `None`. 

The effect of this all was that whenever the bot recovered a connection, the `on_ready` would be triggered again, initiating another background task to change the channel names.

The solution was simple: I've removed the `await`. Now, the final trace message is actually logged and `self.updater_task` is assigned to the Task.