### PR TITLE
Note Type Correction

### DIFF
--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -430,7 +430,7 @@ class Moderation(Scheduler, Cog):
 
         This does not send the user a notification
         """
-        infraction = await post_infraction(ctx, user, type="warning", reason=reason, hidden=True)
+        infraction = await post_infraction(ctx, user, type="note", reason=reason, hidden=True)
         if infraction is None:
             return
 


### PR DESCRIPTION
- In the database, notes were being listed as "warnings" despite having a type specifically for them.  Changed it so that notes are now listed as the proper type.

Signed-off-by: Daniel Brown <browndj3@gmail.com>