### PR TITLE
Merge infraction edit commands

### DIFF
--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -1282,8 +1282,8 @@ class Moderation(Scheduler, Cog):
 
     # endregion
 
-    @staticmethod
-    async def cog_command_error(ctx: Context, error: Exception) -> None:
+    # This cannot be static (must have a __func__ attribute).
+    async def cog_command_error(self, ctx: Context, error: Exception) -> None:
         """Send a notification to the invoking context on a Union failure."""
         if isinstance(error, BadUnionArgument):
             if User in error.converters:

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -19,7 +19,7 @@ from bot.decorators import with_role
 from bot.pagination import LinePaginator
 from bot.utils.moderation import already_has_active_infraction, post_infraction
 from bot.utils.scheduling import Scheduler, create_task
-from bot.utils.time import wait_until
+from bot.utils.time import INFRACTION_FORMAT, format_infraction, wait_until
 
 log = logging.getLogger(__name__)
 
@@ -313,11 +313,7 @@ class Moderation(Scheduler, Cog):
             reason=reason
         )
 
-        infraction_expiration = (
-            datetime
-            .fromisoformat(infraction["expires_at"][:-1])
-            .strftime('%c')
-        )
+        infraction_expiration = format_infraction(infraction["expires_at"])
 
         self.schedule_task(ctx.bot.loop, infraction["id"], infraction)
 
@@ -390,11 +386,7 @@ class Moderation(Scheduler, Cog):
         except Forbidden:
             action_result = False
 
-        infraction_expiration = (
-            datetime
-            .fromisoformat(infraction["expires_at"][:-1])
-            .strftime('%c')
-        )
+        infraction_expiration = format_infraction(infraction["expires_at"])
 
         self.schedule_task(ctx.bot.loop, infraction["id"], infraction)
 
@@ -630,11 +622,7 @@ class Moderation(Scheduler, Cog):
         self.mod_log.ignore(Event.member_update, user.id)
         await user.add_roles(self._muted_role, reason=reason)
 
-        infraction_expiration = (
-            datetime
-            .fromisoformat(infraction["expires_at"][:-1])
-            .strftime('%c')
-        )
+        infraction_expiration = format_infraction(infraction["expires_at"])
 
         self.schedule_task(ctx.bot.loop, infraction["id"], infraction)
 
@@ -694,11 +682,7 @@ class Moderation(Scheduler, Cog):
         except Forbidden:
             action_result = False
 
-        infraction_expiration = (
-            datetime
-            .fromisoformat(infraction["expires_at"][:-1])
-            .strftime('%c')
-        )
+        infraction_expiration = format_infraction(infraction["expires_at"])
 
         self.schedule_task(ctx.bot.loop, infraction["id"], infraction)
 
@@ -915,7 +899,7 @@ class Moderation(Scheduler, Cog):
             confirm_messages.append("marked as permanent")
         elif expires_at is not None:
             request_data['expires_at'] = expires_at.isoformat()
-            confirm_messages.append(f"set to expire on {expires_at.strftime('%c')}")
+            confirm_messages.append(f"set to expire on {expires_at.strftime(INFRACTION_FORMAT)}")
         else:
             confirm_messages.append("expiry unchanged")
 
@@ -1129,11 +1113,11 @@ class Moderation(Scheduler, Cog):
         active = infraction_object["active"]
         user_id = infraction_object["user"]
         hidden = infraction_object["hidden"]
-        created = datetime.fromisoformat(infraction_object["inserted_at"][:-1]).strftime("%Y-%m-%d %H:%M")
+        created = format_infraction(infraction_object["inserted_at"])
         if infraction_object["expires_at"] is None:
             expires = "*Permanent*"
         else:
