### PR TITLE
Refactor "Cogs" cog

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -43,7 +43,7 @@ bot.load_extension("bot.cogs.security")
 bot.load_extension("bot.cogs.antispam")
 bot.load_extension("bot.cogs.bot")
 bot.load_extension("bot.cogs.clean")
-bot.load_extension("bot.cogs.cogs")
+bot.load_extension("bot.cogs.extensions")
 bot.load_extension("bot.cogs.help")
 
 # Only load this in production

--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -5,6 +5,7 @@ from typing import Union
 from discord import Colour, Embed, Member, User
 from discord.ext.commands import Bot, Cog, Command, Context, clean_content, command, group
 
+from bot.cogs.extensions import Extension
 from bot.cogs.watchchannels.watchchannel import proxy_user
 from bot.converters import TagNameConverter
 from bot.pagination import LinePaginator
@@ -84,9 +85,9 @@ class Alias (Cog):
         await self.invoke(ctx, "site rules")
 
     @command(name="reload", hidden=True)
-    async def cogs_reload_alias(self, ctx: Context, *, cog_name: str) -> None:
-        """Alias for invoking <prefix>cogs reload [cog_name]."""
-        await self.invoke(ctx, "cogs reload", cog_name)
+    async def extensions_reload_alias(self, ctx: Context, *extensions: Extension) -> None:
+        """Alias for invoking <prefix>extensions reload [extensions...]."""
+        await self.invoke(ctx, "extensions reload", *extensions)
 
     @command(name="defon", hidden=True)
     async def defcon_enable_alias(self, ctx: Context) -> None:

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -196,6 +196,9 @@ class Extensions(Cog):
                 for func in action.value:
                     func(self.bot, ext)
             except Exception as e:
+                if hasattr(e, "original"):
+                    e = e.original
+
                 log.exception(f"Extension '{ext}' failed to {verb}.")
 
                 error_msg = f"{e.__class__.__name__}: {e}"

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -171,11 +171,11 @@ class Extensions(Cog):
         """).strip()
 
         if unload_failures:
-            failures = '\n'.join(f'{ext}\n    {err}' for ext, err in unload_failures)
+            failures = '\n'.join(f'{ext}\n    {err}' for ext, err in unload_failures.items())
             msg += f'\nUnload failures:```{failures}```'
 
         if load_failures:
-            failures = '\n'.join(f'{ext}\n    {err}' for ext, err in load_failures)
+            failures = '\n'.join(f'{ext}\n    {err}' for ext, err in load_failures.items())
             msg += f'\nLoad failures:```{failures}```'
 
         log.debug(f'Reloaded all extensions.')

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -12,11 +12,11 @@ from bot.pagination import LinePaginator
 
 log = logging.getLogger(__name__)
 
-KEEP_LOADED = ["bot.cogs.cogs", "bot.cogs.modlog"]
+KEEP_LOADED = ["bot.cogs.extensions", "bot.cogs.modlog"]
 
 
-class Cogs(Cog):
-    """Cog management commands."""
+class Extensions(Cog):
+    """Extension management commands."""
 
     def __init__(self, bot: Bot):
         self.bot = bot
@@ -34,13 +34,13 @@ class Cogs(Cog):
         # Allow reverse lookups by reversing the pairs
         self.cogs.update({v: k for k, v in self.cogs.items()})
 
-    @group(name='cogs', aliases=('c',), invoke_without_command=True)
+    @group(name='extensions', aliases=('c', 'ext', 'exts'), invoke_without_command=True)
     @with_role(*MODERATION_ROLES, Roles.core_developer)
-    async def cogs_group(self, ctx: Context) -> None:
+    async def extensions_group(self, ctx: Context) -> None:
         """Load, unload, reload, and list active cogs."""
-        await ctx.invoke(self.bot.get_command("help"), "cogs")
+        await ctx.invoke(self.bot.get_command("help"), "extensions")
 
-    @cogs_group.command(name='load', aliases=('l',))
+    @extensions_group.command(name='load', aliases=('l',))
     @with_role(*MODERATION_ROLES, Roles.core_developer)
     async def load_command(self, ctx: Context, cog: str) -> None:
         """
@@ -91,7 +91,7 @@ class Cogs(Cog):
 
         await ctx.send(embed=embed)
 
-    @cogs_group.command(name='unload', aliases=('ul',))
+    @extensions_group.command(name='unload', aliases=('ul',))
     @with_role(*MODERATION_ROLES, Roles.core_developer)
     async def unload_command(self, ctx: Context, cog: str) -> None:
         """
@@ -141,7 +141,7 @@ class Cogs(Cog):
 
         await ctx.send(embed=embed)
 
-    @cogs_group.command(name='reload', aliases=('r',))
+    @extensions_group.command(name='reload', aliases=('r',))
     @with_role(*MODERATION_ROLES, Roles.core_developer)
     async def reload_command(self, ctx: Context, cog: str) -> None:
         """
@@ -245,7 +245,7 @@ class Cogs(Cog):
 
         await ctx.send(embed=embed)
 
