### PR TITLE
Log member_ban event to #user-log

### DIFF
--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -261,7 +261,6 @@ class Infractions(Scheduler, commands.Cog):
         if infraction is None:
             return
 
-        self.mod_log.ignore(Event.member_ban, user.id)
         self.mod_log.ignore(Event.member_remove, user.id)
 
         action = ctx.guild.ban(user, reason=reason, delete_message_days=0)

--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -353,7 +353,7 @@ class ModLog(Cog, name="ModLog"):
 
     @Cog.listener()
     async def on_member_ban(self, guild: discord.Guild, member: UserTypes) -> None:
-        """Log ban event to mod log."""
+        """Log ban event to user log."""
         if guild.id != GuildConstant.id:
             return
 
@@ -365,7 +365,7 @@ class ModLog(Cog, name="ModLog"):
             Icons.user_ban, Colours.soft_red,
             "User banned", f"{member.name}#{member.discriminator} (`{member.id}`)",
             thumbnail=member.avatar_url_as(static_format="png"),
-            channel_id=Channels.modlog
+            channel_id=Channels.userlog
         )
 
     @Cog.listener()


### PR DESCRIPTION
**Closes #499**

Currently, the `#user-log` channel provides no indication that a member has left the server due to being banned or temporarily banned, only if they voluntarily leave the server.

This is fixed by unignoring the `member_ban` event in the `Infractions` cog, and rerouting the log embed to `#user-log` in the `ModLog` cog.