### PR TITLE
Antimalware cog

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -39,6 +39,7 @@ bot.load_extension("bot.cogs.logging")
 bot.load_extension("bot.cogs.security")
 
 # Commands, etc
+bot.load_extension("bot.cogs.antimalware")
 bot.load_extension("bot.cogs.antispam")
 bot.load_extension("bot.cogs.bot")
 bot.load_extension("bot.cogs.clean")

--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -25,7 +25,6 @@ class AntiMalware(Cog):
                 break  # Other detections irrelevant because we prioritize the .py message.
             if not attachment.filename.lower().endswith(tuple(AntiMalwareConfig.whitelist)):
                 rejected_attachments = True
-                break
 
         if detected_pyfile or rejected_attachments:
             # Send a message to the user indicating the problem (with special treatment for .py)

--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -1,6 +1,6 @@
 import logging
 
-from discord import Message, utils
+from discord import Message, NotFound
 from discord.ext.commands import Bot, Cog
 
 from bot.constants import AntiMalware as AntiMalwareConfig, Channels
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 
 class AntiMalware(Cog):
     """Cog providing anti-malware behavior."""
+
     def __init__(self, bot: Bot):
         self.bot = bot
         self.whitelist = tuple(AntiMalwareConfig.whitelist)
@@ -17,27 +18,31 @@ class AntiMalware(Cog):
     @Cog.listener()
     async def on_message(self, message: Message) -> None:
         """Identify messages with prohibited attachments."""
-        log.trace("Entered AntiMalware.on_message()")
         rejected_attachments = [a for a in message.attachments if
                                 not a.filename.lower().endswith(self.whitelist)]
         detected_pyfile = len([a for a in message.attachments if a.filename.lower().endswith('.py')]) > 0
 
         if len(rejected_attachments) > 0:
-            log.trace("Identified rejected attachment(s)")
-            # Send a message indicating the problem to the user (with special treatment for .py)
+            # Send a message to the user indicating the problem (with special treatment for .py)
             author = message.author
             if detected_pyfile:
                 msg = f"{author.mention}, it looks like you tried to attach a Python file - please " \
                     f"use a code-pasting service such as https://paste.pythondiscord.com/ instead."
             else:
-                meta_channel = utils.get(message.guild.channels, id=Channels.meta)
+                meta_channel = self.bot.get_channel(Channels.meta)
                 msg = f"{author.mention}, it looks like you tried to attach a file type we don't " \
                     f"allow. Feel free to ask in {meta_channel.mention} if you think this is a mistake."
 
             await message.channel.send(msg)
 
+            # Delete the offending message:
+            try:
+                await message.delete()
+            except NotFound:
+                log.info(f"Tried to delete message `{message.id}`, but message could not be found.")
+
 
 def setup(bot: Bot) -> None:
-    """AntiMalware cog load."""
+    """Antimalware cog load."""
     bot.add_cog(AntiMalware(bot))
     log.info("Cog loaded: AntiMalware")

--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -20,13 +20,14 @@ class AntiMalware(Cog):
         rejected_attachments = False
         detected_pyfile = False
         for attachment in message.attachments:
-            if not attachment.filename.lower().endswith(tuple(AntiMalwareConfig.whitelist)):
-                rejected_attachments = True
             if attachment.filename.lower().endswith('.py'):
                 detected_pyfile = True
                 break  # Other detections irrelevant because we prioritize the .py message.
+            if not attachment.filename.lower().endswith(tuple(AntiMalwareConfig.whitelist)):
+                rejected_attachments = True
+                break
 
-        if rejected_attachments:
+        if detected_pyfile or rejected_attachments:
             # Send a message to the user indicating the problem (with special treatment for .py)
             author = message.author
             if detected_pyfile:

