### PR TITLE
Infraction Search Dates

### DIFF
--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -1260,11 +1260,11 @@ class Moderation(Scheduler, Cog):
         active = infraction_object["active"]
         user_id = infraction_object["user"]
         hidden = infraction_object["hidden"]
-        created = datetime.fromisoformat(infraction_object["inserted_at"].strftime("%Y-%m-%d %H:%M"))
+        created = datetime.fromisoformat(infraction_object["inserted_at"]).strftime("%Y-%m-%d %H:%M")
         if infraction_object["expires_at"] is None:
             expires = "*Permanent*"
         else:
-            expires = datetime.fromisoformat(infraction_object["expires_at"].strftime("%Y-%m-%d %H:%M"))
+            expires = datetime.fromisoformat(infraction_object["expires_at"]).strftime("%Y-%m-%d %H:%M")
 
         lines = textwrap.dedent(f"""
             {"**===============**" if active else "==============="}

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -1261,7 +1261,7 @@ class Moderation(Scheduler, Cog):
         user_id = infraction_object["user"]
         hidden = infraction_object["hidden"]
         created = datetime.fromisoformat(infraction_object["inserted_at"].strftime("%Y-%m-%d %H:%M"))
-        if not infraction_object["expires_at"]:
+        if infraction_object["expires_at"] is None:
             expires = "*Permanent*"
         else:
             expires = datetime.fromisoformat(infraction_object["expires_at"].strftime("%Y-%m-%d %H:%M"))

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -1260,6 +1260,11 @@ class Moderation(Scheduler, Cog):
         active = infraction_object["active"]
         user_id = infraction_object["user"]
         hidden = infraction_object["hidden"]
+        created = datetime.fromisoformat(infraction_object["inserted_at"].strftime("%c"))
+        if not infraction_object["expires_at"]:
+            expires = "*Permanent*"
+        else:
+            expires = datetime.fromisoformat(infraction_object["expires_at"].strftime("%c"))
 
         lines = textwrap.dedent(f"""
             {"**===============**" if active else "==============="}
@@ -1268,8 +1273,8 @@ class Moderation(Scheduler, Cog):
             Type: **{infraction_object["type"]}**
             Shadow: {hidden}
             Reason: {infraction_object["reason"] or "*None*"}
-            Created: {infraction_object["inserted_at"]}
-            Expires: {infraction_object["expires_at"] or "*Permanent*"}
+            Created: {created}
+            Expires: {expires}
             Actor: {actor.mention if actor else actor_id}
             ID: `{infraction_object["id"]}`
             {"**===============**" if active else "==============="}

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -1260,11 +1260,11 @@ class Moderation(Scheduler, Cog):
         active = infraction_object["active"]
         user_id = infraction_object["user"]
         hidden = infraction_object["hidden"]
-        created = datetime.fromisoformat(infraction_object["inserted_at"].strftime("%c"))
+        created = datetime.fromisoformat(infraction_object["inserted_at"].strftime("%Y-%m-%d %H:%M"))
         if not infraction_object["expires_at"]:
             expires = "*Permanent*"
         else:
-            expires = datetime.fromisoformat(infraction_object["expires_at"].strftime("%c"))
+            expires = datetime.fromisoformat(infraction_object["expires_at"].strftime("%Y-%m-%d %H:%M"))
 
         lines = textwrap.dedent(f"""
             {"**===============**" if active else "==============="}


### PR DESCRIPTION
Since the rework was launched, the current format for the Created and Expires dates on the infraction search embeds use the standard ISO format, which is a bit of a bear to read.

This PR proposes changing that format to `"%Y-%m-%d %H:%M"` which will appear as `2019-09-18 13:59`