### PR TITLE
Enhance off-topic names search feature

### DIFF
--- a/bot/cogs/off_topic_names.py
+++ b/bot/cogs/off_topic_names.py
@@ -144,20 +144,21 @@ class OffTopicNames(Cog):
 
     @otname_group.command(name='search', aliases=('s',))
     @with_role(*MODERATION_ROLES)
-    async def search_command(self, ctx, *, query: str):
+    async def search_command(self, ctx, *, query: OffTopicName):
         """
         Search for an off-topic name.
         """
 
         result = await self.bot.api_client.get('bot/off-topic-channel-names')
-        matches = difflib.get_close_matches(query, result, n=10, cutoff=0.35)
-        lines = sorted(f"• {name}" for name in matches)
+        in_matches = {name for name in result if query in name}
+        close_matches = difflib.get_close_matches(query, result, n=10, cutoff=0.70)
+        lines = sorted(f"• {name}" for name in in_matches.union(close_matches))
         embed = Embed(
             title=f"Query results",
             colour=Colour.blue()
         )
 
-        if matches:
+        if lines:
             await LinePaginator.paginate(lines, ctx, embed, max_size=400, empty=False)
         else:
             embed.description = "Nothing found."


### PR DESCRIPTION
There's a more colorful description, with examples, in the issue: #435. The examples there were generated using this code.

**Taken from commit cfb6b63:**
This commit is meant to enhance the search feature in three separate, but related ways:

1. By changing the type annotation of the query to OffTopicName, we will use the same character translation table for the query as we did when storing the off-topic name, leading to better matches.

2. By adding a membership test, `query in name`, we are better able to search for off-topic names using a substring.

3. Given point 1 and point 2, we can increase the cut-off value we use for `difflib.get_close_matches` so we reduce the number of matches that bear little resemblance to the query in our human eyes.

This PR closes #435