### PR TITLE
Migrate `test_constants` to unittest

### DIFF
--- a/tests/bot/test_constants.py
+++ b/tests/bot/test_constants.py
@@ -1,0 +1,26 @@
+import inspect
+import unittest
+
+from bot import constants
+
+
+class ConstantsTests(unittest.TestCase):
+    """Tests for our constants."""
+
+    def test_section_configuration_matches_type_specification(self):
+        """The section annotations should match the actual types of the sections."""
+
+        sections = (
+            cls
+            for (name, cls) in inspect.getmembers(constants)
+            if hasattr(cls, 'section') and isinstance(cls, type)
+        )
+        for section in sections:
+            for name, annotation in section.__annotations__.items():
+                with self.subTest(section=section, name=name, annotation=annotation):
+                    value = getattr(section, name)
+
+                    if getattr(annotation, '_name', None) in ('Dict', 'List'):
+                        self.skipTest("Cannot validate containers yet.")
+
+                    self.assertIsInstance(value, annotation)


### PR DESCRIPTION
Migrates `test_constants.py` to the unittest framework. As with the pytest version, it does not yet test container types.

Note: There is a small, but important logical difference with the pytest version. The pytest version skips the rest of the `section` once the first container item was encountered within a section. This version isolates the inner iteration over section items using `self.subTest`, making sure we still check the rest of the items in the section.