--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -1,0 +1,43 @@
+import logging
+
+from discord import Message, utils
+from discord.ext.commands import Bot, Cog
+
+from bot.constants import AntiMalware as AntiMalwareConfig, Channels
+
+log = logging.getLogger(__name__)
+
+
+class AntiMalware(Cog):
+    """Cog providing anti-malware behavior."""
+    def __init__(self, bot: Bot):
+        self.bot = bot
+        self.whitelist = tuple(AntiMalwareConfig.whitelist)
+
+    @Cog.listener()
+    async def on_message(self, message: Message) -> None:
+        """Identify messages with prohibited attachments."""
+        log.trace("Entered AntiMalware.on_message()")
+        rejected_attachments = [a for a in message.attachments if
+                                not a.filename.lower().endswith(self.whitelist)]
+        detected_pyfile = len([a for a in message.attachments if a.filename.lower().endswith('.py')]) > 0
+
+        if len(rejected_attachments) > 0:
+            log.trace("Identified rejected attachment(s)")
+            # Send a message indicating the problem to the user (with special treatment for .py)
+            author = message.author
+            if detected_pyfile:
+                msg = f"{author.mention}, it looks like you tried to attach a Python file - please " \
+                    f"use a code-pasting service such as https://paste.pythondiscord.com/ instead."
+            else:
+                meta_channel = utils.get(message.guild.channels, id=Channels.meta)
+                msg = f"{author.mention}, it looks like you tried to attach a file type we don't " \
+                    f"allow. Feel free to ask in {meta_channel.mention} if you think this is a mistake."
+
+            await message.channel.send(msg)
+
+
+def setup(bot: Bot) -> None:
+    """AntiMalware cog load."""
+    bot.add_cog(AntiMalware(bot))
+    log.info("Cog loaded: AntiMalware")

--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -17,24 +17,29 @@ class AntiMalware(Cog):
     @Cog.listener()
     async def on_message(self, message: Message) -> None:
         """Identify messages with prohibited attachments."""
-        rejected_attachments = list()
-        detected_pyfile = list()
+        rejected_attachments = False
+        detected_pyfile = False
         for attachment in message.attachments:
             if not attachment.filename.lower().endswith(tuple(AntiMalwareConfig.whitelist)):
-                rejected_attachments.append(attachment)
+                rejected_attachments = True
             if attachment.filename.lower().endswith('.py'):
-                detected_pyfile.append(attachment)
+                detected_pyfile = True
+                break  # Other detections irrelevant because we prioritize the .py message.
 
         if rejected_attachments:
             # Send a message to the user indicating the problem (with special treatment for .py)
             author = message.author
             if detected_pyfile:
-                msg = (f"{author.mention}, it looks like you tried to attach a Python file - please "
-                       f"use a code-pasting service such as https://paste.pythondiscord.com/ instead.")
+                msg = (
+                    f"{author.mention}, it looks like you tried to attach a Python file - please "
+                    f"use a code-pasting service such as https://paste.pythondiscord.com/ instead."
+                )
             else:
                 meta_channel = self.bot.get_channel(Channels.meta)
-                msg = (f"{author.mention}, it looks like you tried to attach a file type we don't "
-                       f"allow. Feel free to ask in {meta_channel.mention} if you think this is a mistake.")
+                msg = (
+                    f"{author.mention}, it looks like you tried to attach a file type we don't "
+                    f"allow. Feel free to ask in {meta_channel.mention} if you think this is a mistake."
+                )
 
             await message.channel.send(msg)
 

--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -9,29 +9,32 @@ log = logging.getLogger(__name__)
 
 
 class AntiMalware(Cog):
-    """Cog providing anti-malware behavior."""
+    """Delete messages which contain attachments with non-whitelisted file extensions."""
 
     def __init__(self, bot: Bot):
         self.bot = bot
-        self.whitelist = tuple(AntiMalwareConfig.whitelist)
 
     @Cog.listener()
     async def on_message(self, message: Message) -> None:
         """Identify messages with prohibited attachments."""
-        rejected_attachments = [a for a in message.attachments if
-                                not a.filename.lower().endswith(self.whitelist)]
-        detected_pyfile = len([a for a in message.attachments if a.filename.lower().endswith('.py')]) > 0
+        rejected_attachments = list()
+        detected_pyfile = list()
+        for attachment in message.attachments:
+            if not attachment.filename.lower().endswith(tuple(AntiMalwareConfig.whitelist)):
+                rejected_attachments.append(attachment)
+            if attachment.filename.lower().endswith('.py'):
+                detected_pyfile.append(attachment)
 
-        if len(rejected_attachments) > 0:
+        if rejected_attachments:
             # Send a message to the user indicating the problem (with special treatment for .py)
             author = message.author
             if detected_pyfile:
-                msg = f"{author.mention}, it looks like you tried to attach a Python file - please " \
-                    f"use a code-pasting service such as https://paste.pythondiscord.com/ instead."
+                msg = (f"{author.mention}, it looks like you tried to attach a Python file - please "
+                       f"use a code-pasting service such as https://paste.pythondiscord.com/ instead.")
             else:
                 meta_channel = self.bot.get_channel(Channels.meta)
