### PR TITLE
Adjust development workflow inline with new `site` changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,31 @@
 
 This project is a Discord bot specifically for use with the Python Discord server. It provides numerous utilities
 and other tools to help keep the server running like a well-oiled machine.
+
+## Requirements
+
+- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [Docker](https://docs.docker.com/install/)
+- [Docker-Compose](https://docs.docker.com/compose/install/)
+  - `pip install docker-compose`
+- [Pipenv](https://pipenv.kennethreitz.org/en/latest/install/#installing-pipenv)
+  - `pip install pipenv`
+
+## Setup Reference (temporary)
+
+1. Read the [Contributing](CONTRIBUTING.md) guidelines.
+2. Clone the repository to a suitable working project directory using [`git clone`](https://git-scm.com/docs/git-clone).
+   - If you are not a core developer, you will need to [`fork`](https://help.github.com/en/articles/fork-a-repo) [pythondiscord/bot](https://github.com/python-discord/bot).
+3. Create a copy of `config-default.yml` named `config.yml` and edit the configuration options.
+   - This is to be replaced with different instructions in future due to upcoming config updates.
+4. Create an empty `.env` in the same top-level project directory and add:
+   - `BOT_TOKEN=yourdiscordbottoken`
+   - If you have a development site setup already, get the docker project name and add in `.env`:
+     - `COMPOSE_PROJECT_NAME=site`, adjusting `site` to match the other project name.
+5. Install development dependancies for your IDE/editor/linting:
+   - `pipenv sync --dev`
+5. Run the compose:
+   - If you're running a full development site setup already, run:
+     - `docker-compose up bot`
+   - Otherwise, run:
+     - `docker-compose up`

--- a/README.md
+++ b/README.md
@@ -10,30 +10,4 @@
 This project is a Discord bot specifically for use with the Python Discord server. It provides numerous utilities
 and other tools to help keep the server running like a well-oiled machine.
 
-## Requirements
-
-- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-- [Docker](https://docs.docker.com/install/)
-- [Docker-Compose](https://docs.docker.com/compose/install/)
-  - `pip install docker-compose`
-- [Pipenv](https://pipenv.kennethreitz.org/en/latest/install/#installing-pipenv)
-  - `pip install pipenv`
-
-## Setup Reference (temporary)
-
-1. Read the [Contributing](CONTRIBUTING.md) guidelines.
-2. Clone the repository to a suitable working project directory using [`git clone`](https://git-scm.com/docs/git-clone).
-   - If you are not a core developer, you will need to [`fork`](https://help.github.com/en/articles/fork-a-repo) [pythondiscord/bot](https://github.com/python-discord/bot).
-3. Create a copy of `config-default.yml` named `config.yml` and edit the configuration options.
-   - This is to be replaced with different instructions in future due to upcoming config updates.
-4. Create an empty `.env` in the same top-level project directory and add:
-   - `BOT_TOKEN=yourdiscordbottoken`
-   - If you have a development site setup already, get the docker project name and add in `.env`:
-     - `COMPOSE_PROJECT_NAME=site`, adjusting `site` to match the other project name.
-5. Install development dependancies for your IDE/editor/linting:
-   - `pipenv sync --dev`
-5. Run the compose:
-   - If you're running a full development site setup already, run:
-     - `docker-compose up bot`
-   - Otherwise, run:
-     - `docker-compose up`
+Read the [Contributing Guide](https://pythondiscord.com/pages/contributing/bot/) on our website if you're interested in helping out.

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 from logging import Logger, StreamHandler, handlers
+from pathlib import Path
 
 from logmatic import JsonFormatter
 
@@ -30,21 +31,19 @@ logging_handlers = []
 # We can't import this yet, so we have to define it ourselves
 DEBUG_MODE = True if 'local' in os.environ.get("SITE_URL", "local") else False
 
+LOG_DIR = Path("logs")
+LOG_DIR.mkdir(exist_ok=True)
 
 if DEBUG_MODE:
     logging_handlers.append(StreamHandler(stream=sys.stdout))
 
-    json_handler = logging.FileHandler(filename="log.json", mode="w")
+    json_handler = logging.FileHandler(filename=Path(LOG_DIR, "log.json"), mode="w")
     json_handler.formatter = JsonFormatter()
     logging_handlers.append(json_handler)
 else:
 
-    logdir = "log"
-    logfile = logdir+os.sep+"bot.log"
+    logfile = Path(LOG_DIR, "bot.log")
     megabyte = 1048576
-
-    if not os.path.exists(logdir):
-        os.makedirs(logdir)
 
     filehandler = handlers.RotatingFileHandler(logfile, maxBytes=(megabyte*5), backupCount=7)
     logging_handlers.append(filehandler)
@@ -55,7 +54,7 @@ else:
 
 
 logging.basicConfig(
-    format="%(asctime)s pd.beardfist.com Bot: | %(name)33s | %(levelname)8s | %(message)s",
+    format="%(asctime)s Bot: | %(name)33s | %(levelname)8s | %(message)s",
     datefmt="%b %d %H:%M:%S",
     level=logging.TRACE if DEBUG_MODE else logging.INFO,
     handlers=logging_handlers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,24 +7,37 @@ version: "3.7"
 services:
   postgres:
     image: postgres:11-alpine
-    ports:
-      - "127.0.0.1:7777:5432"
     environment:
       POSTGRES_DB: pysite
       POSTGRES_PASSWORD: pysite
       POSTGRES_USER: pysite
 
   web:
-    image: pythondiscord/site:latest
-    command: >
-      bash -c "echo \"from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'admin', 'admin') if not User.objects.filter(username='admin').exists() else print('Admin user already exists')\" | python manage.py shell
-      && ./manage.py runserver 0.0.0.0:8000"
+    image: pythondiscord/site:dev
+    command: ["run", "--debug"]
+    networks:
+      default:
+        aliases:
+          - api.web
+          - admin.web
+          - staff.web
     ports:
       - "127.0.0.1:8000:8000"
     depends_on:
       - postgres
     environment:
       DATABASE_URL: postgres://pysite:pysite@postgres:5432/pysite
-      DEBUG: "true"
       SECRET_KEY: suitable-for-development-only
       STATIC_ROOT: /var/www/static
+
+  bot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./logs:/bot/logs
+      - .:/bot:ro
+    environment:
+      BOT_TOKEN: ${BOT_TOKEN}
+      BOT_API_KEY: badbot13m0n8f570f942013fc818f234916ca531
+      DATABASE_URL: postgres://pysite:pysite@postgres:5432/pysite

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       POSTGRES_USER: pysite
 
   web:
-    image: pythondiscord/site:dev
+    image: pythondiscord/site:latest
     command: ["run", "--debug"]
     networks:
       default:
@@ -37,7 +37,8 @@ services:
     volumes:
       - ./logs:/bot/logs
       - .:/bot:ro
+    depends_on:
+      - web
     environment:
       BOT_TOKEN: ${BOT_TOKEN}
       BOT_API_KEY: badbot13m0n8f570f942013fc818f234916ca531
-      DATABASE_URL: postgres://pysite:pysite@postgres:5432/pysite


### PR DESCRIPTION
Now that https://github.com/python-discord/site/pull/265 has been merged, the `bot` project can utilise the better entry point, remove a couple of redundant sections in the compose, and add the `bot` service to compose for local development.

`BOT_TOKEN` is pulled directly from the `.env` still, just the same as when launching via `pipenv` locally.

`BOT_API_KEY` uses the default key that `site` now generates automatically.

Setting up the hosts file is now entirely optional, as the API connection between the site and bot works via the inbuilt docker hostname resolution.

The temporary staging database does not need to expose any ports so that has been removed.

The link to the new guide has been added to the README.