### PR TITLE
Update pre-commit config so it actually uses the flake8 plugins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,12 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.2.3
     hooks:
     - id: flake8
+      additional_dependencies: [
+        "flake8-bugbear",
+        "flake8-import-order",
+        "flake8-tidy-imports",
+        "flake8-todo",
+        "flake8-string-format"
+      ]


### PR DESCRIPTION
Since pre-commit creates its own environment for linting, additional flake8 plugins need to be explicitly specified in order to be used.