-                msg = f"{author.mention}, it looks like you tried to attach a file type we don't " \
-                    f"allow. Feel free to ask in {meta_channel.mention} if you think this is a mistake."
+                msg = (f"{author.mention}, it looks like you tried to attach a file type we don't "
+                       f"allow. Feel free to ask in {meta_channel.mention} if you think this is a mistake.")
 
             await message.channel.send(msg)
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -460,6 +460,12 @@ class AntiSpam(metaclass=YAMLGetter):
     rules: Dict[str, Dict[str, int]]
 
 
+class AntiMalware(metaclass=YAMLGetter):
+    section = "anti_malware"
+
+    whitelist: tuple
+
+
 class BigBrother(metaclass=YAMLGetter):
     section = 'big_brother'
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -345,6 +345,7 @@ class Channels(metaclass=YAMLGetter):
     help_7: int
     helpers: int
     message_log: int
+    meta: int
     mod_alerts: int
     modlog: int
     off_topic_0: int

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -463,7 +463,7 @@ class AntiSpam(metaclass=YAMLGetter):
 class AntiMalware(metaclass=YAMLGetter):
     section = "anti_malware"
 
-    whitelist: tuple
+    whitelist: list
 
 
 class BigBrother(metaclass=YAMLGetter):

--- a/config-default.yml
+++ b/config-default.yml
@@ -107,6 +107,7 @@ guild:
         help_7:                           587375768556797982
         helpers:                          385474242440986624
         message_log:       &MESSAGE_LOG   467752170159079424
+        meta:                             429409067623251969
         mod_alerts:                       473092532147060736
         modlog:            &MODLOG        282638479504965634
         off_topic_0:                      291284109232308226
@@ -320,6 +321,11 @@ anti_spam:
         role_mentions:
             interval: 10
             max: 3
+
+
+anti_malware:
+    whitelist: ['.bmp', '.gif', '.jpg', '.jpeg', '.png', '.tiff', # Images
+                '.3gp', '.3g2', '.avi', '.h264', '.m4v', '.mkv', '.mov', '.mp4', '.mpeg', '.mpg', '.wmv' ] # Videos
 
 
 reddit:

--- a/config-default.yml
+++ b/config-default.yml
@@ -324,8 +324,24 @@ anti_spam:
 
 
 anti_malware:
-    whitelist: ['.bmp', '.gif', '.jpg', '.jpeg', '.png', '.tiff', # Images
-                '.3gp', '.3g2', '.avi', '.h264', '.m4v', '.mkv', '.mov', '.mp4', '.mpeg', '.mpg', '.wmv' ] # Videos
+    whitelist:
+        - '.3gp'
+        - '.3g2'
+        - '.avi'
+        - '.bmp'
+        - '.gif'
+        - '.h264'
+        - '.jpg'
+        - '.jpeg'
+        - '.m4v'
+        - '.mkv'
+        - '.mov'
+        - '.mp4'
+        - '.mpeg'
+        - '.mpg'
+        - '.png'
+        - '.tiff'
+        - '.wmv'
 
 
 reddit:


### PR DESCRIPTION
Howdy! This PR is intended to address issue #471 (auto-deleting messages with potentially malicious file attachments). After discussing with @lemonsaurus, it became clear that a new Cog would make for a cleaner implementation, instead of a new rule within the `AntiSpam` Cog. I'll be happy to elaborate on those reasons if anyone would like further details.

Here's about the simplest implementation I could conceive, using the suggestions made in the issue's notes. Some points for further discussion:

1. The whitelist (list of allowed extensions) will need vetting - I used a fairly small list of common image and video file formats, and the Cog rejects everything else.
2. I'm fairly new to this code-base, so there may be some preferred implementation details and such that I neglected, either accidentally or otherwise. For example:
        - `AntiSpam.on_message()` begins with a handful of early-out conditions. I don't quite understand the purpose of some of those, so I did not include any, pending further review by staff.
        - `AntiSpam` calls `ModLog.ignore()` before deleting messages - I wasn't clear on why, so I did not do the same.
3. I did not implement punishment for attaching files with prohibited extensions, but I can do so if requested. It seems a little overly punitive perhaps, because I think most people attaching files will be doing so with good intent, but that's not my call.

I'll be happy to make any requested changes. Thanks!