### PR TITLE
Added a the current nickname of a user in infraction search

### DIFF
--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -1030,6 +1030,7 @@ class Moderation(Scheduler, Cog):
             {"**===============**" if active else "==============="}
             Status: {"__**Active**__" if active else "Inactive"}
             User: {self.bot.get_user(user_id)} (`{user_id}`)
+            Nickname: {actor.nick or "*None*"}
             Type: **{infraction_object["type"]}**
             Shadow: {hidden}
             Reason: {infraction_object["reason"] or "*None*"}


### PR DESCRIPTION
If the user has not changed its nickname, display *None*, otherwise display its current nickname.

Fix #337 