### PR TITLE
Show  the reason in infraction confirmation message if the actor is the bot

### DIFF
--- a/bot/cogs/antispam.py
+++ b/bot/cogs/antispam.py
@@ -207,8 +207,10 @@ class AntiSpam(Cog):
         if not any(role.id == self.muted_role.id for role in member.roles):
             remove_role_after = AntiSpamConfig.punishment['remove_after']
 
-            # We need context, let's get it
+            # Get context and make sure the bot becomes the actor of infraction by patching the `author` attributes
             context = await self.bot.get_context(msg)
+            context.author = self.bot.user
+            context.message.author = self.bot.user
 
             # Since we're going to invoke the tempmute command directly, we need to manually call the converter.
             dt_remove_role_after = await self.expiration_date_converter.convert(context, f"{remove_role_after}S")

--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -416,6 +416,7 @@ class Infractions(Scheduler, commands.Cog):
         expiry_log_text = f"Expires: {expiry}" if expiry else ""
         log_title = "applied"
         log_content = None
+        reason_msg = ""
 
         # DM the user about the infraction if it's not a shadow/hidden infraction.
         if not infraction["hidden"]:
@@ -429,6 +430,9 @@ class Infractions(Scheduler, commands.Cog):
             else:
                 dm_log_text = "\nDM: **Failed**"
                 log_content = ctx.author.mention
+
+        if infraction["actor"] == self.bot.user.id:
+            reason_msg = f" (reason: {infraction['reason']})"
 
         # Execute the necessary actions to apply the infraction on Discord.
         if action_coro:
@@ -445,7 +449,7 @@ class Infractions(Scheduler, commands.Cog):
                 log_title = "failed to apply"
 
         # Send a confirmation message to the invoking context.
-        await ctx.send(f"{dm_result}{confirm_msg} **{infr_type}** to {user.mention}{expiry_msg}.")
+        await ctx.send(f"{dm_result}{confirm_msg} **{infr_type}** to {user.mention}{expiry_msg}{reason_msg}.")
 
         # Send a log message to the mod log.
         await self.mod_log.send_log_message(


### PR DESCRIPTION
This PR adds the reason back to the infraction confirmation message the bot sends after successfully applying an infraction, but only if the actor is the bot itself. The reason is that if the bot itself invokes the infraction, having the reason it did that stated in the confirmation message will give context to what's going to those involved in the conversation.

**Before**
![no_reason](https://user-images.githubusercontent.com/33516116/66420161-b7267e00-ea05-11e9-84b0-9a95d864a566.png)

**After**
![reason_included](https://user-images.githubusercontent.com/33516116/66420188-c0afe600-ea05-11e9-8dba-5d9a3cec7430.png)

If the actor of the infraction is not the bot, then the reason will not be displayed in the confirmation message:
![2019-10-08_19-06](https://user-images.githubusercontent.com/33516116/66420275-e3da9580-ea05-11e9-841a-05124411fe62.png)

This PR closes #476 
