### PR TITLE
Add checks for valid response and retries to fetch_posts()

### DIFF
--- a/bot/cogs/reddit.py
+++ b/bot/cogs/reddit.py
@@ -34,9 +34,7 @@ class Reddit(Cog):
         self.new_posts_task = None
         self.top_weekly_posts_task = None
 
-    async def fetch_posts(
-            self, channel: TextChannel, route: str, *, amount: int = 25, params: dict = None
-    ) -> List[dict]:
+    async def fetch_posts(self, route: str, *, amount: int = 25, params: dict = None) -> List[dict]:
         """A helper method to fetch a certain amount of Reddit posts at a given route."""
         # Reddit's JSON responses only provide 25 posts at most.
         if not 25 >= amount > 0:
@@ -57,8 +55,7 @@ class Reddit(Cog):
                 content = await response.json()
                 posts = content["data"]["children"]
                 return posts[:amount]
-            async with channel.typing():
-                await asyncio.sleep(3)
+            await asyncio.sleep(3)
 
         log.debug(f"Invalid response from: {url} - status code {response.status}, mimetype {response.content_type}")
         return list()  # Failed to get appropriate response within allowed number of retries.
@@ -72,14 +69,14 @@ class Reddit(Cog):
         embed.description = ""
 
         # Get the posts
-        posts = await self.fetch_posts(
-            channel=channel,
-            route=f"{subreddit}/top",
-            amount=5,
-            params={
-                "t": time
-            }
-        )
+        async with channel.typing():
+            posts = await self.fetch_posts(
+                route=f"{subreddit}/top",
+                amount=5,
+                params={
+                    "t": time
+                }
+            )
 
         if not posts:
             embed.title = random.choice(ERROR_REPLIES)
@@ -121,7 +118,7 @@ class Reddit(Cog):
             embed=embed
         )
 
-    async def poll_new_posts(self, channel: TextChannel) -> None:
+    async def poll_new_posts(self) -> None:
         """Periodically search for new subreddit posts."""
         while True:
             await asyncio.sleep(RedditConfig.request_delay)
@@ -142,7 +139,7 @@ class Reddit(Cog):
                 self.prev_lengths[subreddit] = content_length
 
                 # Now we can actually fetch the new data
-                posts = await self.fetch_posts(channel, f"{subreddit}/new")
+                posts = await self.fetch_posts(f"{subreddit}/new")
                 new_posts = []
 
                 # Only show new posts if we've checked before.
@@ -271,7 +268,7 @@ class Reddit(Cog):
 
         if self.reddit_channel is not None:
             if self.new_posts_task is None:
-                self.new_posts_task = self.bot.loop.create_task(self.poll_new_posts(self.reddit_channel))
+                self.new_posts_task = self.bot.loop.create_task(self.poll_new_posts())
             if self.top_weekly_posts_task is None:
                 self.top_weekly_posts_task = self.bot.loop.create_task(self.poll_top_weekly_posts())
         else:

--- a/bot/cogs/reddit.py
+++ b/bot/cogs/reddit.py
@@ -55,6 +55,7 @@ class Reddit(Cog):
                 content = await response.json()
                 posts = content["data"]["children"]
                 return posts[:amount]
+
             await asyncio.sleep(3)
 
         log.debug(f"Invalid response from: {url} - status code {response.status}, mimetype {response.content_type}")

--- a/bot/cogs/reddit.py
+++ b/bot/cogs/reddit.py
@@ -43,9 +43,10 @@ class Reddit(Cog):
         if params is None:
             params = {}
 
+        url = f"{self.URL}/{route}.json"
         for _ in range(self.MAX_FETCH_RETRIES):
             response = await self.bot.http_session.get(
-                url=f"{self.URL}/{route}.json",
+                url=url,
                 headers=self.HEADERS,
                 params=params
             )
@@ -55,6 +56,7 @@ class Reddit(Cog):
                 posts = content["data"]["children"]
                 return posts[:amount]
 
+        log.debug(f"Invalid response from: {url} - status code {response.status}, mimetype {response.content_type}")
         return list()  # Failed to get appropriate response within allowed number of retries.
 
     async def send_top_posts(


### PR DESCRIPTION
Fixes #390

Added checks for response.status and response.content_type for fetch_posts() to validate the response from self.bot.http_session.get(). Also added retries in case a bad response is received.

It's been tested to verify that the `!reddit top` (and similar) commands still work, and I simulated some retry behavior by specifying intentionally bad routes. Please let me know what changes you'd like to see!