### PR TITLE
Add tests for `bot.rules.attachments`.

### DIFF
--- a/bot/rules/attachments.py
+++ b/bot/rules/attachments.py
@@ -11,14 +11,14 @@ async def apply(
     config: Dict[str, int]
 ) -> Optional[Tuple[str, Iterable[Member], Iterable[Message]]]:
 
-    relevant_messages = tuple(
+    relevant_messages = [last_message] + [
         msg
         for msg in recent_messages
         if (
             msg.author == last_message.author
             and len(msg.attachments) > 0
         )
-    )
+    ]
     total_recent_attachments = sum(len(msg.attachments) for msg in relevant_messages)
 
     if total_recent_attachments > config['max']:

--- a/tests/rules/test_attachments.py
+++ b/tests/rules/test_attachments.py
@@ -1,0 +1,52 @@
+import asyncio
+from dataclasses import dataclass
+from typing import Any, List
+
+import pytest
+
+from bot.rules import attachments
+
+
+# Using `MagicMock` sadly doesn't work for this usecase
+# since it's __eq__ compares the MagicMock's ID. We just
+# want to compare the actual attributes we set.
+@dataclass
+class FakeMessage:
+    author: str
+    attachments: List[Any]
+
+
+def msg(total_attachments: int):
+    return FakeMessage(author='lemon', attachments=list(range(total_attachments)))
+
+
+@pytest.mark.parametrize(
+    'messages',
+    (
+        (msg(0), msg(0), msg(0)),
+        (msg(2), msg(2)),
+        (msg(0),),
+    )
+)
+def test_allows_messages_without_too_many_attachments(messages):
+    last_message, *recent_messages = messages
+    coro = attachments.apply(last_message, recent_messages, {'max': 5})
+    assert asyncio.run(coro) is None
+
+
+@pytest.mark.parametrize(
+    ('messages', 'relevant_messages', 'total'),
+    (
+        ((msg(4), msg(0), msg(6)), [msg(4), msg(6)], 10),
+        ((msg(6),), [msg(6)], 6),
+        ((msg(1),) * 6, [msg(1)] * 6, 6),
+    )
+)
+def test_disallows_messages_with_too_many_attachments(messages, relevant_messages, total):
+    last_message, *recent_messages = messages
+    coro = attachments.apply(last_message, recent_messages, {'max': 5})
+    assert asyncio.run(coro) == (
+        f"sent {total} attachments in 5s",
+        ('lemon',),
+        relevant_messages
+    )


### PR DESCRIPTION
This also fixes an issue with the `attachments` rule not respecting the most recent message sent by a user.