-    @cogs_group.command(name='list', aliases=('all',))
+    @extensions_group.command(name='list', aliases=('all',))
     @with_role(*MODERATION_ROLES, Roles.core_developer)
     async def list_command(self, ctx: Context) -> None:
         """
@@ -293,6 +293,6 @@ class Cogs(Cog):
 
 
 def setup(bot: Bot) -> None:
-    """Cogs cog load."""
-    bot.add_cog(Cogs(bot))
-    log.info("Cog loaded: Cogs")
+    """Load the Extensions cog."""
+    bot.add_cog(Extensions(bot))
+    log.info("Cog loaded: Extensions")

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -1,13 +1,12 @@
 import logging
 import os
 from enum import Enum
+from pkgutil import iter_modules
 
 from discord import Colour, Embed
 from discord.ext.commands import Bot, Cog, Context, group
 
-from bot.constants import (
-    Emojis, MODERATION_ROLES, Roles, URLs
-)
+from bot.constants import Emojis, MODERATION_ROLES, Roles, URLs
 from bot.decorators import with_role
 from bot.pagination import LinePaginator
 
@@ -29,19 +28,10 @@ class Extensions(Cog):
 
     def __init__(self, bot: Bot):
         self.bot = bot
-        self.cogs = {}
 
-        # Load up the cog names
-        log.info("Initializing cog names...")
-        for filename in os.listdir("bot/cogs"):
-            if filename.endswith(".py") and "_" not in filename:
-                if os.path.isfile(f"bot/cogs/{filename}"):
-                    cog = filename[:-3]
-
-                    self.cogs[cog] = f"bot.cogs.{cog}"
-
-        # Allow reverse lookups by reversing the pairs
-        self.cogs.update({v: k for k, v in self.cogs.items()})
+        log.info("Initialising extension names...")
+        modules = iter_modules(("bot/cogs", "bot.cogs"))
+        self.cogs = set(ext for ext in modules if ext.name[-1] != "_")
 
     @group(name='extensions', aliases=('c', 'ext', 'exts'), invoke_without_command=True)
     @with_role(*MODERATION_ROLES, Roles.core_developer)

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -14,7 +14,11 @@ from bot.utils.checks import with_role_check
 log = logging.getLogger(__name__)
 
 KEEP_LOADED = ["bot.cogs.extensions", "bot.cogs.modlog"]
-EXTENSIONS = frozenset(ext for ext in iter_modules(("bot/cogs", "bot.cogs")) if ext.name[-1] != "_")
+EXTENSIONS = frozenset(
+    ext.name
+    for ext in iter_modules(("bot/cogs",), "bot.cogs.")
+    if ext.name[-1] != "_"
+)
 
 
 class Action(Enum):

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -106,44 +106,29 @@ class Extensions(commands.Cog):
     @extensions_group.command(name="list", aliases=("all",))
     async def list_command(self, ctx: Context) -> None:
         """
-        Get a list of all cogs, including their loaded status.
+        Get a list of all extensions, including their loaded status.
 
-        Gray indicates that the cog is unloaded. Green indicates that the cog is currently loaded.
+        Grey indicates that the extension is unloaded.
+        Green indicates that the extension is currently loaded.
         """
         embed = Embed()
         lines = []
-        cogs = {}
 
         embed.colour = Colour.blurple()
         embed.set_author(
-            name="Python Bot (Cogs)",
+            name="Extensions List",
             url=URLs.github_bot_repo,
             icon_url=URLs.bot_avatar
         )
 
-        for key, _value in self.cogs.items():
-            if "." not in key:
-                continue
-
-            if key in self.bot.extensions:
-                cogs[key] = True
-            else:
-                cogs[key] = False
-
-        for key in self.bot.extensions.keys():
-            if key not in self.cogs:
-                cogs[key] = True
-
-        for cog, loaded in sorted(cogs.items(), key=lambda x: x[0]):
-            if cog in self.cogs:
-                cog = self.cogs[cog]
-
-            if loaded:
+        for ext in sorted(list(EXTENSIONS)):
+            if ext in self.bot.extensions:
                 status = Emojis.status_online
             else:
                 status = Emojis.status_offline
 
-            lines.append(f"{status}  {cog}")
+            ext = ext.rsplit(".", 1)[1]
+            lines.append(f"{status}  {ext}")
 
         log.debug(f"{ctx.author} requested a list of all cogs. Returning a paginated list.")
         await LinePaginator.paginate(lines, ctx, embed, max_size=300, empty=False)

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from enum import Enum
 
 from discord import Colour, Embed
 from discord.ext.commands import Bot, Cog, Context, group
@@ -13,6 +14,14 @@ from bot.pagination import LinePaginator
 log = logging.getLogger(__name__)
 
 KEEP_LOADED = ["bot.cogs.extensions", "bot.cogs.modlog"]
+
+
+class Action(Enum):
+    """Represents an action to perform on an extension."""
+
+    LOAD = (Bot.load_extension,)
+    UNLOAD = (Bot.unload_extension,)
+    RELOAD = (Bot.unload_extension, Bot.load_extension)
 
 
 class Extensions(Cog):

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -89,8 +89,8 @@ class Extensions(commands.Cog):
 
         If an extension fails to be reloaded, it will be rolled-back to the prior working state.
 
-        If `*` is given as the name, all currently loaded extensions will be reloaded.
-        If `**` is given as the name, all extensions, including unloaded ones, will be reloaded.
+        If '*' is given as the name, all currently loaded extensions will be reloaded.
+        If '**' is given as the name, all extensions, including unloaded ones, will be reloaded.
         """
         if not extensions:
             await ctx.invoke(self.bot.get_command("help"), "extensions reload")