-            expires = datetime.fromisoformat(infraction_object["expires_at"][:-1]).strftime("%Y-%m-%d %H:%M")
+            expires = format_infraction(infraction_object["expires_at"])
 
         lines = textwrap.dedent(f"""
             {"**===============**" if active else "==============="}
@@ -1164,7 +1148,7 @@ class Moderation(Scheduler, Cog):
         Returns a boolean indicator of whether the DM was successful.
         """
         if isinstance(expires_at, datetime):
-            expires_at = expires_at.strftime('%c')
+            expires_at = expires_at.strftime(INFRACTION_FORMAT)
 
         embed = Embed(
             description=textwrap.dedent(f"""

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -916,6 +916,8 @@ class Moderation(Scheduler, Cog):
         elif expires_at is not None:
             request_data['expires_at'] = expires_at.isoformat()
             confirm_messages.append(f"set to expire on {expires_at.strftime('%c')}")
+        else:
+            confirm_messages.append("expiry unchanged")
 
         if reason:
             request_data['reason'] = reason
@@ -924,6 +926,8 @@ class Moderation(Scheduler, Cog):
                 Previous reason: {old_infraction['reason']}
                 New reason: {reason}
             """.rstrip()
+        else:
+            confirm_messages.append("reason unchanged")
 
         # Update the infraction
         new_infraction = await self.bot.api_client.patch(

--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -938,8 +938,8 @@ class Moderation(Scheduler, Cog):
             self.schedule_task(loop, new_infraction['id'], new_infraction)
 
             log_text += f"""
-                Previous expiry: {old_infraction['expires_at']}
-                New expiry: {new_infraction['expires_at']}
+                Previous expiry: {old_infraction['expires_at'] or "Permanent"}
+                New expiry: {new_infraction['expires_at'] or "Permanent"}
             """.rstrip()
 
         await ctx.send(f":ok_hand: Updated infraction: {' & '.join(confirm_messages)}")

--- a/bot/cogs/superstarify/__init__.py
+++ b/bot/cogs/superstarify/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import random
-from datetime import datetime
 
 from discord import Colour, Embed, Member
 from discord.errors import Forbidden
@@ -13,6 +12,7 @@ from bot.constants import Icons, MODERATION_ROLES, POSITIVE_REPLIES
 from bot.converters import Duration
 from bot.decorators import with_role
 from bot.utils.moderation import post_infraction
+from bot.utils.time import format_infraction
 
 log = logging.getLogger(__name__)
 NICKNAME_POLICY_URL = "https://pythondiscord.com/pages/rules/#wiki-toc-nickname-policy"
@@ -71,10 +71,7 @@ class Superstarify(Cog):
                 f"Changing the nick back to {before.display_name}."
             )
             await after.edit(nick=forced_nick)
-            end_timestamp_human = (
-                datetime.fromisoformat(infraction['expires_at'][:-1])
-                .strftime('%c')
-            )
+            end_timestamp_human = format_infraction(infraction['expires_at'])
 
             try:
                 await after.send(
@@ -113,9 +110,7 @@ class Superstarify(Cog):
             [infraction] = active_superstarifies
             forced_nick = get_nick(infraction['id'], member.id)
             await member.edit(nick=forced_nick)
-            end_timestamp_human = (
-                datetime.fromisoformat(infraction['expires_at'][:-1]).strftime('%c')
-            )
+            end_timestamp_human = format_infraction(infraction['expires_at'])
 
             try:
                 await member.send(

--- a/bot/cogs/verification.py
+++ b/bot/cogs/verification.py
@@ -141,8 +141,8 @@ class Verification(Cog):
             f"{ctx.author.mention} Unsubscribed from <#{Channels.announcements}> notifications."
         )
 
-    @staticmethod
-    async def cog_command_error(ctx: Context, error: Exception) -> None:
+    # This cannot be static (must have a __func__ attribute).
+    async def cog_command_error(self, ctx: Context, error: Exception) -> None:
         """Check for & ignore any InChannelCheckFailure."""
         if isinstance(error, InChannelCheckFailure):
             error.handled = True

--- a/bot/cogs/watchchannels/talentpool.py
+++ b/bot/cogs/watchchannels/talentpool.py
@@ -10,6 +10,7 @@ from bot.api import ResponseCodeError
 from bot.constants import Channels, Guild, Roles, Webhooks
 from bot.decorators import with_role
 from bot.pagination import LinePaginator
+from bot.utils import time
 from .watchchannel import WatchChannel, proxy_user
 
 log = logging.getLogger(__name__)
@@ -198,7 +199,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
         log.debug(active)
         log.debug(type(nomination_object["inserted_at"]))
 
-        start_date = self._get_human_readable(nomination_object["inserted_at"])
+        start_date = time.format_infraction(nomination_object["inserted_at"])
         if active:
             lines = textwrap.dedent(
                 f"""
@@ -212,7 +213,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
                 """
             )
         else:
-            end_date = self._get_human_readable(nomination_object["ended_at"])
+            end_date = time.format_infraction(nomination_object["ended_at"])
             lines = textwrap.dedent(
                 f"""
                 ===============

--- a/bot/cogs/watchchannels/watchchannel.py
+++ b/bot/cogs/watchchannels/watchchannel.py
@@ -329,14 +329,6 @@ class WatchChannel(metaclass=CogABCMeta):
 
         return time_delta
 
-    @staticmethod
-    def _get_human_readable(time_string: str, output_format: str = "%Y-%m-%d %H:%M:%S") -> str:
-        date_time = datetime.datetime.strptime(
-            time_string,
-            "%Y-%m-%dT%H:%M:%S.%fZ"
-        ).replace(tzinfo=None)
-        return date_time.strftime(output_format)
-
     def _remove_user(self, user_id: int) -> None:
         """Removes a user from a watch channel."""
         self.watched_users.pop(user_id, None)

--- a/bot/cogs/watchchannels/watchchannel.py
+++ b/bot/cogs/watchchannels/watchchannel.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import logging
 import re
 import textwrap
@@ -8,6 +7,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass
 from typing import Optional
 
+import dateutil.parser
 import discord
 from discord import Color, Embed, HTTPException, Message, Object, errors
 from discord.ext.commands import BadArgument, Bot, Cog, Context
@@ -321,10 +321,7 @@ class WatchChannel(metaclass=CogABCMeta):
     @staticmethod
     def _get_time_delta(time_string: str) -> str:
         """Returns the time in human-readable time delta format."""
-        date_time = datetime.datetime.strptime(
-            time_string,
-            "%Y-%m-%dT%H:%M:%S.%fZ"
-        ).replace(tzinfo=None)
+        date_time = dateutil.parser.isoparse(time_string).replace(tzinfo=None)
         time_delta = time_since(date_time, precision="minutes", max_units=1)
 
         return time_delta

--- a/bot/utils/time.py
+++ b/bot/utils/time.py
@@ -4,6 +4,7 @@ import datetime
 from dateutil.relativedelta import relativedelta
 
 RFC1123_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"
+INFRACTION_FORMAT = "%Y-%m-%d %H:%M"
 
 
 def _stringify_time_unit(value: int, unit: str) -> str:
@@ -95,3 +96,8 @@ async def wait_until(time: datetime.datetime) -> None:
     # Incorporate a small delay so we don't rapid-fire the event due to time precision errors
     if delay_seconds > 1.0:
         await asyncio.sleep(delay_seconds)
+
+
+def format_infraction(timestamp: str) -> str:
+    """Format an infraction timestamp to a more readable ISO 8601 format."""
+    return datetime.datetime.fromisoformat(timestamp[:-1]).strftime(INFRACTION_FORMAT)

--- a/bot/utils/time.py
+++ b/bot/utils/time.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 
+import dateutil.parser
 from dateutil.relativedelta import relativedelta
 
 RFC1123_FORMAT = "%a, %d %b %Y %H:%M:%S GMT"
@@ -100,4 +101,4 @@ async def wait_until(time: datetime.datetime) -> None:
 
 def format_infraction(timestamp: str) -> str:
     """Format an infraction timestamp to a more readable ISO 8601 format."""
-    return datetime.datetime.fromisoformat(timestamp[:-1]).strftime(INFRACTION_FORMAT)
+    return dateutil.parser.isoparse(timestamp).strftime(INFRACTION_FORMAT)


### PR DESCRIPTION
Closes #349.

Also made the format of infraction timestamps consistent.

Some things to note:

* If the duration converter fails, the argument will instead be considered part of a reason. Therefore a typo like `!infraction edit 1337 50` (missing a unit for the duration) will make the reason `50` and expiration unchanged.
* The new reason is no longer displayed in the confirmation message. This is similar to #325.
* The two old commands are gone. Only `infraction edit` can be used.
* Expiration for all infractions can _still_ be edited, even ones for which it doesn't make sense (i.e. notes and warnings, which are meant to always be permanent).
* Editing the expiration for an expired infraction _still_ wont re-apply the infraction (it will reschedule it but the actual moderation action (mute or ban) will not reoccur).