### PR TITLE
Ensure docker containers are published only for master branch builds.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
   - job: build
     displayName: 'Build & Push Container'
     dependsOn: 'test'
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 
     steps:
       - task: Docker@2


### PR DESCRIPTION
Closes #459 

If an Azure Pipeline was started manually, it would no longer have `PullRequest` as the build reason, allowing the build and push job conditions to pass even if on a different branch than master. 

This addition ensures the source branch is master for any situation that the CI runs.