### PR TITLE
Make `!tags edit` use PATCH to update tags

### DIFF
--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -86,7 +86,7 @@ class Tags(Cog):
                     max_lines=15
                 )
 
-    @tags_group.command(name='set', aliases=('add', 'edit', 's'))
+    @tags_group.command(name='set', aliases=('add', 's'))
     @with_role(*MODERATION_ROLES)
     async def set_command(
         self,
@@ -95,7 +95,7 @@ class Tags(Cog):
         *,
         tag_content: TagContentConverter,
     ) -> None:
-        """Create a new tag or update an existing one."""
+        """Create a new tag."""
         body = {
             'title': tag_name.lower().strip(),
             'embed': {
@@ -113,6 +113,35 @@ class Tags(Cog):
         await ctx.send(embed=Embed(
             title="Tag successfully added",
             description=f"**{tag_name}** added to tag database.",
+            colour=Colour.blurple()
+        ))
+
+    @tags_group.command(name='edit', aliases=('e', ))
+    @with_role(*MODERATION_ROLES)
+    async def edit_command(
+        self,
+        ctx: Context,
+        tag_name: TagNameConverter,
+        *,
+        tag_content: TagContentConverter,
+    ) -> None:
+        """Edit an existing tag."""
+        body = {
+            'embed': {
+                'title': tag_name,
+                'description': tag_content
+            }
+        }
+
+        await self.bot.api_client.patch(f'bot/tags/{tag_name}', json=body)
+
+        log.debug(f"{ctx.author} successfully edited the following tag in our database: \n"
+                  f"tag_name: {tag_name}\n"
+                  f"tag_content: '{tag_content}'\n")
+
+        await ctx.send(embed=Embed(
+            title="Tag successfully edited",
+            description=f"**{tag_name}** edited in the database.",
             colour=Colour.blurple()
         ))
 


### PR DESCRIPTION
This pull request makes sure that we're using the PATCH method to update tags, instead of the POST method. 

The problem was that the `!tags edit` command was an alias of `!tags set`, which uses the POST method to post new tags to the API. However, when a tag with a given name already exists, the API will refuse a POST request in an attempt to update it; we need to use the PATCH method to the `bot/tags/{tag_name}` endpoint instead.

To fix this, I've created a separate subcommand, `!tags edit`, that uses the correct PATCH method to the correct endpoint to update an existing tag.

This pull request closes #474