### PR TITLE
Add Discord Hack Week server to Whitelist

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -165,6 +165,7 @@ filter:
         - 249111029668249601  # Gentoo
         - 327254708534116352  # Adafruit
         - 544525886180032552  # kennethreitz.org
+        - 590806733924859943  # Discord Hack Week
 
     domain_blacklist:
         - pornhub.com


### PR DESCRIPTION
> From June 24th to 28th, we’ll be hurling magic into the world from our minds and fingertips for Discord Hack Week. So, grab the nearest toolset you can find, because we want you to participate!

The actual event description is super long, so read it here! https://blog.discordapp.com/discord-community-hack-week-build-and-create-alongside-us-6b2a7b7bba33
