### PR TITLE
Feat/attachment spam threshold

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -282,7 +282,7 @@ anti_spam:
     rules:
         attachments:
             interval: 10
-            max: 3
+            max: 9
 
         burst:
             interval: 10


### PR DESCRIPTION
It's been decided by staff that triggering an auto mute from sending 4 attachments in quick succession is almost always a false positive, and that the threshold should be increased to 10. Note that this means the max needs to be 9.

Closes #323 