### PR TITLE
Fix rule alias.

### DIFF
--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -79,10 +79,10 @@ class Alias (Cog):
         """Alias for invoking <prefix>site faq."""
         await self.invoke(ctx, "site faq")
 
-    @command(name="rules", hidden=True)
-    async def site_rules_alias(self, ctx: Context) -> None:
+    @command(name="rules", aliases=("rule",), hidden=True)
+    async def site_rules_alias(self, ctx: Context, *rules: int) -> None:
         """Alias for invoking <prefix>site rules."""
-        await self.invoke(ctx, "site rules")
+        await self.invoke(ctx, "site rules", *rules)
 
     @command(name="reload", hidden=True)
     async def extensions_reload_alias(self, ctx: Context, *extensions: Extension) -> None:

--- a/bot/cogs/site.py
+++ b/bot/cogs/site.py
@@ -126,15 +126,15 @@ class Site(Cog):
         invalid_indices = tuple(
             pick
             for pick in rules
-            if pick < 0 or pick >= len(full_rules)
+            if pick < 1 or pick > len(full_rules)
         )
 
         if invalid_indices:
             indices = ', '.join(map(str, invalid_indices))
-            await ctx.send(f":x: Invalid rule indices {indices}")
+            await ctx.send(f":x: Invalid rule indices: {indices}")
             return
 
-        final_rules = tuple(f"**{pick}.** {full_rules[pick]}" for pick in rules)
+        final_rules = tuple(f"**{pick}.** {full_rules[pick - 1]}" for pick in rules)
 
         await LinePaginator.paginate(final_rules, ctx, rules_embed, max_lines=3)
 


### PR DESCRIPTION
**Closes: #536**
- Rules are now 1-indexed, so valid indices for the command are 1 to 10 inclusive.
- Allows the use of `!rule <num>` and `!rules <num>` besides `!site rule <num>`

![image](https://user-images.githubusercontent.com/41782385/66840798-2fa7b480-ef9b-11e9-93cb-79e26272d1d8.png)