### PR TITLE
Split !resources into !tools and !resources.

### DIFF
--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -54,11 +54,8 @@ class Alias (Cog):
         await self.invoke(ctx, "site resources")
 
     @command(name="tools", hidden=True)
-    async def site_tools_alias(self, ctx):
-        """
-        Alias for invoking <prefix>site tools.
-        """
-
+    async def site_tools_alias(self, ctx: Context) -> None:
+        """Alias for invoking <prefix>site tools."""
         await self.invoke(ctx, "site tools")
 
     @command(name="watch", hidden=True)

--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -53,6 +53,14 @@ class Alias (Cog):
         """Alias for invoking <prefix>site resources."""
         await self.invoke(ctx, "site resources")
 
+    @command(name="tools", hidden=True)
+    async def site_tools_alias(self, ctx):
+        """
+        Alias for invoking <prefix>site tools.
+        """
+
+        await self.invoke(ctx, "site tools")
+
     @command(name="watch", hidden=True)
     async def bigbrother_watch_alias(self, ctx: Context, user: Union[Member, User, proxy_user], *, reason: str) -> None:
         """Alias for invoking <prefix>bigbrother watch [user] [reason]."""

--- a/bot/cogs/site.py
+++ b/bot/cogs/site.py
@@ -44,17 +44,30 @@ class Site(Cog):
     async def site_resources(self, ctx: Context) -> None:
         """Info about the site's Resources page."""
         learning_url = f"{PAGES_URL}/resources"
-        tools_url = f"{PAGES_URL}/tools"
 
-        embed = Embed(title="Resources & Tools")
-        embed.set_footer(text=f"{learning_url} | {tools_url}")
+        embed = Embed(title="Resources")
+        embed.set_footer(text=f"{learning_url}")
         embed.colour = Colour.blurple()
         embed.description = (
             f"The [Resources page]({learning_url}) on our website contains a "
-            "list of hand-selected goodies that we regularly recommend "
-            f"to both beginners and experts. The [Tools page]({tools_url}) "
-            "contains a couple of the most popular tools for programming in "
-            "Python."
+            "list of hand-selected learning resources that we regularly recommend "
+            f"to both beginners and experts."
+        )
+
+        await ctx.send(embed=embed)
+
+    @site_group.command(name="tools")
+    async def site_tools(self, ctx: Context):
+        """Info about the site's Tools page."""
+
+        tools_url = f"{PAGES_URL}/tools"
+
+        embed = Embed(title="Tools")
+        embed.set_footer(text=f"{tools_url}")
+        embed.colour = Colour.blurple()
+        embed.description = (
+            f"The [Tools page]({tools_url}) on our website contains a "
+            f"couple of the most popular tools for programming in Python."
         )
 
         await ctx.send(embed=embed)

--- a/bot/cogs/site.py
+++ b/bot/cogs/site.py
@@ -57,9 +57,8 @@ class Site(Cog):
         await ctx.send(embed=embed)
 
     @site_group.command(name="tools")
-    async def site_tools(self, ctx: Context):
+    async def site_tools(self, ctx: Context) -> None:
         """Info about the site's Tools page."""
-
         tools_url = f"{PAGES_URL}/tools"
 
         embed = Embed(title="Tools")


### PR DESCRIPTION
This splits the former `!site resources` command into two separate commands, one for `!site resources` and one for `!site tools`. This makes sense now that we've split up the lists into two pages.

It also adds a new alias, `!tools`, with which to to call this command.

![image](https://user-images.githubusercontent.com/2098517/66003120-82ff0a80-e4a5-11e9-8786-7f23a6842088.png)

Closes #478.
