### PR TITLE
Fix `cog_unload` bug in WatchChannel ABC

### DIFF
--- a/bot/cogs/watchchannels/watchchannel.py
+++ b/bot/cogs/watchchannels/watchchannel.py
@@ -335,7 +335,7 @@ class WatchChannel(metaclass=CogABCMeta):
     def cog_unload(self) -> None:
         """Takes care of unloading the cog and canceling the consumption task."""
         self.log.trace(f"Unloading the cog")
-        if not self._consume_task.done():
+        if self._consume_task and not self._consume_task.done():
             self._consume_task.cancel()
             try:
                 self._consume_task.result()


### PR DESCRIPTION
There was small bug in the `cog_unload` method of the `WatchChannel` ABC. The reason is that it tries to check if the Task assigned to `self._consume_task` is done by accessing its `done` method without ensuring that `self._consume_task` has been assigned to an actual `Task` yet. 

My solution is to change the `if` condition to this:

  `if self._consume_task and not self._consume_task.done():`

This pull request closes #482