### PR TITLE
Added to the `.gitignore` a new file to be ignored .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ config.yml
 
 # JUnit XML reports from pytest
 junit.xml
+
+# Mac OS .DS_Store, which is a file that stores custom attributes of its containing folder
+.DS_Store


### PR DESCRIPTION
Only on Mac OS. `.DS_Store` is a file that stores custom attributes of its containing folder. New contributors on Mac OS won't have to bother anymore about this mysterious file that is created when you fork the project.