### PR TITLE
Fix error when symbol_id cannot be found in doc HTML

### DIFF
--- a/bot/cogs/doc.py
+++ b/bot/cogs/doc.py
@@ -207,6 +207,9 @@ class Doc(commands.Cog):
         symbol_heading = soup.find(id=symbol_id)
         signature_buffer = []
 
+        if symbol_heading is None:
+            return None
+
         # Traverse the tags of the signature header and ignore any
         # unwanted symbols from it. Add all of it to a temporary buffer.
         for tag in symbol_heading.strings:


### PR DESCRIPTION
Fixes #477 

What was causing this:

* The symbol `discord` returns the URL `https://discordpy.readthedocs.io/en/latest/discord.html`
* The URL has no  `#symbol_name` at the end, so splitting by `#` and getting the last element returns the entire URL
    ```py
    symbol_id = url.split('#')[-1]
    ```
* Searching for an element in the HTML which has an ID equal to the entire URL obviously fails, hence the returned element is `None`
* Thus accessing the `strings` attribute of `None` fails.

The simple fix was just to show that docs could not be found for that symbol. However, a URL actually was found. It could be changed to somehow send that link to the user but the infrastructure isn't really there to do that currently (the function is supposed to return a signature and a description).