### PR TITLE
Forward arguments to !docs get

### DIFF
--- a/bot/cogs/doc.py
+++ b/bot/cogs/doc.py
@@ -261,7 +261,7 @@ class Doc(commands.Cog):
     @commands.group(name='docs', aliases=('doc', 'd'), invoke_without_command=True)
     async def docs_group(self, ctx: commands.Context, symbol: commands.clean_content = None) -> None:
         """Lookup documentation for Python symbols."""
-        await ctx.invoke(self.get_command)
+        await self.get_command(ctx, symbol)
 
     @docs_group.command(name='get', aliases=('g',))
     async def get_command(self, ctx: commands.Context, symbol: commands.clean_content = None) -> None:

--- a/bot/cogs/doc.py
+++ b/bot/cogs/doc.py
@@ -261,7 +261,7 @@ class Doc(commands.Cog):
     @commands.group(name='docs', aliases=('doc', 'd'), invoke_without_command=True)
     async def docs_group(self, ctx: commands.Context, symbol: commands.clean_content = None) -> None:
         """Lookup documentation for Python symbols."""
-        await self.get_command(ctx, symbol)
+        await ctx.invoke(self.get_command, symbol)
 
     @docs_group.command(name='get', aliases=('g',))
     async def get_command(self, ctx: commands.Context, symbol: commands.clean_content = None) -> None:

--- a/bot/cogs/doc.py
+++ b/bot/cogs/doc.py
@@ -319,9 +319,9 @@ class Doc(commands.Cog):
 
         Example:
             !docs set \
-                    discord \
-                    https://discordpy.readthedocs.io/en/rewrite/ \
-                    https://discordpy.readthedocs.io/en/rewrite/objects.inv
+                    python \
+                    https://docs.python.org/3/ \
+                    https://docs.python.org/3/objects.inv
         """
         body = {
             'package': package_name,

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -49,7 +49,7 @@ class ValidURL(Converter):
             async with ctx.bot.http_session.get(url) as resp:
                 if resp.status != 200:
                     raise BadArgument(
-                        f"HTTP GET on `{url}` returned status `{resp.status_code}`, expected 200"
+                        f"HTTP GET on `{url}` returned status `{resp.status}`, expected 200"
                     )
         except CertificateError:
             if url.startswith('https'):


### PR DESCRIPTION
A minor usability that allows `!docs Python` in place of `!docs get Python`.

This seems to have been the intention of the old code, however `invoke` doesn't pass the arguments forward by default, so the UX was confusing.

AFAICT this could be written `ctx.invoke(self.get_command, symbol)`, however this would only serve to complicate and slow things down. Lmk if it provides some utility, and I'll change it