### PR TITLE
Add converter for ISO-formatted datetime strings

### DIFF
--- a/bot/converters.py
+++ b/bot/converters.py
@@ -219,7 +219,7 @@ class Duration(Converter):
 
 
 class ISODateTime(Converter):
-    """"Converts an ISO-8601 datetime string into a datetime.datetime."""
+    """Converts an ISO-8601 datetime string into a datetime.datetime."""
 
     async def convert(self, ctx: Context, datetime_string: str) -> datetime:
         """

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from ssl import CertificateError
 from typing import Union
 
+import dateutil.parser
 import discord
 from aiohttp import ClientConnectorError
 from dateutil.relativedelta import relativedelta
@@ -215,3 +216,35 @@ class Duration(Converter):
         now = datetime.utcnow()
 
         return now + delta
+
+
+class ISODateTime(Converter):
+    """"Converts an ISO-8601 datetime string into a datetime.datetime."""
+
+    async def convert(self, ctx: Context, datetime_string: str) -> datetime:
+        """
+        Converts a ISO-8601 `datetime_string` into a `datetime.datetime` object.
+
+        The converter is flexible in the formats it accepts, as it uses the `isoparse` method of
+        `dateutil.parser`. In general, it accepts datetime strings that start with a date,
+        optionally followed by a time.
+
+        See: <https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse>
+
+        Formats that are guaranteed to be valid by our tests are:
+
+        - `YYYY-mm-ddTHH:MM:SS` | `YYYY-mm-dd HH:MM:SS`
+        - `YYYY-mm-ddTHH:MM` | `YYYY-mm-dd HH:MM`
+        - `YYYY-mm-dd`
+        - `YYYY-mm`
+        - `YYYY`
+
+        Note: ISO-8601 specifies a `T` as the separator between the date and the time part of the
+        datetime string. The converter accepts both a `T` and a single space character.
+        """
+        try:
+            dt = dateutil.parser.isoparse(datetime_string)
+        except ValueError:
+            raise BadArgument(f"`{datetime_string}` is not a valid ISO-8601 datetime string")
+
+        return dt

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -229,7 +229,7 @@ class ISODateTime(Converter):
         `dateutil.parser`. In general, it accepts datetime strings that start with a date,
         optionally followed by a time.
 
-        See: <https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse>
+        See: https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse
 
         Formats that are guaranteed to be valid by our tests are:
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -231,7 +231,9 @@ def test_duration_converter_for_invalid(duration: str):
 )
 def test_isodatetime_converter_for_valid(datetime_string: str, expected_dt: datetime.datetime):
     converter = ISODateTime()
-    assert asyncio.run(converter.convert(None, datetime_string)) == expected_dt
+    converted_dt = asyncio.run(converter.convert(None, datetime_string))
+    assert converted_dt.tzinfo is None
+    assert converted_dt == expected_dt
 
 
 @pytest.mark.parametrize(

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -190,6 +190,27 @@ def test_duration_converter_for_invalid(duration: str):
 @pytest.mark.parametrize(
     ("datetime_string", "expected_dt"),
     (
+
+        # `YYYY-mm-ddTHH:MM:SSZ` | `YYYY-mm-dd HH:MM:SSZ`
+        ('2019-09-02T02:03:05Z', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+        ('2019-09-02 02:03:05Z', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+
+        # `YYYY-mm-ddTHH:MM:SS±HH:MM` | `YYYY-mm-dd HH:MM:SS±HH:MM`
+        ('2019-09-02T03:18:05+01:15', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+        ('2019-09-02 03:18:05+01:15', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+        ('2019-09-02T00:48:05-01:15', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+        ('2019-09-02 00:48:05-01:15', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+
+        # `YYYY-mm-ddTHH:MM:SS±HHMM` | `YYYY-mm-dd HH:MM:SS±HHMM`
+        ('2019-09-02T03:18:05+0115', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+        ('2019-09-02 03:18:05+0115', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+        ('2019-09-02T00:48:05-0115', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+        ('2019-09-02 00:48:05-0115', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+
+        # `YYYY-mm-ddTHH:MM:SS±HH` | `YYYY-mm-dd HH:MM:SS±HH`
+        ('2019-09-02 03:03:05+01', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+        ('2019-09-02T01:03:05-01', datetime.datetime(2019, 9, 2, 2, 3, 5)),
+
         # `YYYY-mm-ddTHH:MM:SS` | `YYYY-mm-dd HH:MM:SS`
         ('2019-09-02T02:03:05', datetime.datetime(2019, 9, 2, 2, 3, 5)),
         ('2019-09-02 02:03:05', datetime.datetime(2019, 9, 2, 2, 3, 5)),

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -216,7 +216,7 @@ def test_isodatetime_converter_for_valid(datetime_string: str, expected_dt: date
 @pytest.mark.parametrize(
     ("datetime_string"),
     (
-        # Make sure it doesn't interfere with the Duration converation
+        # Make sure it doesn't interfere with the Duration converter
         ('1Y'),
         ('1d'),
         ('1H'),


### PR DESCRIPTION
This pull requests adds a converter that automatically parses ISO-formatted datetime strings and returns a `datetime.datetime` object. It uses [`dateutil.parser.isoparse`](https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse) to do the heavy lifting and therefore supports the same formats.

In addition, I've added tests that "guarantee" that certain standard formats will be accepted and added these "guaranteed" formats to the docstring of the `ISODate.convert` method.

This pull request should make it easy to implement #458. However, I did not yet want to touch the moderation cog, since it's currently being worked on by @MarkKoz. If we merge this soon, Mark may be able to directly implement it during the work he's doing anyway, though.