### PR TITLE
Fix help command invocation

### DIFF
--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -110,9 +110,9 @@ class HelpSession:
         cog = self._bot.cogs.get(query)
         if cog:
             return Cog(
-                name=cog.cog_name,
+                name=cog.qualified_name,
                 description=inspect.getdoc(cog),
-                commands=[c for c in self._bot.commands if c.cog_name == cog.cog_name]
+                commands=[c for c in self._bot.commands if c.cog is cog]
             )
 
         self._handle_not_found(query)

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -110,9 +110,9 @@ class HelpSession:
         cog = self._bot.cogs.get(query)
         if cog:
             return Cog(
-                name=cog.__class__.__name__,
+                name=cog.cog_name,
                 description=inspect.getdoc(cog),
-                commands=[c for c in self._bot.commands if c.instance is cog]
+                commands=[c for c in self._bot.commands if c.cog_name == cog.cog_name]
             )
 
         self._handle_not_found(query)

--- a/bot/cogs/watchchannels/watchchannel.py
+++ b/bot/cogs/watchchannels/watchchannel.py
@@ -148,8 +148,8 @@ class WatchChannel(metaclass=CogABCMeta):
                 title=f"Warning: Failed to retrieve user cache for the {self.__class__.__name__} watch channel",
                 text="Could not retrieve the list of watched users from the API and messages will not be relayed.",
                 ping_everyone=True,
-                icon=Icons.token_removed,
-                color=Color.red()
+                icon_url=Icons.token_removed,
+                colour=Color.red()
             )
 
     async def fetch_user_cache(self) -> bool:


### PR DESCRIPTION
Per #456, the `!help` raises an `AttributeError` when fetching information for Cogs due to referencing of an attribute that is no longer present in d.py. The no longer present `instance` attribute has been replaced with `cog_name` .

This also kaizens in a fix for some incorrect kwargs in one of the watchchannel cog's mod log invocations.

Closes #456 