### PR TITLE
Ensure display name changes are logged to the user-log

### DIFF
--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -20,7 +20,7 @@ GUILD_CHANNEL = t.Union[discord.CategoryChannel, discord.TextChannel, discord.Vo
 
 CHANNEL_CHANGES_UNSUPPORTED = ("permissions",)
 CHANNEL_CHANGES_SUPPRESSED = ("_overwrites", "position")
-MEMBER_CHANGES_SUPPRESSED = ("status", "activities", "_client_status")
+MEMBER_CHANGES_SUPPRESSED = ("status", "activities", "_client_status", "nick")
 ROLE_CHANGES_UNSUPPORTED = ("colour", "permissions")
 
 
@@ -496,6 +496,11 @@ class ModLog(Cog, name="ModLog"):
         if before.discriminator != after.discriminator:
             changes.append(
                 f"**Discriminator:** `{before.discriminator}` **->** `{after.discriminator}`"
+            )
+
+        if before.display_name != after.display_name:
+            changes.append(
+                f"**Display name:** `{before.display_name}` **->** `{after.display_name}`"
             )
 
         if not changes:


### PR DESCRIPTION
Recently, we discovered that not all display name changes were logged to the #user-log channel. This problem was caused by the `old_value` or the `new_value` showing up as `None` when a user sets or removes a guild-specific nickname. Since we ignore changes in which either the `old_value` or the `new_value` is `None`, we did not log these `None->nick` or `nick->None` events.

As we are mainly interested in the display name of the user, and the display name is either equal to the user's guild-specific nickname, if they have one, or otherwise their username, I made the following changes:

- Add logging of changes in the display names of members.

- Ignore nick-specific changes completely, since these changes are already captured by the changes in the display name we now log.

The new display name logs will show up in #user-log as this:

![display name logging](https://user-images.githubusercontent.com/33516116/66428928-47b98a00-ea17-11e9-9d47-01cdaa814f1b.png)

This PR closes #489