@@ -137,8 +137,8 @@ class Extensions(commands.Cog):
         """
         Reload given extensions and return a message with the results.
 
-        If `*` is given, all currently loaded extensions will be reloaded along with any other
-        specified extensions. If `**` is given, all extensions, including unloaded ones, will be
+        If '*' is given, all currently loaded extensions will be reloaded along with any other
+        specified extensions. If '**' is given, all extensions, including unloaded ones, will be
         reloaded.
         """
         failures = {}

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -92,6 +92,10 @@ class Extensions(commands.Cog):
         If `*` is given as the name, all currently loaded extensions will be reloaded.
         If `**` is given as the name, all extensions, including unloaded ones, will be reloaded.
         """
+        if not extensions:
+            await ctx.invoke(self.bot.get_command("help"), "extensions reload")
+            return
+
         if len(extensions) > 1:
             msg = await self.batch_reload(*extensions)
         else:

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -71,8 +71,8 @@ class Extensions(commands.Cog):
         """
         Load extensions given their fully qualified or unqualified names.
 
-        If '*' or '**' is given as the name, all unloaded extensions will be loaded.
-        """
+        If '\*' or '\*\*' is given as the name, all unloaded extensions will be loaded.
+        """  # noqa: W605
         if "*" in extensions or "**" in extensions:
             extensions = set(EXTENSIONS) - set(self.bot.extensions.keys())
 
@@ -84,8 +84,8 @@ class Extensions(commands.Cog):
         """
         Unload currently loaded extensions given their fully qualified or unqualified names.
 
-        If '*' or '**' is given as the name, all loaded extensions will be unloaded.
-        """
+        If '\*' or '\*\*' is given as the name, all loaded extensions will be unloaded.
+        """  # noqa: W605
         blacklisted = "\n".join(UNLOAD_BLACKLIST & set(extensions))
 
         if blacklisted:
@@ -105,9 +105,9 @@ class Extensions(commands.Cog):
 
         If an extension fails to be reloaded, it will be rolled-back to the prior working state.
 
-        If '*' is given as the name, all currently loaded extensions will be reloaded.
-        If '**' is given as the name, all extensions, including unloaded ones, will be reloaded.
-        """
+        If '\*' is given as the name, all currently loaded extensions will be reloaded.
+        If '\*\*' is given as the name, all extensions, including unloaded ones, will be reloaded.
+        """  # noqa: W605
         if not extensions:
             await ctx.invoke(self.bot.get_command("help"), "extensions reload")
             return

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -73,6 +73,10 @@ class Extensions(commands.Cog):
 
         If '\*' or '\*\*' is given as the name, all unloaded extensions will be loaded.
         """  # noqa: W605
+        if not extensions:
+            await ctx.invoke(self.bot.get_command("help"), "extensions load")
+            return
+
         if "*" in extensions or "**" in extensions:
             extensions = set(EXTENSIONS) - set(self.bot.extensions.keys())
 
@@ -86,6 +90,10 @@ class Extensions(commands.Cog):
 
         If '\*' or '\*\*' is given as the name, all loaded extensions will be unloaded.
         """  # noqa: W605
+        if not extensions:
+            await ctx.invoke(self.bot.get_command("help"), "extensions unload")
+            return
+
         blacklisted = "\n".join(UNLOAD_BLACKLIST & set(extensions))
 
         if blacklisted:


### PR DESCRIPTION
Notable user-facing changes:

* Fixes #479
* Embeds have been ditched everywhere except for the list command.
* Renamed to _extensions_ because it really loads extensions, not cogs (cogs just happen to be inside extensions). The old _cogs_ aliases are still available.
* `*` can be used to reload only all loaded extensions and `**` can be used to "reload" all extensions, even unloaded extensions.
* Multiple names of extensions can be given to the reload command. If `*` is also given, a union will be done with all loaded extensions and the extensions named explicitly.
* The fully qualified name of the extension is shown in response messages (e.g. confirmation/failure messages, errors, etc.). The list command is an exception and shows unqualified names.
* When batch reloading, errors have been merged into a single list (no more distinction between load/unload errors).
* [`reload_extension()`](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.Bot.reload_extension) is used for reloading, so if an error occurs while reloading, the extension will be reverted to its previously working state.
* When reloading, if an extension was not initially loaded, it will be implicitly loaded anyway.

---

Plan is to rename it to `extensions` and re-do it based on how I did it in another bot, which has less redundancy in terms of output messages:

https://github.com/MarkKoz/d.py-test-bot/blob/master/testbot/extensions/manager.py
https://github.com/MarkKoz/d.py-test-bot/blob/master/testbot/utils/extensions.py