### PR TITLE
Change pep command to use `.txt` by default

### DIFF
--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -38,7 +38,7 @@ class Utils:
         else:
             return await ctx.invoke(self.bot.get_command("help"), "pep")
 
-        possible_extensions = ['.rst', '.txt']
+        possible_extensions = ['.txt', '.rst']
         found_pep = False
         for extension in possible_extensions:
             # Attempt to fetch the PEP

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -38,54 +38,56 @@ class Utils:
         else:
             return await ctx.invoke(self.bot.get_command("help"), "pep")
 
-        # Newer PEPs are written in RST instead of txt
-        if pep_number > 542:
-            pep_url = f"{self.base_github_pep_url}{pep_number:04}.rst"
-        else:
-            pep_url = f"{self.base_github_pep_url}{pep_number:04}.txt"
+        possible_extensions = ['.rst', '.txt']
+        found_pep = False
+        for extension in possible_extensions:
+            # Attempt to fetch the PEP
+            pep_url = f"{self.base_github_pep_url}{pep_number:04}{extension}"
+            log.trace(f"Requesting PEP {pep_number} with {pep_url}")
+            response = await self.bot.http_session.get(pep_url)
 
-        # Attempt to fetch the PEP
-        log.trace(f"Requesting PEP {pep_number} with {pep_url}")
-        response = await self.bot.http_session.get(pep_url)
+            if response.status == 200:
+                log.trace("PEP found")
+                found_pep = True
 
-        if response.status == 200:
-            log.trace("PEP found")
+                pep_content = await response.text()
 
-            pep_content = await response.text()
+                # Taken from https://github.com/python/peps/blob/master/pep0/pep.py#L179
+                pep_header = HeaderParser().parse(StringIO(pep_content))
 
-            # Taken from https://github.com/python/peps/blob/master/pep0/pep.py#L179
-            pep_header = HeaderParser().parse(StringIO(pep_content))
+                # Assemble the embed
+                pep_embed = Embed(
+                    title=f"**PEP {pep_number} - {pep_header['Title']}**",
+                    description=f"[Link]({self.base_pep_url}{pep_number:04})",
+                )
 
-            # Assemble the embed
-            pep_embed = Embed(
-                title=f"**PEP {pep_number} - {pep_header['Title']}**",
-                description=f"[Link]({self.base_pep_url}{pep_number:04})",
-            )
+                pep_embed.set_thumbnail(url="https://www.python.org/static/opengraph-icon-200x200.png")
 
-            pep_embed.set_thumbnail(url="https://www.python.org/static/opengraph-icon-200x200.png")
+                # Add the interesting information
+                if "Status" in pep_header:
+                    pep_embed.add_field(name="Status", value=pep_header["Status"])
+                if "Python-Version" in pep_header:
+                    pep_embed.add_field(name="Python-Version", value=pep_header["Python-Version"])
+                if "Created" in pep_header:
+                    pep_embed.add_field(name="Created", value=pep_header["Created"])
+                if "Type" in pep_header:
+                    pep_embed.add_field(name="Type", value=pep_header["Type"])
 
-            # Add the interesting information
-            if "Status" in pep_header:
-                pep_embed.add_field(name="Status", value=pep_header["Status"])
-            if "Python-Version" in pep_header:
-                pep_embed.add_field(name="Python-Version", value=pep_header["Python-Version"])
-            if "Created" in pep_header:
-                pep_embed.add_field(name="Created", value=pep_header["Created"])
-            if "Type" in pep_header:
-                pep_embed.add_field(name="Type", value=pep_header["Type"])
+            elif response.status != 404:
+                # any response except 200 and 404 is expected
+                found_pep = True  # actually not, but it's easier to display this way
+                log.trace(f"The user requested PEP {pep_number}, but the response had an unexpected status code: "
+                          f"{response.status}.\n{response.text}")
 
-        elif response.status == 404:
+                error_message = "Unexpected HTTP error during PEP search. Please let us know."
+                pep_embed = Embed(title="Unexpected error", description=error_message)
+                pep_embed.colour = Colour.red()
+                break
+
+        if not found_pep:
             log.trace("PEP was not found")
             not_found = f"PEP {pep_number} does not exist."
             pep_embed = Embed(title="PEP not found", description=not_found)
-            pep_embed.colour = Colour.red()
-
-        else:
-            log.trace(f"The user requested PEP {pep_number}, but the response had an unexpected status code: "
-                      f"{response.status}.\n{response.text}")
-
-            error_message = "Unexpected HTTP error during PEP search. Please let us know."
-            pep_embed = Embed(title="Unexpected error", description=error_message)
             pep_embed.colour = Colour.red()
 
         await ctx.message.channel.send(embed=pep_embed)


### PR DESCRIPTION
The pep command would assume either .txt or .rst, which was not always correct. It now always tries both, and should still error the same way when the pip was not found. This is the 2nd time this pull request has been opened because the write history of the previous one had been destroyed.

Closes: #367 