### PR TITLE
Build GitHub Pages -ready auto-generated documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,76 @@
+# Python Utility Bot
+
+> Auto-generated documentation index.
+
+[![Discord](https://img.shields.io/discord/267624335836053506?color=%237289DA&label=Python%20Discord&logo=discord&logoColor=white)](https://discord.gg/2B963hn)
+[![Build Status](https://dev.azure.com/python-discord/Python%20Discord/_apis/build/status/Bot?branchName=master)](https://dev.azure.com/python-discord/Python%20Discord/_build/latest?definitionId=1&branchName=master)
+[![Tests](https://img.shields.io/azure-devops/tests/python-discord/Python%20Discord/1?compact_message)](https://dev.azure.com/python-discord/Python%20Discord/_apis/build/status/Bot?branchName=master)
+[![Coverage](https://img.shields.io/azure-devops/coverage/python-discord/Python%20Discord/1/master)](https://dev.azure.com/python-discord/Python%20Discord/_apis/build/status/Bot?branchName=master)
+[![License](https://img.shields.io/github/license/python-discord/bot)](LICENSE)
+[![Website](https://img.shields.io/badge/website-visit-brightgreen)](https://pythondiscord.com)
+
+- [Python Utility Bot](#python-utility-bot)
+  - [Modules](#modules)
+
+This project is a Discord bot specifically for use with the Python Discord server. It provides numerous utilities
+and other tools to help keep the server running like a well-oiled machine.
+
+Read the [Contributing Guide](https://pythondiscord.com/pages/contributing/bot/) on our website if you're interested in helping out.
+
+## Modules
+
+- [Bot](bot/index.md#bot)
+  - [Api](bot/api.md#api)
+  - Cogs
+    - [Alias](bot/cogs/alias.md#alias)
+    - [AntiSpam](bot/cogs/antispam.md#antispam)
+    - [Bot](bot/cogs/bot.md#bot)
+    - [Clean](bot/cogs/clean.md#clean)
+    - [Defcon](bot/cogs/defcon.md#defcon)
+    - [Doc](bot/cogs/doc.md#doc)
+    - [ErrorHandler](bot/cogs/error_handler.md#errorhandler)
+    - [Eval](bot/cogs/eval.md#eval)
+    - [Extensions](bot/cogs/extensions.md#extensions)
+    - [Filtering](bot/cogs/filtering.md#filtering)
+    - [Free](bot/cogs/free.md#free)
+    - [Help](bot/cogs/help.md#help)
+    - [Information](bot/cogs/information.md#information)
+    - [Jams](bot/cogs/jams.md#jams)
+    - [Logging](bot/cogs/logging.md#logging)
+    - [Moderation](bot/cogs/moderation/index.md#moderation)
+    - [OffTopicNames](bot/cogs/off_topic_names.md#offtopicnames)
+    - [Reddit](bot/cogs/reddit.md#reddit)
+    - [Reminders](bot/cogs/reminders.md#reminders)
+    - [Security](bot/cogs/security.md#security)
+    - [Site](bot/cogs/site.md#site)
+    - [Snekbox](bot/cogs/snekbox.md#snekbox)
+    - [Sync](bot/cogs/sync/index.md#sync)
+    - [Tags](bot/cogs/tags.md#tags)
+    - [TokenRemover](bot/cogs/token_remover.md#tokenremover)
+    - [Utils](bot/cogs/utils.md#utils)
+    - [Verification](bot/cogs/verification.md#verification)
+    - [Watchchannels](bot/cogs/watchchannels/index.md#watchchannels)
+    - [Wolfram](bot/cogs/wolfram.md#wolfram)
+  - [Constants](bot/constants.md#constants)
+  - [Converters](bot/converters.md#converters)
+  - [Decorators](bot/decorators.md#decorators)
+  - [Interpreter](bot/interpreter.md#interpreter)
+  - [Pagination](bot/pagination.md#pagination)
+  - [Patches](bot/patches/index.md#patches)
+    - [message_edited_at patch.](bot/patches/message_edited_at.md#message_edited_at-patch)
+  - [Rules](bot/rules/index.md#rules)
+    - [Attachments](bot/rules/attachments.md#attachments)
+    - [Burst](bot/rules/burst.md#burst)
+    - [Burst Shared](bot/rules/burst_shared.md#burst-shared)
+    - [Chars](bot/rules/chars.md#chars)
+    - [Discord Emojis](bot/rules/discord_emojis.md#discord-emojis)
+    - [Duplicates](bot/rules/duplicates.md#duplicates)
+    - [Links](bot/rules/links.md#links)
+    - [Mentions](bot/rules/mentions.md#mentions)
+    - [Newlines](bot/rules/newlines.md#newlines)
+    - [Role Mentions](bot/rules/role_mentions.md#role-mentions)
+  - [Utils](bot/utils/index.md#utils)
+    - [Checks](bot/utils/checks.md#checks)
+    - [Messages](bot/utils/messages.md#messages)
+    - [Scheduling](bot/utils/scheduling.md#scheduling)
+    - [Time](bot/utils/time.md#time)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-cayman

--- a/docs/bot/api.md
+++ b/docs/bot/api.md
@@ -1,0 +1,169 @@
+# Api
+
+> Auto-generated documentation for [bot.api](https://github.com/python-discord/bot/blob/master/bot/api.py) module.
+
+- [Index](../README.md#modules) / [Bot](index.md#bot) / Api
+  - [APIClient](#apiclient)
+    - [APIClient().delete](#apiclientdelete)
+    - [APIClient().get](#apiclientget)
+    - [APIClient().maybe_raise_for_status](#apiclientmaybe_raise_for_status)
+    - [APIClient().patch](#apiclientpatch)
+    - [APIClient().post](#apiclientpost)
+    - [APIClient().put](#apiclientput)
+  - [APILoggingHandler](#apilogginghandler)
+    - [APILoggingHandler().emit](#apilogginghandleremit)
+    - [APILoggingHandler().schedule_queued_tasks](#apilogginghandlerschedule_queued_tasks)
+    - [APILoggingHandler().ship_off](#apilogginghandlership_off)
+  - [ResponseCodeError](#responsecodeerror)
+  - [loop_is_running](#loop_is_running)
+
+## APIClient
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L32)
+
+```python
+class APIClient(kwargs)
+```
+
+Django Site API wrapper.
+
+### APIClient().delete
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L85)
+
+```python
+def delete(endpoint: str, args, kwargs) -> Union[dict, NoneType]
+```
+
+Site API DELETE.
+
+### APIClient().get
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L61)
+
+```python
+def get(endpoint: str, args, kwargs) -> dict
+```
+
+Site API GET.
+
+### APIClient().maybe_raise_for_status
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L51)
+
+```python
+def maybe_raise_for_status(
+    response: ClientResponse,
+    should_raise: bool,
+) -> None
+```
+
+Raise ResponseCodeError for non-OK response if an exception should be raised.
+
+### APIClient().patch
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L67)
+
+```python
+def patch(endpoint: str, args, kwargs) -> dict
+```
+
+Site API PATCH.
+
+### APIClient().post
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L73)
+
+```python
+def post(endpoint: str, args, kwargs) -> dict
+```
+
+Site API POST.
+
+### APIClient().put
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L79)
+
+```python
+def put(endpoint: str, args, kwargs) -> dict
+```
+
+Site API PUT.
+
+## APILoggingHandler
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L109)
+
+```python
+class APILoggingHandler(client: APIClient)
+```
+
+Site API logging handler.
+
+#### See also
+
+- [APIClient](#apiclient)
+
+### APILoggingHandler().emit
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L137)
+
+```python
+def emit(record: LogRecord) -> None
+```
+
+Determine if a log record should be shipped to the logging API.
+
+If the asyncio event loop is not yet running, log records will instead be put in a queue
+which will be consumed once the event loop is running.
+
+The following two conditions are set:
+    1. Do not log anything below DEBUG (only applies to the monkeypatched `TRACE` level)
+    2. Ignore log records originating from this logging handler itself to prevent infinite recursion
+
+### APILoggingHandler().schedule_queued_tasks
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L168)
+
+```python
+def schedule_queued_tasks() -> None
+```
+
+Consume the queue and schedule the logging of each queued record.
+
+### APILoggingHandler().ship_off
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L120)
+
+```python
+def ship_off(payload: dict) -> None
+```
+
+Ship log payload to the logging API.
+
+## ResponseCodeError
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L13)
+
+```python
+class ResponseCodeError(
+    response: ClientResponse,
+    response_json: Union[dict, NoneType] = None,
+    response_text: str = '',
+)
+```
+
+Raised when a non-OK HTTP response is received.
+
+## loop_is_running
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/api.py#L95)
+
+```python
+def loop_is_running() -> bool
+```
+
+Determine if there is a running asyncio event loop.
+
+This helps enable "call this when event loop is running" logic (see: Twisted's `callWhenRunning`),
+which is currently not provided by asyncio.

--- a/docs/bot/cogs/alias.md
+++ b/docs/bot/cogs/alias.md
@@ -1,0 +1,38 @@
+# Alias
+
+> Auto-generated documentation for [bot.cogs.alias](https://github.com/python-discord/bot/blob/master/bot/cogs/alias.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Alias
+  - [Alias](#alias)
+    - [Alias().invoke](#aliasinvoke)
+  - [setup](#setup)
+
+## Alias
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/alias.py#L16)
+
+```python
+class Alias(bot: Bot)
+```
+
+Aliases for commonly used commands.
+
+### Alias().invoke
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/alias.py#L22)
+
+```python
+def invoke(ctx: Context, cmd_name: str, args, kwargs) -> None
+```
+
+Invokes a command with args and kwargs.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/alias.py#L149)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Alias cog load.

--- a/docs/bot/cogs/antispam.md
+++ b/docs/bot/cogs/antispam.md
@@ -1,0 +1,145 @@
+# AntiSpam
+
+> Auto-generated documentation for [bot.cogs.antispam](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / AntiSpam
+  - [AntiSpam](#antispam)
+    - [AntiSpam().mod_log](#antispammod_log)
+    - [AntiSpam().alert_on_validation_error](#antispamalert_on_validation_error)
+    - [AntiSpam().maybe_delete_messages](#antispammaybe_delete_messages)
+    - [AntiSpam().on_message](#antispamon_message)
+    - [AntiSpam().punish](#antispampunish)
+  - [DeletionContext](#deletioncontext)
+    - [DeletionContext().add](#deletioncontextadd)
+    - [DeletionContext().upload_messages](#deletioncontextupload_messages)
+  - [setup](#setup)
+  - [validate_config](#validate_config)
+
+## AntiSpam
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L97)
+
+```python
+class AntiSpam(bot: Bot, validation_errors: bool) -> None
+```
+
+Cog that controls our anti-spam measures.
+
+### AntiSpam().mod_log
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L97)
+
+```python
+#property getter
+def mod_log() -> ModLog
+```
+
+Allows for easy access of the ModLog cog.
+
+### AntiSpam().alert_on_validation_error
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L117)
+
+```python
+def alert_on_validation_error() -> None
+```
+
+Unloads the cog and alerts admins if configuration validation failed.
+
+### AntiSpam().maybe_delete_messages
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L226)
+
+```python
+def maybe_delete_messages(
+    channel: TextChannel,
+    messages: List[discord.message.Message],
+) -> None
+```
+
+Cleans the messages if cleaning is configured.
+
+### AntiSpam().on_message
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L136)
+
+```python
+def on_message(message: Message) -> None
+```
+
+Applies the antispam rules to each received message.
+
+### AntiSpam().punish
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L207)
+
+```python
+def punish(msg: Message, member: Member, reason: str) -> None
+```
+
+Punishes the given member for triggering an antispam rule.
+
+## DeletionContext
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L40)
+
+```python
+class DeletionContext(
+    channel: TextChannel,
+    members: Dict[int, discord.member.Member] = <factory>,
+    rules: Set[str] = <factory>,
+    messages: Dict[int, discord.message.Message] = <factory>,
+) -> None
+```
+
+Represents a Deletion Context for a single spam event.
+
+### DeletionContext().add
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L48)
+
+```python
+def add(
+    rule_name: str,
+    members: Iterable[discord.member.Member],
+    messages: Iterable[discord.message.Message],
+) -> None
+```
+
+Adds new rule violation events to the deletion context.
+
+### DeletionContext().upload_messages
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L60)
+
+```python
+def upload_messages(actor_id: int, modlog: ModLog) -> None
+```
+
+Method that takes care of uploading the queue and posting modlog alert.
+
+#### See also
+
+- [ModLog](moderation/modlog.md#modlog)
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L278)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Antispam cog load.
+
+## validate_config
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/antispam.py#L257)
+
+```python
+def validate_config(
+    rules: Mapping = {'attachments': {'interval': 10, 'max': 9}, 'burst': {'interval': 10, 'max': 7}, 'burst_shared': {'interval': 10, 'max': 20}, 'chars': {'interval': 5, 'max': 3000}, 'duplicates': {'interval': 10, 'max': 3}, 'discord_emojis': {'interval': 10, 'max': 20}, 'links': {'interval': 10, 'max': 10}, 'mentions': {'interval': 10, 'max': 5}, 'newlines': {'interval': 10, 'max': 100, 'max_consecutive': 10}, 'role_mentions': {'interval': 10, 'max': 3}},
+) -> Dict[str, str]
+```
+
+Validates the antispam configs.

--- a/docs/bot/cogs/bot.md
+++ b/docs/bot/cogs/bot.md
@@ -1,0 +1,110 @@
+# Bot
+
+> Auto-generated documentation for [bot.cogs.bot](https://github.com/python-discord/bot/blob/master/bot/cogs/bot.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Bot
+  - [Bot](#bot)
+    - [Bot().codeblock_stripping](#botcodeblock_stripping)
+    - [Bot().fix_indentation](#botfix_indentation)
+    - [Bot().has_bad_ticks](#bothas_bad_ticks)
+    - [Bot().on_message](#boton_message)
+    - [Bot().on_raw_message_edit](#boton_raw_message_edit)
+    - [Bot().repl_stripping](#botrepl_stripping)
+  - [setup](#setup)
+
+## Bot
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/bot.py#L19)
+
+```python
+class Bot(bot: Bot)
+```
+
+Bot information commands.
+
+### Bot().codeblock_stripping
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/bot.py#L85)
+
+```python
+def codeblock_stripping(
+    msg: str,
+    bad_ticks: bool,
+) -> Union[Tuple[Tuple[str, ...], str], NoneType]
+```
+
+Strip msg in order to find Python code.
+
+Tries to strip out Python code out of msg and returns the stripped block or
+None if the block is a valid Python codeblock.
+
+### Bot().fix_indentation
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/bot.py#L154)
+
+```python
+def fix_indentation(msg: str) -> str
+```
+
+Attempts to fix badly indented code.
+
+### Bot().has_bad_ticks
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/bot.py#L213)
+
+```python
+def has_bad_ticks(msg: Message) -> bool
+```
+
+Check to see if msg contains ticks that aren't '`'.
+
+### Bot().on_message
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/bot.py#L223)
+
+```python
+def on_message(msg: Message) -> None
+```
+
+Detect poorly formatted Python code in new messages.
+
+If poorly formatted code is detected, send the user a helpful message explaining how to do
+properly formatted Python syntax highlighting codeblocks.
+
+### Bot().on_raw_message_edit
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/bot.py#L348)
+
+```python
+def on_raw_message_edit(payload: RawMessageUpdateEvent) -> None
+```
+
+Check to see if an edited message (previously called out) still contains poorly formatted code.
+
+### Bot().repl_stripping
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/bot.py#L193)
+
+```python
+def repl_stripping(msg: str) -> Tuple[str, bool]
+```
+
+Strip msg in order to extract Python code out of REPL output.
+
+Tries to strip out REPL Python code out of msg and returns the stripped msg.
+
+Returns True for the boolean if REPL code was found in the input msg.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/bot.py#L376)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Bot cog load.
+
+#### See also
+
+- [Bot](#bot)

--- a/docs/bot/cogs/clean.md
+++ b/docs/bot/cogs/clean.md
@@ -1,0 +1,45 @@
+# Clean
+
+> Auto-generated documentation for [bot.cogs.clean](https://github.com/python-discord/bot/blob/master/bot/cogs/clean.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Clean
+  - [Clean](#clean)
+    - [Clean().mod_log](#cleanmod_log)
+  - [setup](#setup)
+
+## Clean
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/clean.py#L19)
+
+```python
+class Clean(bot: Bot)
+```
+
+A cog that allows messages to be deleted in bulk, while applying various filters.
+
+You can delete messages sent by a specific user, messages sent by bots, all messages, or messages that match a
+specific regular expression.
+
+The deleted messages are saved and uploaded to the database via an API endpoint, and a URL is returned which can be
+used to view the messages in the Discord dark theme style.
+
+### Clean().mod_log
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/clean.py#L19)
+
+```python
+#property getter
+def mod_log() -> ModLog
+```
+
+Get currently loaded ModLog cog instance.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/clean.py#L213)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Clean cog load.

--- a/docs/bot/cogs/defcon.md
+++ b/docs/bot/cogs/defcon.md
@@ -1,0 +1,98 @@
+# Defcon
+
+> Auto-generated documentation for [bot.cogs.defcon](https://github.com/python-discord/bot/blob/master/bot/cogs/defcon.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Defcon
+  - [Defcon](#defcon)
+    - [Defcon().mod_log](#defconmod_log)
+    - [Defcon().build_defcon_msg](#defconbuild_defcon_msg)
+    - [Defcon().on_member_join](#defconon_member_join)
+    - [Defcon().send_defcon_log](#defconsend_defcon_log)
+    - [Defcon().sync_settings](#defconsync_settings)
+    - [Defcon().update_channel_topic](#defconupdate_channel_topic)
+  - [setup](#setup)
+
+## Defcon
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/defcon.py#L27)
+
+```python
+class Defcon(bot: Bot)
+```
+
+Time-sensitive server defense mechanisms.
+
+### Defcon().mod_log
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/defcon.py#L27)
+
+```python
+#property getter
+def mod_log() -> ModLog
+```
+
+Get currently loaded ModLog cog instance.
+
+### Defcon().build_defcon_msg
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/defcon.py#L226)
+
+```python
+def build_defcon_msg(change: str, e: Exception = None) -> str
+```
+
+Build in-channel response string for DEFCON action.
+
+`change` string may be one of the following: ('enabled', 'disabled', 'updated')
+
+### Defcon().on_member_join
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/defcon.py#L72)
+
+```python
+def on_member_join(member: Member) -> None
+```
+
+If DEFCON is enabled, check newly joining users to see if they meet the account age threshold.
+
+### Defcon().send_defcon_log
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/defcon.py#L250)
+
+```python
+def send_defcon_log(change: str, actor: Member, e: Exception = None) -> None
+```
+
+Send log message for DEFCON action.
+
+`change` string may be one of the following: ('enabled', 'disabled', 'updated')
+
+### Defcon().sync_settings
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/defcon.py#L45)
+
+```python
+def sync_settings() -> None
+```
+
+On cog load, try to synchronize DEFCON settings to the API.
+
+### Defcon().update_channel_topic
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/defcon.py#L215)
+
+```python
+def update_channel_topic() -> None
+```
+
+Update the #defcon channel topic with the current DEFCON status.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/defcon.py#L282)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+DEFCON cog load.

--- a/docs/bot/cogs/doc.md
+++ b/docs/bot/cogs/doc.md
@@ -1,0 +1,221 @@
+# Doc
+
+> Auto-generated documentation for [bot.cogs.doc](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Doc
+  - [Doc](#doc)
+    - [Doc().get_symbol_embed](#docget_symbol_embed)
+    - [Doc().get_symbol_html](#docget_symbol_html)
+    - [Doc().init_refresh_inventory](#docinit_refresh_inventory)
+    - [Doc().refresh_inventory](#docrefresh_inventory)
+    - [Doc().update_single](#docupdate_single)
+  - [DocMarkdownConverter](#docmarkdownconverter)
+    - [DocMarkdownConverter().convert_code](#docmarkdownconverterconvert_code)
+    - [DocMarkdownConverter().convert_pre](#docmarkdownconverterconvert_pre)
+  - [DummyObject](#dummyobject)
+  - [InventoryURL](#inventoryurl)
+    - [InventoryURL.convert](#inventoryurlconvert)
+  - [SphinxConfiguration](#sphinxconfiguration)
+  - [async_cache](#async_cache)
+  - [markdownify](#markdownify)
+  - [setup](#setup)
+
+## Doc
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L121)
+
+```python
+class Doc(bot: Bot)
+```
+
+A set of commands for querying & displaying documentation.
+
+### Doc().get_symbol_embed
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L44)
+
+```python
+def get_symbol_embed(args) -> Union[discord.embeds.Embed, NoneType]
+```
+
+Attempt to scrape and fetch the data for the given `symbol`, and build an embed from its contents.
+
+If the symbol is known, an Embed with documentation about it is returned.
+
+### Doc().get_symbol_html
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L188)
+
+```python
+def get_symbol_html(symbol: str) -> Union[Tuple[str, str], NoneType]
+```
+
+Given a Python symbol, return its signature and description.
+
+Returns a tuple in the form (str, str), or `None`.
+
+The first tuple element is the signature of the given symbol as a markup-free string, and
+the second tuple element is the description of the given symbol with HTML markup included.
+
+If the given symbol could not be found, returns `None`.
+
+### Doc().init_refresh_inventory
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L131)
+
+```python
+def init_refresh_inventory() -> None
+```
+
+Refresh documentation inventory on cog initialization.
+
+### Doc().refresh_inventory
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L164)
+
+```python
+def refresh_inventory() -> None
+```
+
+Refresh internal documentation inventory.
+
+### Doc().update_single
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L136)
+
+```python
+def update_single(
+    package_name: str,
+    base_url: str,
+    inventory_url: str,
+    config: SphinxConfiguration,
+) -> None
+```
+
+Rebuild the inventory for a single package.
+
+Where:
+    * `package_name` is the package name to use, appears in the log
+    * `base_url` is the root documentation URL for the specified package, used to build
+        absolute paths that link to specific symbols
+    * `inventory_url` is the absolute URL to the intersphinx inventory, fetched by running
+        `intersphinx.fetch_inventory` in an executor on the bot's event loop
+    * `config` is a [SphinxConfiguration](#sphinxconfiguration) instance to mock the regular sphinx
+        project layout, required for use with intersphinx
+
+#### See also
+
+- [SphinxConfiguration](#sphinxconfiguration)
+
+## DocMarkdownConverter
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L60)
+
+```python
+class DocMarkdownConverter(options)
+```
+
+Subclass markdownify's MarkdownCoverter to provide custom conversion methods.
+
+### DocMarkdownConverter().convert_code
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L63)
+
+```python
+def convert_code(el: PageElement, text: str) -> str
+```
+
+Undo [markdownify](#markdownify)s underscore escaping.
+
+### DocMarkdownConverter().convert_pre
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L67)
+
+```python
+def convert_pre(el: PageElement, text: str) -> str
+```
+
+Wrap any codeblocks in `py` for syntax highlighting.
+
+## DummyObject
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L78)
+
+```python
+class DummyObject()
+```
+
+A dummy object which supports assigning anything, which the builtin `object()` does not support normally.
+
+## InventoryURL
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L90)
+
+```python
+class InventoryURL()
+```
+
+Represents an Intersphinx inventory URL.
+
+This converter checks whether intersphinx accepts the given inventory URL, and raises
+`BadArgument` if that is not the case.
+
+Otherwise, it simply passes through the given URL.
+
+### InventoryURL.convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L100)
+
+```python
+def convert(ctx: Context, url: str) -> str
+```
+
+Convert url to Intersphinx inventory URL.
+
+## SphinxConfiguration
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L82)
+
+```python
+class SphinxConfiguration()
+```
+
+Dummy configuration for use with intersphinx.
+
+## async_cache
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L31)
+
+```python
+def async_cache(max_size: int = 128, arg_offset: int = 0) -> Callable
+```
+
+LRU cache implementation for coroutines.
+
+Once the cache exceeds the maximum size, keys are deleted in FIFO order.
+
+An offset may be optionally provided to be applied to the coroutine's arguments when creating the cache key.
+
+## markdownify
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L73)
+
+```python
+def markdownify(html: str) -> DocMarkdownConverter
+```
+
+Create a DocMarkdownConverter object from the input html.
+
+#### See also
+
+- [DocMarkdownConverter](#docmarkdownconverter)
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/doc.py#L369)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Doc cog load.

--- a/docs/bot/cogs/error_handler.md
+++ b/docs/bot/cogs/error_handler.md
@@ -1,0 +1,66 @@
+# ErrorHandler
+
+> Auto-generated documentation for [bot.cogs.error_handler](https://github.com/python-discord/bot/blob/master/bot/cogs/error_handler.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / ErrorHandler
+  - [ErrorHandler](#errorhandler)
+    - [ErrorHandler.handle_unexpected_error](#errorhandlerhandle_unexpected_error)
+    - [ErrorHandler().on_command_error](#errorhandleron_command_error)
+  - [setup](#setup)
+
+## ErrorHandler
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/error_handler.py#L26)
+
+```python
+class ErrorHandler(bot: Bot)
+```
+
+Handles errors emitted from commands.
+
+### ErrorHandler.handle_unexpected_error
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/error_handler.py#L132)
+
+```python
+def handle_unexpected_error(ctx: Context, e: CommandError) -> None
+```
+
+Generic handler for errors without an explicit handler.
+
+### ErrorHandler().on_command_error
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/error_handler.py#L32)
+
+```python
+def on_command_error(ctx: Context, e: CommandError) -> None
+```
+
+Provide generic command error handling.
+
+Error handling is deferred to any local error handler, if present.
+
+Error handling emits a single error response, prioritized as follows:
+    1. If the name fails to match a command but matches a tag, the tag is invoked
+    2. Send a BadArgument error message to the invoking context & invoke the command's help
+    3. Send a UserInputError error message to the invoking context & invoke the command's help
+    4. Send a NoPrivateMessage error message to the invoking context
+    5. Send a BotMissingPermissions error message to the invoking context
+    6. Log a MissingPermissions error, no message is sent
+    7. Send a InChannelCheckFailure error message to the invoking context
+    8. Log CheckFailure, CommandOnCooldown, and DisabledCommand errors, no message is sent
+    9. For CommandInvokeErrors, response is based on the type of error:
+        * 404: Error message is sent to the invoking context
+        * 400: Log the resopnse JSON, no message is sent
+        * 500 <= status <= 600: Error message is sent to the invoking context
+    10. Otherwise, handling is deferred to `handle_unexpected_error`
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/error_handler.py#L145)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Error handler cog load.

--- a/docs/bot/cogs/eval.md
+++ b/docs/bot/cogs/eval.md
@@ -1,0 +1,27 @@
+# Eval
+
+> Auto-generated documentation for [bot.cogs.eval](https://github.com/python-discord/bot/blob/master/bot/cogs/eval.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Eval
+  - [CodeEval](#codeeval)
+  - [setup](#setup)
+
+## CodeEval
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/eval.py#L21)
+
+```python
+class CodeEval(bot: Bot)
+```
+
+Owner and admin feature that evaluates code and returns the result to the channel.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/eval.py#L199)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Code eval cog load.

--- a/docs/bot/cogs/extensions.md
+++ b/docs/bot/cogs/extensions.md
@@ -1,0 +1,116 @@
+# Extensions
+
+> Auto-generated documentation for [bot.cogs.extensions](https://github.com/python-discord/bot/blob/master/bot/cogs/extensions.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Extensions
+  - [Action](#action)
+  - [Extension](#extension)
+    - [Extension().convert](#extensionconvert)
+  - [Extensions](#extensions)
+    - [Extensions().batch_manage](#extensionsbatch_manage)
+    - [Extensions().cog_check](#extensionscog_check)
+    - [Extensions().cog_command_error](#extensionscog_command_error)
+    - [Extensions().manage](#extensionsmanage)
+  - [setup](#setup)
+
+## Action
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/extensions.py#L25)
+
+```python
+class Action()
+```
+
+Represents an action to perform on an extension.
+
+## Extension
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/extensions.py#L34)
+
+```python
+class Extension()
+```
+
+Fully qualify the name of an extension and ensure it exists.
+
+The * and ** values bypass this when used with the reload command.
+
+### Extension().convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/extensions.py#L41)
+
+```python
+def convert(ctx: Context, argument: str) -> str
+```
+
+Fully qualify the name of an extension and ensure it exists.
+
+## Extensions
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/extensions.py#L58)
+
+```python
+class Extensions(bot: Bot)
+```
+
+Extension management commands.
+
+### Extensions().batch_manage
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/extensions.py#L163)
+
+```python
+def batch_manage(action: Action, extensions: str) -> str
+```
+
+Apply an action to multiple extensions and return a message with the results.
+
+If only one extension is given, it is deferred to `manage()`.
+
+#### See also
+
+- [Action](#action)
+
+### Extensions().cog_check
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/extensions.py#L221)
+
+```python
+def cog_check(ctx: Context) -> bool
+```
+
+Only allow moderators and core developers to invoke the commands in this cog.
+
+### Extensions().cog_command_error
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/extensions.py#L226)
+
+```python
+def cog_command_error(ctx: Context, error: Exception) -> None
+```
+
+Handle BadArgument errors locally to prevent the help command from showing.
+
+### Extensions().manage
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/extensions.py#L192)
+
+```python
+def manage(action: Action, ext: str) -> Tuple[str, Union[str, NoneType]]
+```
+
+Apply an action to an extension and return the status message and any error message.
+
+#### See also
+
+- [Action](#action)
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/extensions.py#L233)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Load the Extensions cog.

--- a/docs/bot/cogs/filtering.md
+++ b/docs/bot/cogs/filtering.md
@@ -1,0 +1,80 @@
+# Filtering
+
+> Auto-generated documentation for [bot.cogs.filtering](https://github.com/python-discord/bot/blob/master/bot/cogs/filtering.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Filtering
+  - [Filtering](#filtering)
+    - [Filtering().mod_log](#filteringmod_log)
+    - [Filtering().notify_member](#filteringnotify_member)
+    - [Filtering().on_message](#filteringon_message)
+    - [Filtering().on_message_edit](#filteringon_message_edit)
+  - [setup](#setup)
+
+## Filtering
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/filtering.py#L40)
+
+```python
+class Filtering(bot: Bot)
+```
+
+Filtering out invites, blacklisting domains, and warning us of certain regular expressions.
+
+### Filtering().mod_log
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/filtering.py#L40)
+
+```python
+#property getter
+def mod_log() -> ModLog
+```
+
+Get currently loaded ModLog cog instance.
+
+### Filtering().notify_member
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/filtering.py#L351)
+
+```python
+def notify_member(
+    filtered_member: Member,
+    reason: str,
+    channel: TextChannel,
+) -> None
+```
+
+Notify filtered_member about a moderation action with the reason str.
+
+First attempts to DM the user, fall back to in-channel notification if user has DMs disabled
+
+### Filtering().on_message
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/filtering.py#L105)
+
+```python
+def on_message(msg: Message) -> None
+```
+
+Invoke message filter for new messages.
+
+### Filtering().on_message_edit
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/filtering.py#L110)
+
+```python
+def on_message_edit(before: Message, after: Message) -> None
+```
+
+Invoke message filter for message edits.
+
+If there have been multiple edits, calculate the time delta from the previous edit.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/filtering.py#L363)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Filtering cog load.

--- a/docs/bot/cogs/free.md
+++ b/docs/bot/cogs/free.md
@@ -1,0 +1,27 @@
+# Free
+
+> Auto-generated documentation for [bot.cogs.free](https://github.com/python-discord/bot/blob/master/bot/cogs/free.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Free
+  - [Free](#free)
+  - [setup](#setup)
+
+## Free
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/free.py#L18)
+
+```python
+class Free()
+```
+
+Tries to figure out which help channels are free.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/free.py#L103)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Free cog load.

--- a/docs/bot/cogs/help.md
+++ b/docs/bot/cogs/help.md
@@ -1,0 +1,367 @@
+# Help
+
+> Auto-generated documentation for [bot.cogs.help](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Help
+  - [Cog](#cog)
+    - [Cog().commands](#cogcommands)
+    - [Cog().description](#cogdescription)
+    - [Cog().name](#cogname)
+  - [Help](#help)
+  - [HelpQueryNotFound](#helpquerynotfound)
+  - [HelpSession](#helpsession)
+    - [HelpSession().is_first_page](#helpsessionis_first_page)
+    - [HelpSession().is_last_page](#helpsessionis_last_page)
+    - [HelpSession().add_reactions](#helpsessionadd_reactions)
+    - [HelpSession().build_pages](#helpsessionbuild_pages)
+    - [HelpSession().do_back](#helpsessiondo_back)
+    - [HelpSession().do_end](#helpsessiondo_end)
+    - [HelpSession().do_first](#helpsessiondo_first)
+    - [HelpSession().do_next](#helpsessiondo_next)
+    - [HelpSession().do_stop](#helpsessiondo_stop)
+    - [HelpSession().embed_page](#helpsessionembed_page)
+    - [HelpSession().on_message_delete](#helpsessionon_message_delete)
+    - [HelpSession().on_reaction_add](#helpsessionon_reaction_add)
+    - [HelpSession().prepare](#helpsessionprepare)
+    - [HelpSession().reset_timeout](#helpsessionreset_timeout)
+    - [HelpSession.start](#helpsessionstart)
+    - [HelpSession().stop](#helpsessionstop)
+    - [HelpSession().timeout](#helpsessiontimeout)
+    - [HelpSession().update_page](#helpsessionupdate_page)
+  - [setup](#setup)
+  - [teardown](#teardown)
+  - [unload](#unload)
+
+## Cog
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L1)
+
+```python
+class Cog()
+```
+
+Cog(name, description, commands)
+
+### Cog().commands
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(2)()
+```
+
+Alias for field number 2
+
+### Cog().description
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(1)()
+```
+
+Alias for field number 1
+
+### Cog().name
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(0)()
+```
+
+Alias for field number 0
+
+## Help
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L504)
+
+```python
+class Help()
+```
+
+Custom Embed Pagination Help feature.
+
+## HelpQueryNotFound
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L32)
+
+```python
+class HelpQueryNotFound(arg: str, possible_matches: dict = None)
+```
+
+Raised when a HelpSession Query doesn't match a command or cog.
+
+Contains the custom attribute of ``possible_matches``.
+
+Instances of this object contain a dictionary of any command(s) that were close to matching the
+query, where keys are the possible matched command names and values are the likeness match scores.
+
+## HelpSession
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L47)
+
+```python
+class HelpSession(ctx: Context, command)
+```
+
+An interactive session for bot and command help output.
+
+Expected attributes include:
+    * title: str
+        The title of the help message.
+    * query: Union[discord.ext.commands.Bot, discord.ext.commands.Command]
+    * description: str
+        The description of the query.
+    * pages: list[str]
+        A list of the help content split into manageable pages.
+    * message: `discord.Message`
+        The message object that's showing the help contents.
+    * destination: `discord.abc.Messageable`
+        Where the help message is to be sent to.
+
+Cogs can be grouped into custom categories. All cogs with the same category will be displayed
+under a single category name in the help output. Custom categories are defined inside the cogs
+as a class attribute named `category`. A description can also be specified with the attribute
+`category_description`. If a description is not found in at least one cog, the default will be
+the regular description (class docstring) of the first cog found in the category.
+
+### HelpSession().is_first_page
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L47)
+
+```python
+#property getter
+def is_first_page() -> bool
+```
+
+Check if session is currently showing the first page.
+
+### HelpSession().is_last_page
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L47)
+
+```python
+#property getter
+def is_last_page() -> bool
+```
+
+Check if the session is currently showing the last page.
+
+### HelpSession().add_reactions
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L217)
+
+```python
+def add_reactions() -> None
+```
+
+Adds the relevant reactions to the help message based on if pagination is required.
+
+### HelpSession().build_pages
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L279)
+
+```python
+def build_pages() -> None
+```
+
+Builds the list of content pages to be paginated through in the help message, as a list of str.
+
+### HelpSession().do_back
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L484)
+
+```python
+def do_back() -> None
+```
+
+Event that is called when the user requests the previous page.
+
+### HelpSession().do_end
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L494)
+
+```python
+def do_end() -> None
+```
+
+Event that is called when the user requests the last page.
+
+### HelpSession().do_first
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L479)
+
+```python
+def do_first() -> None
+```
+
+Event that is called when the user requests the first page.
+
+### HelpSession().do_next
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L489)
+
+```python
+def do_next() -> None
+```
+
+Event that is called when the user requests the next page.
+
+### HelpSession().do_stop
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L499)
+
+```python
+def do_stop() -> None
+```
+
+Event that is called when the user requests to stop the help session.
+
+### HelpSession().embed_page
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L407)
+
+```python
+def embed_page(page_number: int = 0) -> Embed
+```
+
+Returns an Embed with the requested page formatted within.
+
+### HelpSession().on_message_delete
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L199)
+
+```python
+def on_message_delete(message: Message) -> None
+```
+
+Closes the help session when the help message is deleted.
+
+### HelpSession().on_reaction_add
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L172)
+
+```python
+def on_reaction_add(reaction: Reaction, user: User) -> None
+```
+
+Event handler for when reactions are added on the help message.
+
+### HelpSession().prepare
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L204)
+
+```python
+def prepare() -> None
+```
+
+Sets up the help session pages, events, message and reactions.
+
+### HelpSession().reset_timeout
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L162)
+
+```python
+def reset_timeout() -> None
+```
+
+Cancels the original timeout task and sets it again from the start.
+
+### HelpSession.start
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L437)
+
+```python
+def start(ctx: Context, command, options) -> HelpSession
+```
+
+Create and begin a help session based on the given command context.
+
+Available options kwargs:
+    * cleanup: Optional[bool]
+        Set to `True` to have the message deleted on session end. Defaults to `False`.
+    * only_can_run: Optional[bool]
+        Set to `True` to hide commands the user can't run. Defaults to `False`.
+    * show_hidden: Optional[bool]
+        Set to `True` to include hidden commands. Defaults to `False`.
+    * max_lines: Optional[int]
+        Sets the max number of lines the paginator will add to a single page. Defaults to 20.
+
+### HelpSession().stop
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L457)
+
+```python
+def stop() -> None
+```
+
+Stops the help session, removes event listeners and attempts to delete the help message.
+
+### HelpSession().timeout
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L157)
+
+```python
+def timeout(seconds: int = 30) -> None
+```
+
+Waits for a set number of seconds, then stops the help session.
+
+### HelpSession().update_page
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L427)
+
+```python
+def update_page(page_number: int = 0) -> None
+```
+
+Sends the intial message, or changes the existing one to the given page number.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L535)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+The setup for the help extension.
+
+This is called automatically on `bot.load_extension` being run.
+
+Stores the original help command instance on the `bot._old_help` attribute for later
+reinstatement, before removing it from the command registry so the new help command can be
+loaded successfully.
+
+If an exception is raised during the loading of the cog, [unload](#unload) will be called in order to
+reinstate the original help command.
+
+## teardown
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L558)
+
+```python
+def teardown(bot: Bot) -> None
+```
+
+The teardown for the help extension.
+
+This is called automatically on `bot.unload_extension` being run.
+
+Calls [unload](#unload) in order to reinstate the original help command.
+
+## unload
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/help.py#L525)
+
+```python
+def unload(bot: Bot) -> None
+```
+
+Reinstates the original help command.
+
+This is run if the cog raises an exception on load, or if the extension is unloaded.

--- a/docs/bot/cogs/information.md
+++ b/docs/bot/cogs/information.md
@@ -1,0 +1,41 @@
+# Information
+
+> Auto-generated documentation for [bot.cogs.information](https://github.com/python-discord/bot/blob/master/bot/cogs/information.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Information
+  - [Information](#information)
+    - [Information().format_fields](#informationformat_fields)
+  - [setup](#setup)
+
+## Information
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/information.py#L21)
+
+```python
+class Information(bot: Bot)
+```
+
+A cog with commands for generating embeds with server info, such as server stats and user info.
+
+### Information().format_fields
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/information.py#L236)
+
+```python
+def format_fields(
+    mapping: Mapping[str, Any],
+    field_width: Union[int, NoneType] = None,
+) -> str
+```
+
+Format a mapping to be readable to a human.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/information.py#L313)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Information cog load.

--- a/docs/bot/cogs/jams.md
+++ b/docs/bot/cogs/jams.md
@@ -1,0 +1,27 @@
+# Jams
+
+> Auto-generated documentation for [bot.cogs.jams](https://github.com/python-discord/bot/blob/master/bot/cogs/jams.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Jams
+  - [CodeJams](#codejams)
+  - [setup](#setup)
+
+## CodeJams
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/jams.py#L13)
+
+```python
+class CodeJams(bot: Bot)
+```
+
+Manages the code-jam related parts of our server.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/jams.py#L111)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Code Jams cog load.

--- a/docs/bot/cogs/logging.md
+++ b/docs/bot/cogs/logging.md
@@ -1,0 +1,38 @@
+# Logging
+
+> Auto-generated documentation for [bot.cogs.logging](https://github.com/python-discord/bot/blob/master/bot/cogs/logging.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Logging
+  - [Logging](#logging)
+    - [Logging().startup_greeting](#loggingstartup_greeting)
+  - [setup](#setup)
+
+## Logging
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/logging.py#L12)
+
+```python
+class Logging(bot: Bot)
+```
+
+Debug logging module.
+
+### Logging().startup_greeting
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/logging.py#L20)
+
+```python
+def startup_greeting() -> None
+```
+
+Announce our presence to the configured devlog channel.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/logging.py#L39)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Logging cog load.

--- a/docs/bot/cogs/moderation/index.md
+++ b/docs/bot/cogs/moderation/index.md
@@ -1,0 +1,22 @@
+# Moderation
+
+> Auto-generated documentation for [bot.cogs.moderation](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/__init__.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / Moderation
+  - [setup](#setup)
+  - Modules
+    - [Infractions](infractions.md#infractions)
+    - [Management](management.md#management)
+    - [ModLog](modlog.md#modlog)
+    - [Superstarify](superstarify.md#superstarify)
+    - [Utils](utils.md#utils)
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/__init__.py#L13)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Load the moderation extension (Infractions, ModManagement, ModLog, & Superstarify cogs).

--- a/docs/bot/cogs/moderation/infractions.md
+++ b/docs/bot/cogs/moderation/infractions.md
@@ -1,0 +1,180 @@
+# Infractions
+
+> Auto-generated documentation for [bot.cogs.moderation.infractions](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / [Moderation](index.md#moderation) / Infractions
+  - [Infractions](#infractions)
+    - [Infractions().description](#infractionsdescription)
+    - [Infractions().mod_log](#infractionsmod_log)
+    - [Infractions().qualified_name](#infractionsqualified_name)
+    - [Infractions().apply_ban](#infractionsapply_ban)
+    - [Infractions().apply_infraction](#infractionsapply_infraction)
+    - [Infractions().apply_kick](#infractionsapply_kick)
+    - [Infractions().apply_mute](#infractionsapply_mute)
+    - [Infractions().cog_check](#infractionscog_check)
+    - [Infractions().cog_command_error](#infractionscog_command_error)
+    - [Infractions().deactivate_infraction](#infractionsdeactivate_infraction)
+    - [Infractions().on_member_join](#infractionson_member_join)
+    - [Infractions().pardon_infraction](#infractionspardon_infraction)
+    - [Infractions().reschedule_infractions](#infractionsreschedule_infractions)
+
+## Infractions
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L28)
+
+```python
+class Infractions(bot: Bot)
+```
+
+Apply and pardon infractions on users for moderation purposes.
+
+### Infractions().description
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L28)
+
+```python
+#property getter
+def description()
+```
+
+class `str`: Returns the cog's description, typically the cleaned docstring.
+
+### Infractions().mod_log
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L28)
+
+```python
+#property getter
+def mod_log() -> ModLog
+```
+
+Get currently loaded ModLog cog instance.
+
+### Infractions().qualified_name
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L28)
+
+```python
+#property getter
+def qualified_name()
+```
+
+class `str`: Returns the cog's specified name, not the class name.
+
+### Infractions().apply_ban
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L162)
+
+```python
+def apply_ban(ctx: Context, args, kwargs) -> None
+```
+
+Apply a ban infraction with kwargs passed to `post_infraction`.
+
+### Infractions().apply_infraction
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L421)
+
+```python
+def apply_infraction(
+    ctx: Context,
+    infraction: Dict[str, Union[str, int, bool]],
+    user: Union[discord.member.Member, discord.user.User, discord.object.Object],
+    action_coro: Union[Awaitable, NoneType] = None,
+) -> None
+```
+
+Apply an infraction to the user, log the infraction, and optionally notify the user.
+
+### Infractions().apply_kick
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L162)
+
+```python
+def apply_kick(ctx: Context, args, kwargs) -> None
+```
+
+Apply a kick infraction with kwargs passed to `post_infraction`.
+
+### Infractions().apply_mute
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L238)
+
+```python
+def apply_mute(ctx: Context, user: Member, reason: str, kwargs) -> None
+```
+
+Apply a mute infraction with kwargs passed to `post_infraction`.
+
+### Infractions().cog_check
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L597)
+
+```python
+def cog_check(ctx: Context) -> bool
+```
+
+Only allow moderators to invoke the commands in this cog.
+
+### Infractions().cog_command_error
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L602)
+
+```python
+def cog_command_error(ctx: Context, error: Exception) -> None
+```
+
+Send a notification to the invoking context on a Union failure.
+
+### Infractions().deactivate_infraction
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L297)
+
+```python
+def deactivate_infraction(
+    infraction: Dict[str, Union[str, int, bool]],
+    send_log: bool = True,
+) -> Dict[str, str]
+```
+
+Deactivate an active infraction and return a dictionary of lines to send in a mod log.
+
+The infraction is removed from Discord, marked as inactive in the database, and has its
+expiration task cancelled. If `send_log` is True, a mod log is sent for the
+deactivation of the infraction.
+
+Supported infraction types are mute and ban. Other types will raise a ValueError.
+
+### Infractions().on_member_join
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L60)
+
+```python
+def on_member_join(member: Member) -> None
+```
+
+Reapply active mute infractions for returning members.
+
+### Infractions().pardon_infraction
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L503)
+
+```python
+def pardon_infraction(
+    ctx: Context,
+    infr_type: str,
+    user: Union[discord.member.Member, discord.user.User, discord.object.Object],
+) -> None
+```
+
+Prematurely end an infraction for a user and log the action in the mod log.
+
+### Infractions().reschedule_infractions
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/infractions.py#L48)
+
+```python
+def reschedule_infractions() -> None
+```
+
+Schedule expiration for previous infractions.

--- a/docs/bot/cogs/moderation/management.md
+++ b/docs/bot/cogs/moderation/management.md
@@ -1,0 +1,99 @@
+# Management
+
+> Auto-generated documentation for [bot.cogs.moderation.management](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/management.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / [Moderation](index.md#moderation) / Management
+  - [ModManagement](#modmanagement)
+    - [ModManagement().infractions_cog](#modmanagementinfractions_cog)
+    - [ModManagement().mod_log](#modmanagementmod_log)
+    - [ModManagement().cog_check](#modmanagementcog_check)
+    - [ModManagement().cog_command_error](#modmanagementcog_command_error)
+    - [ModManagement().infraction_to_string](#modmanagementinfraction_to_string)
+    - [ModManagement().send_infraction_list](#modmanagementsend_infraction_list)
+  - [permanent_duration](#permanent_duration)
+
+## ModManagement
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/management.py#L33)
+
+```python
+class ModManagement(bot: Bot)
+```
+
+Management of infractions.
+
+### ModManagement().infractions_cog
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/management.py#L33)
+
+```python
+#property getter
+def infractions_cog() -> Infractions
+```
+
+Get currently loaded Infractions cog instance.
+
+### ModManagement().mod_log
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/management.py#L33)
+
+```python
+#property getter
+def mod_log() -> ModLog
+```
+
+Get currently loaded ModLog cog instance.
+
+### ModManagement().cog_check
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/management.py#L258)
+
+```python
+def cog_check(ctx: Context) -> bool
+```
+
+Only allow moderators to invoke the commands in this cog.
+
+### ModManagement().cog_command_error
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/management.py#L263)
+
+```python
+def cog_command_error(ctx: Context, error: Exception) -> None
+```
+
+Send a notification to the invoking context on a Union failure.
+
+### ModManagement().infraction_to_string
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/management.py#L225)
+
+```python
+def infraction_to_string(infraction: Dict[str, Union[str, int, bool]]) -> str
+```
+
+Convert the infraction object to a string representation.
+
+### ModManagement().send_infraction_list
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/management.py#L200)
+
+```python
+def send_infraction_list(
+    ctx: Context,
+    embed: Embed,
+    infractions: Iterable[Dict[str, Union[str, int, bool]]],
+) -> None
+```
+
+Send a paginated embed of infractions for the specified user.
+
+## permanent_duration
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/management.py#L24)
+
+```python
+def permanent_duration(expires_at: str) -> str
+```
+
+Only allow an expiration to be 'permanent' if it is a string.

--- a/docs/bot/cogs/moderation/modlog.md
+++ b/docs/bot/cogs/moderation/modlog.md
@@ -1,0 +1,257 @@
+# ModLog
+
+> Auto-generated documentation for [bot.cogs.moderation.modlog](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / [Moderation](index.md#moderation) / ModLog
+  - [ModLog](#modlog)
+    - [ModLog().ignore](#modlogignore)
+    - [ModLog().on_guild_channel_create](#modlogon_guild_channel_create)
+    - [ModLog().on_guild_channel_delete](#modlogon_guild_channel_delete)
+    - [ModLog().on_guild_channel_update](#modlogon_guild_channel_update)
+    - [ModLog().on_guild_role_create](#modlogon_guild_role_create)
+    - [ModLog().on_guild_role_delete](#modlogon_guild_role_delete)
+    - [ModLog().on_guild_role_update](#modlogon_guild_role_update)
+    - [ModLog().on_guild_update](#modlogon_guild_update)
+    - [ModLog().on_member_ban](#modlogon_member_ban)
+    - [ModLog().on_member_join](#modlogon_member_join)
+    - [ModLog().on_member_remove](#modlogon_member_remove)
+    - [ModLog().on_member_unban](#modlogon_member_unban)
+    - [ModLog().on_member_update](#modlogon_member_update)
+    - [ModLog().on_message_delete](#modlogon_message_delete)
+    - [ModLog().on_message_edit](#modlogon_message_edit)
+    - [ModLog().on_raw_message_delete](#modlogon_raw_message_delete)
+    - [ModLog().on_raw_message_edit](#modlogon_raw_message_edit)
+    - [ModLog().send_log_message](#modlogsend_log_message)
+    - [ModLog().upload_log](#modlogupload_log)
+
+## ModLog
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L27)
+
+```python
+class ModLog(bot: Bot)
+```
+
+Logging for server events and staff actions.
+
+### ModLog().ignore
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L65)
+
+```python
+def ignore(event: Event, items: int) -> None
+```
+
+Add event to ignored events to suppress log emission.
+
+#### See also
+
+- [Event](../../constants.md#event)
+
+### ModLog().on_guild_channel_create
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L119)
+
+```python
+def on_guild_channel_create(
+    channel: Union[discord.channel.CategoryChannel, discord.channel.TextChannel, discord.channel.VoiceChannel],
+) -> None
+```
+
+Log channel create event to mod log.
+
+### ModLog().on_guild_channel_delete
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L145)
+
+```python
+def on_guild_channel_delete(
+    channel: Union[discord.channel.CategoryChannel, discord.channel.TextChannel, discord.channel.VoiceChannel],
+) -> None
+```
+
+Log channel delete event to mod log.
+
+### ModLog().on_guild_channel_update
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L168)
+
+```python
+def on_guild_channel_update(
+    before: Union[discord.channel.CategoryChannel, discord.channel.TextChannel, discord.channel.VoiceChannel],
+    after: GuildChannel,
+) -> None
+```
+
+Log channel update event to mod log.
+
+### ModLog().on_guild_role_create
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L228)
+
+```python
+def on_guild_role_create(role: Role) -> None
+```
+
+Log role create event to mod log.
+
+### ModLog().on_guild_role_delete
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L239)
+
+```python
+def on_guild_role_delete(role: Role) -> None
+```
+
+Log role delete event to mod log.
+
+### ModLog().on_guild_role_update
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L250)
+
+```python
+def on_guild_role_update(before: Role, after: Role) -> None
+```
+
+Log role update event to mod log.
+
+### ModLog().on_guild_update
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L303)
+
+```python
+def on_guild_update(before: Guild, after: Guild) -> None
+```
+
+Log guild update event to mod log.
+
+### ModLog().on_member_ban
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L354)
+
+```python
+def on_member_ban(
+    guild: Guild,
+    member: Union[discord.member.Member, discord.user.User],
+) -> None
+```
+
+Log ban event to user log.
+
+### ModLog().on_member_join
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L371)
+
+```python
+def on_member_join(member: Member) -> None
+```
+
+Log member join event to user log.
+
+### ModLog().on_member_remove
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L393)
+
+```python
+def on_member_remove(member: Member) -> None
+```
+
+Log member leave event to user log.
+
+### ModLog().on_member_unban
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L410)
+
+```python
+def on_member_unban(guild: Guild, member: User) -> None
+```
+
+Log member unban event to mod log.
+
+### ModLog().on_member_update
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L427)
+
+```python
+def on_member_update(before: Member, after: Member) -> None
+```
+
+Log member update event to user log.
+
+### ModLog().on_message_delete
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L523)
+
+```python
+def on_message_delete(message: Message) -> None
+```
+
+Log message delete event to message change log.
+
+### ModLog().on_message_edit
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L620)
+
+```python
+def on_message_edit(before: Message, after: Message) -> None
+```
+
+Log message edit event to message change log.
+
+### ModLog().on_raw_message_delete
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L579)
+
+```python
+def on_raw_message_delete(event: RawMessageDeleteEvent) -> None
+```
+
+Log raw message delete event to message change log.
+
+### ModLog().on_raw_message_edit
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L695)
+
+```python
+def on_raw_message_edit(event: RawMessageUpdateEvent) -> None
+```
+
+Log raw message edit event to message change log.
+
+### ModLog().send_log_message
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L71)
+
+```python
+def send_log_message(
+    icon_url: Union[str, NoneType],
+    colour: Union[discord.colour.Colour, int],
+    title: Union[str, NoneType],
+    text: str,
+    thumbnail: Union[str, discord.asset.Asset, NoneType] = None,
+    channel_id: int = 282638479504965634,
+    ping_everyone: bool = False,
+    files: Union[List[discord.file.File], NoneType] = None,
+    content: Union[str, NoneType] = None,
+    additional_embeds: Union[List[discord.embeds.Embed], NoneType] = None,
+    additional_embeds_msg: Union[str, NoneType] = None,
+    timestamp_override: Union[datetime.datetime, NoneType] = None,
+    footer: Union[str, NoneType] = None,
+) -> Context
+```
+
+Generate log embed and send to logging channel.
+
+### ModLog().upload_log
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/modlog.py#L37)
+
+```python
+def upload_log(messages: List[discord.message.Message], actor_id: int) -> str
+```
+
+Uploads the log data to the database via an API endpoint for uploading logs.
+
+Used in several mod log embeds.
+
+Returns a URL that can be used to view the log.

--- a/docs/bot/cogs/moderation/superstarify.md
+++ b/docs/bot/cogs/moderation/superstarify.md
@@ -1,0 +1,79 @@
+# Superstarify
+
+> Auto-generated documentation for [bot.cogs.moderation.superstarify](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/superstarify.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / [Moderation](index.md#moderation) / Superstarify
+  - [Superstarify](#superstarify)
+    - [Superstarify().modlog](#superstarifymodlog)
+    - [Superstarify().cog_check](#superstarifycog_check)
+    - [Superstarify.get_nick](#superstarifyget_nick)
+    - [Superstarify().on_member_join](#superstarifyon_member_join)
+    - [Superstarify().on_member_update](#superstarifyon_member_update)
+
+## Superstarify
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/superstarify.py#L23)
+
+```python
+class Superstarify(bot: Bot)
+```
+
+A set of commands to moderate terrible nicknames.
+
+### Superstarify().modlog
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/superstarify.py#L23)
+
+```python
+#property getter
+def modlog() -> ModLog
+```
+
+Get currently loaded ModLog cog instance.
+
+### Superstarify().cog_check
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/superstarify.py#L257)
+
+```python
+def cog_check(ctx: Context) -> bool
+```
+
+Only allow moderators to invoke the commands in this cog.
+
+### Superstarify.get_nick
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/superstarify.py#L250)
+
+```python
+def get_nick(infraction_id: int, member_id: int) -> str
+```
+
+Randomly select a nickname from the Superstarify nickname list.
+
+### Superstarify().on_member_join
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/superstarify.py#L89)
+
+```python
+def on_member_join(member: Member) -> None
+```
+
+This event will trigger when someone (re)joins the server.
+
+At this point we will look up the user in our database and check whether they are in
+superstar-prison. If so, we will change their name back to the forced nickname.
+
+### Superstarify().on_member_update
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/superstarify.py#L34)
+
+```python
+def on_member_update(before: Member, after: Member) -> None
+```
+
+This event will trigger when someone changes their name.
+
+At this point we will look up the user in our database and check whether they are allowed to
+change their names, or if they are in superstar-prison. If they are not allowed, we will
+change it back.

--- a/docs/bot/cogs/moderation/utils.md
+++ b/docs/bot/cogs/moderation/utils.md
@@ -1,0 +1,101 @@
+# Utils
+
+> Auto-generated documentation for [bot.cogs.moderation.utils](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/utils.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / [Moderation](index.md#moderation) / Utils
+  - [has_active_infraction](#has_active_infraction)
+  - [notify_infraction](#notify_infraction)
+  - [notify_pardon](#notify_pardon)
+  - [post_infraction](#post_infraction)
+  - [proxy_user](#proxy_user)
+  - [send_private_embed](#send_private_embed)
+
+## has_active_infraction
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/utils.py#L92)
+
+```python
+def has_active_infraction(
+    ctx: Context,
+    user: Union[discord.member.Member, discord.user.User, discord.object.Object],
+    infr_type: str,
+) -> bool
+```
+
+Checks if a user already has an active infraction of the given type.
+
+## notify_infraction
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/utils.py#L112)
+
+```python
+def notify_infraction(
+    user: Union[discord.member.Member, discord.user.User],
+    infr_type: str,
+    expires_at: Union[str, NoneType] = None,
+    reason: Union[str, NoneType] = None,
+    icon_url: str = 'https://cdn.discordapp.com/emojis/470326273298792469.png',
+) -> bool
+```
+
+DM a user about their new infraction and return True if the DM is successful.
+
+## notify_pardon
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/utils.py#L141)
+
+```python
+def notify_pardon(
+    user: Union[discord.member.Member, discord.user.User],
+    title: str,
+    content: str,
+    icon_url: str = 'https://cdn.discordapp.com/emojis/470326274519334936.png',
+) -> bool
+```
+
+DM a user about their pardoned infraction and return True if the DM is successful.
+
+## post_infraction
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/utils.py#L51)
+
+```python
+def post_infraction(
+    ctx: Context,
+    user: Union[discord.member.Member, discord.user.User, discord.object.Object],
+    infr_type: str,
+    reason: str,
+    expires_at: datetime = None,
+    hidden: bool = False,
+    active: bool = True,
+) -> Union[dict, NoneType]
+```
+
+Posts an infraction to the API.
+
+## proxy_user
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/utils.py#L33)
+
+```python
+def proxy_user(user_id: str) -> Object
+```
+
+Create a proxy user object from the given id.
+
+Used when a Member or User object cannot be resolved.
+
+## send_private_embed
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/moderation/utils.py#L158)
+
+```python
+def send_private_embed(
+    user: Union[discord.member.Member, discord.user.User],
+    embed: Embed,
+) -> bool
+```
+
+A helper method for sending an embed to a user's DMs.
+
+Returns a boolean indicator of DM success.

--- a/docs/bot/cogs/off_topic_names.md
+++ b/docs/bot/cogs/off_topic_names.md
@@ -1,0 +1,82 @@
+# OffTopicNames
+
+> Auto-generated documentation for [bot.cogs.off_topic_names](https://github.com/python-discord/bot/blob/master/bot/cogs/off_topic_names.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / OffTopicNames
+  - [OffTopicName](#offtopicname)
+    - [OffTopicName.convert](#offtopicnameconvert)
+  - [OffTopicNames](#offtopicnames)
+    - [OffTopicNames().cog_unload](#offtopicnamescog_unload)
+    - [OffTopicNames().init_offtopic_updater](#offtopicnamesinit_offtopic_updater)
+  - [setup](#setup)
+  - [update_names](#update_names)
+
+## OffTopicName
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/off_topic_names.py#L19)
+
+```python
+class OffTopicName()
+```
+
+A converter that ensures an added off-topic name is valid.
+
+### OffTopicName.convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/off_topic_names.py#L22)
+
+```python
+def convert(ctx: Context, argument: str) -> str
+```
+
+Attempt to replace any invalid characters with their approximate Unicode equivalent.
+
+## OffTopicNames
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/off_topic_names.py#L71)
+
+```python
+class OffTopicNames(bot: Bot)
+```
+
+Commands related to managing the off-topic category channel names.
+
+### OffTopicNames().cog_unload
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/off_topic_names.py#L80)
+
+```python
+def cog_unload() -> None
+```
+
+Cancel any running updater tasks on cog unload.
+
+### OffTopicNames().init_offtopic_updater
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/off_topic_names.py#L85)
+
+```python
+def init_offtopic_updater() -> None
+```
+
+Start off-topic channel updating event loop if it hasn't already started.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/off_topic_names.py#L190)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Off topic names cog load.
+
+## update_names
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/off_topic_names.py#L43)
+
+```python
+def update_names(bot: Bot) -> None
+```
+
+Background updater task that performs the daily channel name update.

--- a/docs/bot/cogs/reddit.md
+++ b/docs/bot/cogs/reddit.md
@@ -1,0 +1,91 @@
+# Reddit
+
+> Auto-generated documentation for [bot.cogs.reddit](https://github.com/python-discord/bot/blob/master/bot/cogs/reddit.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Reddit
+  - [Reddit](#reddit)
+    - [Reddit().fetch_posts](#redditfetch_posts)
+    - [Reddit().init_reddit_polling](#redditinit_reddit_polling)
+    - [Reddit().poll_new_posts](#redditpoll_new_posts)
+    - [Reddit().poll_top_weekly_posts](#redditpoll_top_weekly_posts)
+    - [Reddit().send_top_posts](#redditsend_top_posts)
+  - [setup](#setup)
+
+## Reddit
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reddit.py#L19)
+
+```python
+class Reddit(bot: Bot)
+```
+
+Track subreddit posts and show detailed statistics about them.
+
+### Reddit().fetch_posts
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reddit.py#L39)
+
+```python
+def fetch_posts(route: str) -> List[dict]
+```
+
+A helper method to fetch a certain amount of Reddit posts at a given route.
+
+### Reddit().init_reddit_polling
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reddit.py#L267)
+
+```python
+def init_reddit_polling() -> None
+```
+
+Initiate reddit post event loop.
+
+### Reddit().poll_new_posts
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reddit.py#L124)
+
+```python
+def poll_new_posts() -> None
+```
+
+Periodically search for new subreddit posts.
+
+### Reddit().poll_top_weekly_posts
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reddit.py#L185)
+
+```python
+def poll_top_weekly_posts() -> None
+```
+
+Post a summary of the top posts every week.
+
+### Reddit().send_top_posts
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reddit.py#L66)
+
+```python
+def send_top_posts(
+    channel: TextChannel,
+    subreddit: Subreddit,
+    content: str = None,
+    time: str = 'all',
+) -> Message
+```
+
+Create an embed for the top posts, then send it in a given TextChannel.
+
+#### See also
+
+- [Subreddit](../converters.md#subreddit)
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reddit.py#L281)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Reddit cog load.

--- a/docs/bot/cogs/reminders.md
+++ b/docs/bot/cogs/reminders.md
@@ -1,0 +1,73 @@
+# Reminders
+
+> Auto-generated documentation for [bot.cogs.reminders](https://github.com/python-discord/bot/blob/master/bot/cogs/reminders.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Reminders
+  - [Reminders](#reminders)
+    - [Reminders().description](#remindersdescription)
+    - [Reminders().qualified_name](#remindersqualified_name)
+    - [Reminders().reschedule_reminders](#remindersreschedule_reminders)
+    - [Reminders().send_reminder](#reminderssend_reminder)
+  - [setup](#setup)
+
+## Reminders
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reminders.py#L26)
+
+```python
+class Reminders(bot: Bot)
+```
+
+Provide in-channel reminder functionality.
+
+### Reminders().description
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reminders.py#L26)
+
+```python
+#property getter
+def description()
+```
+
+class `str`: Returns the cog's description, typically the cleaned docstring.
+
+### Reminders().qualified_name
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reminders.py#L26)
+
+```python
+#property getter
+def qualified_name()
+```
+
+class `str`: Returns the cog's specified name, not the class name.
+
+### Reminders().reschedule_reminders
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reminders.py#L35)
+
+```python
+def reschedule_reminders() -> None
+```
+
+Get all current reminders from the API and reschedule them.
+
+### Reminders().send_reminder
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reminders.py#L95)
+
+```python
+def send_reminder(reminder: dict, late: relativedelta = None) -> None
+```
+
+Send the reminder.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/reminders.py#L285)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Reminders cog load.

--- a/docs/bot/cogs/security.md
+++ b/docs/bot/cogs/security.md
@@ -1,0 +1,49 @@
+# Security
+
+> Auto-generated documentation for [bot.cogs.security](https://github.com/python-discord/bot/blob/master/bot/cogs/security.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Security
+  - [Security](#security)
+    - [Security().check_not_bot](#securitycheck_not_bot)
+    - [Security().check_on_guild](#securitycheck_on_guild)
+  - [setup](#setup)
+
+## Security
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/security.py#L8)
+
+```python
+class Security(bot: Bot)
+```
+
+Security-related helpers.
+
+### Security().check_not_bot
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/security.py#L16)
+
+```python
+def check_not_bot(ctx: Context) -> bool
+```
+
+Check if the context is a bot user.
+
+### Security().check_on_guild
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/security.py#L20)
+
+```python
+def check_on_guild(ctx: Context) -> bool
+```
+
+Check if the context is in a guild.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/security.py#L27)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Security cog load.

--- a/docs/bot/cogs/site.md
+++ b/docs/bot/cogs/site.md
@@ -1,0 +1,27 @@
+# Site
+
+> Auto-generated documentation for [bot.cogs.site](https://github.com/python-discord/bot/blob/master/bot/cogs/site.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Site
+  - [Site](#site)
+  - [setup](#setup)
+
+## Site
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/site.py#L15)
+
+```python
+class Site(bot: Bot)
+```
+
+Commands for linking to different parts of the site.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/site.py#L142)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Site cog load.

--- a/docs/bot/cogs/snekbox.md
+++ b/docs/bot/cogs/snekbox.md
@@ -1,0 +1,85 @@
+# Snekbox
+
+> Auto-generated documentation for [bot.cogs.snekbox](https://github.com/python-discord/bot/blob/master/bot/cogs/snekbox.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Snekbox
+  - [Snekbox](#snekbox)
+    - [Snekbox().format_output](#snekboxformat_output)
+    - [Snekbox.get_results_message](#snekboxget_results_message)
+    - [Snekbox().post_eval](#snekboxpost_eval)
+    - [Snekbox.prepare_input](#snekboxprepare_input)
+    - [Snekbox().upload_output](#snekboxupload_output)
+  - [setup](#setup)
+
+## Snekbox
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/snekbox.py#L39)
+
+```python
+class Snekbox(bot: Bot)
+```
+
+Safe evaluation of Python code using Snekbox.
+
+### Snekbox().format_output
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/snekbox.py#L118)
+
+```python
+def format_output(output: str) -> Tuple[str, Union[str, NoneType]]
+```
+
+Format the output and return a tuple of the formatted output and a URL to the full output.
+
+Prepend each line with a line number. Truncate if there are over 10 lines or 1000 characters
+and upload the full output to a paste service.
+
+### Snekbox.get_results_message
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/snekbox.py#L93)
+
+```python
+def get_results_message(results: dict) -> Tuple[str, str]
+```
+
+Return a user-friendly message and error corresponding to the process's return code.
+
+### Snekbox().post_eval
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/snekbox.py#L46)
+
+```python
+def post_eval(code: str) -> dict
+```
+
+Send a POST request to the Snekbox API to evaluate code and return the results.
+
+### Snekbox.prepare_input
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/snekbox.py#L72)
+
+```python
+def prepare_input(code: str) -> str
+```
+
+Extract code from the Markdown, format it, and insert it into the code template.
+
+### Snekbox().upload_output
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/snekbox.py#L53)
+
+```python
+def upload_output(output: str) -> Union[str, NoneType]
+```
+
+Upload the eval output to a paste service and return a URL to it if successful.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/snekbox.py#L218)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Snekbox cog load.

--- a/docs/bot/cogs/sync/cog.md
+++ b/docs/bot/cogs/sync/cog.md
@@ -1,0 +1,97 @@
+# Cog
+
+> Auto-generated documentation for [bot.cogs.sync.cog](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/cog.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / [Sync](index.md#sync) / Cog
+  - [Sync](#sync)
+    - [Sync().on_guild_role_create](#syncon_guild_role_create)
+    - [Sync().on_guild_role_delete](#syncon_guild_role_delete)
+    - [Sync().on_guild_role_update](#syncon_guild_role_update)
+    - [Sync().on_member_join](#syncon_member_join)
+    - [Sync().on_member_remove](#syncon_member_remove)
+    - [Sync().on_member_update](#syncon_member_update)
+    - [Sync().sync_guild](#syncsync_guild)
+
+## Sync
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/cog.py#L15)
+
+```python
+class Sync(bot: Bot) -> None
+```
+
+Captures relevant events and sends them to the site.
+
+### Sync().on_guild_role_create
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/cog.py#L53)
+
+```python
+def on_guild_role_create(role: Role) -> None
+```
+
+Adds newly create role to the database table over the API.
+
+### Sync().on_guild_role_delete
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/cog.py#L67)
+
+```python
+def on_guild_role_delete(role: Role) -> None
+```
+
+Deletes role from the database when it's deleted from the guild.
+
+### Sync().on_guild_role_update
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/cog.py#L72)
+
+```python
+def on_guild_role_update(before: Role, after: Role) -> None
+```
+
+Syncs role with the database if any of the stored attributes were updated.
+
+### Sync().on_member_join
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/cog.py#L92)
+
+```python
+def on_member_join(member: Member) -> None
+```
+
+Adds a new user or updates existing user to the database when a member joins the guild.
+
+If the joining member is a user that is already known to the database (i.e., a user that
+previously left), it will update the user's information. If the user is not yet known by
+the database, the user is added.
+
+### Sync().on_member_remove
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/cog.py#L128)
+
+```python
+def on_member_remove(member: Member) -> None
+```
+
+Updates the user information when a member leaves the guild.
+
+### Sync().on_member_update
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/cog.py#L143)
+
+```python
+def on_member_update(before: Member, after: Member) -> None
+```
+
+Updates the user information if any of relevant attributes have changed.
+
+### Sync().sync_guild
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/cog.py#L34)
+
+```python
+def sync_guild() -> None
+```
+
+Syncs the roles/users of the guild with the database.

--- a/docs/bot/cogs/sync/index.md
+++ b/docs/bot/cogs/sync/index.md
@@ -1,0 +1,19 @@
+# Sync
+
+> Auto-generated documentation for [bot.cogs.sync](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/__init__.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / Sync
+  - [setup](#setup)
+  - Modules
+    - [Cog](cog.md#cog)
+    - [Syncers](syncers.md#syncers)
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/__init__.py#L10)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Sync cog load.

--- a/docs/bot/cogs/sync/syncers.md
+++ b/docs/bot/cogs/sync/syncers.md
@@ -1,0 +1,290 @@
+# Syncers
+
+> Auto-generated documentation for [bot.cogs.sync.syncers](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / [Sync](index.md#sync) / Syncers
+  - [Role](#role)
+    - [Role().colour](#rolecolour)
+    - [Role().id](#roleid)
+    - [Role().name](#rolename)
+    - [Role().permissions](#rolepermissions)
+    - [Role().position](#roleposition)
+  - [User](#user)
+    - [User().avatar_hash](#useravatar_hash)
+    - [User().discriminator](#userdiscriminator)
+    - [User().id](#userid)
+    - [User().in_guild](#userin_guild)
+    - [User().name](#username)
+    - [User().roles](#userroles)
+  - [get_roles_for_sync](#get_roles_for_sync)
+  - [get_users_for_sync](#get_users_for_sync)
+  - [sync_roles](#sync_roles)
+  - [sync_users](#sync_users)
+
+## Role
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+class Role()
+```
+
+Role(id, name, colour, permissions, position)
+
+### Role().colour
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(2)()
+```
+
+Alias for field number 2
+
+### Role().id
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(0)()
+```
+
+Alias for field number 0
+
+### Role().name
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(1)()
+```
+
+Alias for field number 1
+
+### Role().permissions
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(3)()
+```
+
+Alias for field number 3
+
+### Role().position
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(4)()
+```
+
+Alias for field number 4
+
+## User
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+class User()
+```
+
+User(id, name, discriminator, avatar_hash, roles, in_guild)
+
+### User().avatar_hash
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(3)()
+```
+
+Alias for field number 3
+
+### User().discriminator
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(2)()
+```
+
+Alias for field number 2
+
+### User().id
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(0)()
+```
+
+Alias for field number 0
+
+### User().in_guild
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(5)()
+```
+
+Alias for field number 5
+
+### User().name
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(1)()
+```
+
+Alias for field number 1
+
+### User().roles
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L1)
+
+```python
+#property getter
+def operator.itemgetter(4)()
+```
+
+Alias for field number 4
+
+## get_roles_for_sync
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L13)
+
+```python
+def get_roles_for_sync(
+    guild_roles: Set[bot.cogs.sync.syncers.Role],
+    api_roles: Set[bot.cogs.sync.syncers.Role],
+) -> Tuple[Set[bot.cogs.sync.syncers.Role], Set[bot.cogs.sync.syncers.Role], Set[bot.cogs.sync.syncers.Role]]
+```
+
+Determine which roles should be created or updated on the site.
+
+#### Arguments
+
+guild_roles (Set[Role]):
+    Roles that were found on the guild at startup.
+
+api_roles (Set[Role]):
+    Roles that were retrieved from the API at startup.
+
+#### Returns
+
+Tuple[Set[Role], Set[Role]. Set[Role]]:
+    A tuple with three elements. The first element represents
+    roles to be created on the site, meaning that they were
+    present on the cached guild but not on the API. The second
+    element represents roles to be updated, meaning they were
+    present on both the cached guild and the API but non-ID
+    fields have changed inbetween. The third represents roles
+    to be deleted on the site, meaning the roles are present on
+    the API but not in the cached guild.
+
+#### See also
+
+- [Role](#role)
+
+## get_users_for_sync
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L114)
+
+```python
+def get_users_for_sync(
+    guild_users: Dict[int, bot.cogs.sync.syncers.User],
+    api_users: Dict[int, bot.cogs.sync.syncers.User],
+) -> Tuple[Set[bot.cogs.sync.syncers.User], Set[bot.cogs.sync.syncers.User]]
+```
+
+Determine which users should be created or updated on the website.
+
+#### Arguments
+
+guild_users (Dict[int, User]):
+    A mapping of user IDs to user data, populated from the
+    guild cached on the running bot instance.
+
+api_users (Dict[int, User]):
+    A mapping of user IDs to user data, populated from the API's
+    current inventory of all users.
+
+#### Returns
+
+Tuple[Set[User], Set[User]]:
+    Two user sets as a tuple. The first element represents users
+    to be created on the website, these are users that are present
+    in the cached guild data but not in the API at all, going by
+    their ID. The second element represents users to update. It is
+    populated by users which are present on both the API and the
+    guild, but where the attribute of a user on the API is not
+    equal to the attribute of the user on the guild.
+
+#### See also
+
+- [User](#user)
+
+## sync_roles
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L50)
+
+```python
+def sync_roles(bot: Bot, guild: Guild) -> Tuple[int, int, int]
+```
+
+Synchronize roles found on the given `guild` with the ones on the API.
+
+#### Arguments
+
+bot (discord.ext.commands.Bot):
+    The bot instance that we're running with.
+
+guild (discord.Guild):
+    The guild instance from the bot's cache
+    to synchronize roles with.
+
+#### Returns
+
+Tuple[int, int, int]:
+    A tuple with three integers representing how many roles were created
+    (element `0`) , how many roles were updated (element `1`), and how many
+    roles were deleted (element `2`) on the API.
+
+## sync_users
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/sync/syncers.py#L167)
+
+```python
+def sync_users(bot: Bot, guild: Guild) -> Tuple[int, int, NoneType]
+```
+
+Synchronize users found in the given `guild` with the ones in the API.
+
+#### Arguments
+
+bot (discord.ext.commands.Bot):
+    The bot instance that we're running with.
+
+guild (discord.Guild):
+    The guild instance from the bot's cache
+    to synchronize roles with.
+
+#### Returns
+
+Tuple[int, int, None]:
+    A tuple with two integers, representing how many users were created
+    (element `0`) and how many users were updated (element `1`), and `None`
+    to indicate that a user sync never deletes entries from the API.

--- a/docs/bot/cogs/tags.md
+++ b/docs/bot/cogs/tags.md
@@ -1,0 +1,27 @@
+# Tags
+
+> Auto-generated documentation for [bot.cogs.tags](https://github.com/python-discord/bot/blob/master/bot/cogs/tags.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Tags
+  - [Tags](#tags)
+  - [setup](#setup)
+
+## Tags
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/tags.py#L22)
+
+```python
+class Tags(bot: Bot)
+```
+
+Save new tags and fetch existing tags.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/tags.py#L162)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Tags cog load.

--- a/docs/bot/cogs/token_remover.md
+++ b/docs/bot/cogs/token_remover.md
@@ -1,0 +1,78 @@
+# TokenRemover
+
+> Auto-generated documentation for [bot.cogs.token_remover](https://github.com/python-discord/bot/blob/master/bot/cogs/token_remover.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / TokenRemover
+  - [TokenRemover](#tokenremover)
+    - [TokenRemover().mod_log](#tokenremovermod_log)
+    - [TokenRemover.is_valid_timestamp](#tokenremoveris_valid_timestamp)
+    - [TokenRemover.is_valid_user_id](#tokenremoveris_valid_user_id)
+    - [TokenRemover().on_message](#tokenremoveron_message)
+  - [setup](#setup)
+
+## TokenRemover
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/token_remover.py#L37)
+
+```python
+class TokenRemover(bot: Bot)
+```
+
+Scans messages for potential discord.py bot tokens and removes them.
+
+### TokenRemover().mod_log
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/token_remover.py#L37)
+
+```python
+#property getter
+def mod_log() -> ModLog
+```
+
+Get currently loaded ModLog cog instance.
+
+### TokenRemover.is_valid_timestamp
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/token_remover.py#L104)
+
+```python
+def is_valid_timestamp(b64_content: str) -> bool
+```
+
+Check potential token to see if it contains a valid timestamp.
+
+See: https://discordapp.com/developers/docs/reference#snowflakes
+
+### TokenRemover.is_valid_user_id
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/token_remover.py#L89)
+
+```python
+def is_valid_user_id(b64_content: str) -> bool
+```
+
+Check potential token to see if it contains a valid Discord user ID.
+
+See: https://discordapp.com/developers/docs/reference#snowflakes
+
+### TokenRemover().on_message
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/token_remover.py#L48)
+
+```python
+def on_message(msg: Message) -> None
+```
+
+Check each message for a string that matches Discord's token pattern.
+
+See: https://discordapp.com/developers/docs/reference#snowflakes
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/token_remover.py#L121)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Token Remover cog load.

--- a/docs/bot/cogs/utils.md
+++ b/docs/bot/cogs/utils.md
@@ -1,0 +1,27 @@
+# Utils
+
+> Auto-generated documentation for [bot.cogs.utils](https://github.com/python-discord/bot/blob/master/bot/cogs/utils.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Utils
+  - [Utils](#utils)
+  - [setup](#setup)
+
+## Utils
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/utils.py#L20)
+
+```python
+class Utils(bot: Bot)
+```
+
+A selection of utilities which don't have a clear category.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/utils.py#L178)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Utils cog load.

--- a/docs/bot/cogs/verification.md
+++ b/docs/bot/cogs/verification.md
@@ -1,0 +1,94 @@
+# Verification
+
+> Auto-generated documentation for [bot.cogs.verification](https://github.com/python-discord/bot/blob/master/bot/cogs/verification.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Verification
+  - [Verification](#verification)
+    - [Verification().mod_log](#verificationmod_log)
+    - [Verification().before_ping](#verificationbefore_ping)
+    - [Verification.bot_check](#verificationbot_check)
+    - [Verification().cog_command_error](#verificationcog_command_error)
+    - [Verification().cog_unload](#verificationcog_unload)
+    - [Verification().on_message](#verificationon_message)
+  - [setup](#setup)
+
+## Verification
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/verification.py#L38)
+
+```python
+class Verification(bot: Bot)
+```
+
+User verification and role self-management.
+
+### Verification().mod_log
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/verification.py#L38)
+
+```python
+#property getter
+def mod_log() -> ModLog
+```
+
+Get currently loaded ModLog cog instance.
+
+### Verification().before_ping
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/verification.py#L185)
+
+```python
+def before_ping() -> None
+```
+
+Only start the loop when the bot is ready.
+
+### Verification.bot_check
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/verification.py#L158)
+
+```python
+def bot_check(ctx: Context) -> bool
+```
+
+Block any command within the verification channel that is not !accept.
+
+### Verification().cog_command_error
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/verification.py#L153)
+
+```python
+def cog_command_error(ctx: Context, error: Exception) -> None
+```
+
+Check for & ignore any InChannelCheckFailure.
+
+### Verification().cog_unload
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/verification.py#L190)
+
+```python
+def cog_unload() -> None
+```
+
+Cancel the periodic ping task when the cog is unloaded.
+
+### Verification().on_message
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/verification.py#L50)
+
+```python
+def on_message(message: Context) -> None
+```
+
+Check new message event for messages to the checkpoint channel & process.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/verification.py#L195)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Verification cog load.

--- a/docs/bot/cogs/watchchannels/bigbrother.md
+++ b/docs/bot/cogs/watchchannels/bigbrother.md
@@ -1,0 +1,40 @@
+# BigBrother
+
+> Auto-generated documentation for [bot.cogs.watchchannels.bigbrother](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/bigbrother.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / [Watchchannels](index.md#watchchannels) / BigBrother
+  - [BigBrother](#bigbrother)
+    - [BigBrother().description](#bigbrotherdescription)
+    - [BigBrother().qualified_name](#bigbrotherqualified_name)
+
+## BigBrother
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/bigbrother.py#L16)
+
+```python
+class BigBrother(bot: Bot) -> None
+```
+
+Monitors users by relaying their messages to a watch channel to assist with moderation.
+
+### BigBrother().description
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/bigbrother.py#L16)
+
+```python
+#property getter
+def description()
+```
+
+class `str`: Returns the cog's description, typically the cleaned docstring.
+
+### BigBrother().qualified_name
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/bigbrother.py#L16)
+
+```python
+#property getter
+def qualified_name()
+```
+
+class `str`: Returns the cog's specified name, not the class name.

--- a/docs/bot/cogs/watchchannels/index.md
+++ b/docs/bot/cogs/watchchannels/index.md
@@ -1,0 +1,20 @@
+# Watchchannels
+
+> Auto-generated documentation for [bot.cogs.watchchannels](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/__init__.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / Watchchannels
+  - [setup](#setup)
+  - Modules
+    - [BigBrother](bigbrother.md#bigbrother)
+    - [TalentPool](talentpool.md#talentpool)
+    - [WatchChannel](watchchannel.md#watchchannel)
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/__init__.py#L12)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Monitoring cogs load.

--- a/docs/bot/cogs/watchchannels/talentpool.md
+++ b/docs/bot/cogs/watchchannels/talentpool.md
@@ -1,0 +1,40 @@
+# TalentPool
+
+> Auto-generated documentation for [bot.cogs.watchchannels.talentpool](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/talentpool.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / [Watchchannels](index.md#watchchannels) / TalentPool
+  - [TalentPool](#talentpool)
+    - [TalentPool().description](#talentpooldescription)
+    - [TalentPool().qualified_name](#talentpoolqualified_name)
+
+## TalentPool
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/talentpool.py#L20)
+
+```python
+class TalentPool(bot: Bot) -> None
+```
+
+Relays messages of helper candidates to a watch channel to observe them.
+
+### TalentPool().description
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/talentpool.py#L20)
+
+```python
+#property getter
+def description()
+```
+
+class `str`: Returns the cog's description, typically the cleaned docstring.
+
+### TalentPool().qualified_name
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/talentpool.py#L20)
+
+```python
+#property getter
+def qualified_name()
+```
+
+class `str`: Returns the cog's specified name, not the class name.

--- a/docs/bot/cogs/watchchannels/watchchannel.md
+++ b/docs/bot/cogs/watchchannels/watchchannel.md
@@ -1,0 +1,182 @@
+# WatchChannel
+
+> Auto-generated documentation for [bot.cogs.watchchannels.watchchannel](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py) module.
+
+- [Index](../../../README.md#modules) / [Bot](../../index.md#bot) / `Cogs` / [Watchchannels](index.md#watchchannels) / WatchChannel
+  - [MessageHistory](#messagehistory)
+  - [WatchChannel](#watchchannel)
+    - [WatchChannel().consuming_messages](#watchchannelconsuming_messages)
+    - [WatchChannel().modlog](#watchchannelmodlog)
+    - [WatchChannel().cog_unload](#watchchannelcog_unload)
+    - [WatchChannel().consume_messages](#watchchannelconsume_messages)
+    - [WatchChannel().fetch_user_cache](#watchchannelfetch_user_cache)
+    - [WatchChannel().list_watched_users](#watchchannellist_watched_users)
+    - [WatchChannel().on_message](#watchchannelon_message)
+    - [WatchChannel().relay_message](#watchchannelrelay_message)
+    - [WatchChannel().send_header](#watchchannelsend_header)
+    - [WatchChannel().start_watchchannel](#watchchannelstart_watchchannel)
+    - [WatchChannel().webhook_send](#watchchannelwebhook_send)
+  - [proxy_user](#proxy_user)
+
+## MessageHistory
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L44)
+
+```python
+class MessageHistory(
+    last_author: Union[int, NoneType] = None,
+    last_channel: Union[int, NoneType] = None,
+    message_count: int = 0,
+) -> None
+```
+
+Represents a watch channel's message history.
+
+## WatchChannel
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L52)
+
+```python
+class WatchChannel(
+    bot: Bot,
+    destination: int,
+    webhook_id: int,
+    api_endpoint: str,
+    api_default_params: dict,
+    logger: <MagicMock id='140270945482344'>,
+) -> None
+```
+
+ABC with functionality for relaying users' messages to a certain channel.
+
+### WatchChannel().consuming_messages
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L52)
+
+```python
+#property getter
+def consuming_messages() -> bool
+```
+
+Checks if a consumption task is currently running.
+
+### WatchChannel().modlog
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L52)
+
+```python
+#property getter
+def modlog() -> ModLog
+```
+
+Provides access to the ModLog cog for alert purposes.
+
+### WatchChannel().cog_unload
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L335)
+
+```python
+def cog_unload() -> None
+```
+
+Takes care of unloading the cog and canceling the consumption task.
+
+### WatchChannel().consume_messages
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L185)
+
+```python
+def consume_messages(delay_consumption: bool = True) -> None
+```
+
+Consumes the message queues to log watched users' messages.
+
+### WatchChannel().fetch_user_cache
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L155)
+
+```python
+def fetch_user_cache() -> bool
+```
+
+Fetches watched users from the API and updates the watched user cache accordingly.
+
+This function returns `True` if the update succeeded.
+
+### WatchChannel().list_watched_users
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L296)
+
+```python
+def list_watched_users(ctx: Context, update_cache: bool = True) -> None
+```
+
+Gives an overview of the watched user list for this channel.
+
+The optional kwarg `update_cache` specifies whether the cache should
+be refreshed by polling the API.
+
+### WatchChannel().on_message
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L175)
+
+```python
+def on_message(msg: Message) -> None
+```
+
+Queues up messages sent by watched users.
+
+### WatchChannel().relay_message
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L230)
+
+```python
+def relay_message(msg: Message) -> None
+```
+
+Relays the message to the relevant watch channel.
+
+### WatchChannel().send_header
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L278)
+
+```python
+def send_header(msg: Message) -> None
+```
+
+Sends a header embed with information about the relayed messages to the watch channel.
+
+### WatchChannel().start_watchchannel
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L107)
+
+```python
+def start_watchchannel() -> None
+```
+
+Starts the watch channel by getting the channel, webhook, and user cache ready.
+
+### WatchChannel().webhook_send
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L214)
+
+```python
+def webhook_send(
+    content: Union[str, NoneType] = None,
+    username: Union[str, NoneType] = None,
+    avatar_url: Union[str, NoneType] = None,
+    embed: Union[discord.embeds.Embed, NoneType] = None,
+) -> None
+```
+
+Sends a message to the webhook with the specified kwargs.
+
+## proxy_user
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/watchchannels/watchchannel.py#L27)
+
+```python
+def proxy_user(user_id: str) -> Object
+```
+
+A proxy user object that mocks a real User instance for when the later is not available.

--- a/docs/bot/cogs/wolfram.md
+++ b/docs/bot/cogs/wolfram.md
@@ -1,0 +1,73 @@
+# Wolfram
+
+> Auto-generated documentation for [bot.cogs.wolfram](https://github.com/python-discord/bot/blob/master/bot/cogs/wolfram.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / `Cogs` / Wolfram
+  - [Wolfram](#wolfram)
+  - [custom_cooldown](#custom_cooldown)
+  - [get_pod_pages](#get_pod_pages)
+  - [send_embed](#send_embed)
+  - [setup](#setup)
+
+## Wolfram
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/wolfram.py#L151)
+
+```python
+class Wolfram(bot: Bot)
+```
+
+Commands for interacting with the Wolfram|Alpha API.
+
+## custom_cooldown
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/wolfram.py#L55)
+
+```python
+def custom_cooldown(ignore: List[int]) -> Callable
+```
+
+Implement per-user and per-guild cooldowns for requests to the Wolfram API.
+
+A list of roles may be provided to ignore the per-user cooldown
+
+## get_pod_pages
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/wolfram.py#L97)
+
+```python
+def get_pod_pages(
+    ctx: Context,
+    bot: Bot,
+    query: str,
+) -> Union[List[Tuple], NoneType]
+```
+
+Get the Wolfram API pod pages for the provided query.
+
+## send_embed
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/wolfram.py#L32)
+
+```python
+def send_embed(
+    ctx: Context,
+    message_txt: str,
+    colour: int = 13462893,
+    footer: str = None,
+    img_url: str = None,
+    f: File = None,
+) -> None
+```
+
+Generate & send a response embed with Wolfram as the author.
+
+## setup
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/cogs/wolfram.py#L269)
+
+```python
+def setup(bot: Bot) -> None
+```
+
+Wolfram cog load.

--- a/docs/bot/constants.md
+++ b/docs/bot/constants.md
@@ -1,0 +1,313 @@
+# Constants
+
+> Auto-generated documentation for [bot.constants](https://github.com/python-discord/bot/blob/master/bot/constants.py) module.
+
+Loads bot configuration from YAML files.
+By default, this simply loads the default
+configuration located at `config-default.yml`.
+If a file called `config.yml` is found in the
+project directory, the default configuration
+is recursively updated with any settings from
+the custom configuration. Any settings left
+out in the custom user configuration will stay
+their default values from `config-default.yml`.
+
+- [Index](../README.md#modules) / [Bot](index.md#bot) / Constants
+  - [AntiSpam](#antispam)
+  - [BigBrother](#bigbrother)
+  - [Bot](#bot)
+  - [Categories](#categories)
+  - [Channels](#channels)
+  - [CleanMessages](#cleanmessages)
+  - [Colours](#colours)
+  - [Cooldowns](#cooldowns)
+  - [Emojis](#emojis)
+  - [Event](#event)
+  - [Filter](#filter)
+  - [Free](#free)
+  - [Guild](#guild)
+  - [Icons](#icons)
+  - [Keys](#keys)
+  - [Mention](#mention)
+  - [Reddit](#reddit)
+  - [RedirectOutput](#redirectoutput)
+  - [Roles](#roles)
+  - [URLs](#urls)
+  - [Webhooks](#webhooks)
+  - [Wolfram](#wolfram)
+  - [YAMLGetter](#yamlgetter)
+  - [_env_var_constructor](#_env_var_constructor)
+  - [_join_var_constructor](#_join_var_constructor)
+  - [_recursive_update](#_recursive_update)
+  - [check_required_keys](#check_required_keys)
+
+## AntiSpam
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L453)
+
+```python
+class AntiSpam()
+```
+
+## BigBrother
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L463)
+
+```python
+class BigBrother()
+```
+
+## Bot
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L191)
+
+```python
+class Bot()
+```
+
+## Categories
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L319)
+
+```python
+class Categories()
+```
+
+## Channels
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L326)
+
+```python
+class Channels()
+```
+
+## CleanMessages
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L312)
+
+```python
+class CleanMessages()
+```
+
+## Colours
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L230)
+
+```python
+class Colours()
+```
+
+## Cooldowns
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L223)
+
+```python
+class Cooldowns()
+```
+
+## Emojis
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L239)
+
+```python
+class Emojis()
+```
+
+## Event
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L559)
+
+```python
+class Event()
+```
+
+Event names. This does not include every event (for example, raw
+events aren't here), but only events used in ModLog for now.
+
+## Filter
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L198)
+
+```python
+class Filter()
+```
+
+## Free
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L470)
+
+```python
+class Free()
+```
+
+## Guild
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L389)
+
+```python
+class Guild()
+```
+
+## Icons
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L263)
+
+```python
+class Icons()
+```
+
+## Keys
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L396)
+
+```python
+class Keys()
+```
+
+## Mention
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L478)
+
+```python
+class Mention()
+```
+
+## Reddit
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L438)
+
+```python
+class Reddit()
+```
+
+## RedirectOutput
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L485)
+
+```python
+class RedirectOutput()
+```
+
+## Roles
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L369)
+
+```python
+class Roles()
+```
+
+## URLs
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L402)
+
+```python
+class URLs()
+```
+
+## Webhooks
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L361)
+
+```python
+class Webhooks()
+```
+
+## Wolfram
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L445)
+
+```python
+class Wolfram()
+```
+
+## YAMLGetter
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L135)
+
+```python
+class YAMLGetter()
+```
+
+Implements a custom metaclass used for accessing
+configuration data by simply accessing class attributes.
+Supports getting configuration from up to two levels
+of nested configuration through `section` and `subsection`.
+
+`section` specifies the YAML configuration section (or "key")
+in which the configuration lives, and must be set.
+
+`subsection` is an optional attribute specifying the section
+within the section from which configuration should be loaded.
+
+Example Usage:
+
+# config.yml
+bot:
+    prefixes:
+        direct_message: ''
+        guild: '!'
+
+# config.py
+class Prefixes(metaclass=YAMLGetter):
+    section = "bot"
+    subsection = "prefixes"
+
+# Usage in Python code
+from config import Prefixes
+def get_prefix(bot, message):
+    if isinstance(message.channel, PrivateChannel):
+        return Prefixes.direct_message
+    return Prefixes.guild
+
+## _env_var_constructor
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L25)
+
+```python
+def _env_var_constructor(loader, node)
+```
+
+Implements a custom YAML tag for loading optional environment
+variables. If the environment variable is set, returns the
+value of it. Otherwise, returns `None`.
+
+Example usage in the YAML configuration:
+
+# Optional app configuration. Set `MY_APP_KEY` in the environment to use it.
+application:
+    key: !ENV 'MY_APP_KEY'
+
+## _join_var_constructor
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L59)
+
+```python
+def _join_var_constructor(loader, node)
+```
+
+Implements a custom YAML tag for concatenating other tags in
+the document to strings. This allows for a much more DRY configuration
+file.
+
+## _recursive_update
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L81)
+
+```python
+def _recursive_update(original, new)
+```
+
+Helper method which implements a recursive `dict.update`
+method, used for updating the original configuration with
+configuration specified by the user.
+
+## check_required_keys
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/constants.py#L107)
+
+```python
+def check_required_keys(keys)
+```
+
+Verifies that keys that are set to be required are present in the
+loaded configuration.

--- a/docs/bot/converters.md
+++ b/docs/bot/converters.md
@@ -1,0 +1,236 @@
+# Converters
+
+> Auto-generated documentation for [bot.converters](https://github.com/python-discord/bot/blob/master/bot/converters.py) module.
+
+- [Index](../README.md#modules) / [Bot](index.md#bot) / Converters
+  - [Duration](#duration)
+    - [Duration().convert](#durationconvert)
+  - [ISODateTime](#isodatetime)
+    - [ISODateTime().convert](#isodatetimeconvert)
+  - [InfractionSearchQuery](#infractionsearchquery)
+    - [InfractionSearchQuery.convert](#infractionsearchqueryconvert)
+  - [Subreddit](#subreddit)
+    - [Subreddit.convert](#subredditconvert)
+  - [TagContentConverter](#tagcontentconverter)
+    - [TagContentConverter.convert](#tagcontentconverterconvert)
+  - [TagNameConverter](#tagnameconverter)
+    - [TagNameConverter.convert](#tagnameconverterconvert)
+  - [ValidPythonIdentifier](#validpythonidentifier)
+    - [ValidPythonIdentifier.convert](#validpythonidentifierconvert)
+  - [ValidURL](#validurl)
+    - [ValidURL.convert](#validurlconvert)
+
+## Duration
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L183)
+
+```python
+class Duration()
+```
+
+Convert duration strings into UTC datetime.datetime objects.
+
+### Duration().convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L196)
+
+```python
+def convert(ctx: Context, duration: str) -> datetime
+```
+
+Converts a `duration` string to a datetime object that's `duration` in the future.
+
+The converter supports the following symbols for each unit of time:
+- years: `Y`, `y`, `year`, `years`
+- months: `m`, `month`, `months`
+- weeks: `w`, `W`, `week`, `weeks`
+- days: `d`, `D`, `day`, `days`
+- hours: `H`, `h`, `hour`, `hours`
+- minutes: `M`, `minute`, `minutes`
+- seconds: `S`, `s`, `second`, `seconds`
+
+The units need to be provided in descending order of magnitude.
+
+## ISODateTime
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L222)
+
+```python
+class ISODateTime()
+```
+
+Converts an ISO-8601 datetime string into a datetime.datetime.
+
+### ISODateTime().convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L225)
+
+```python
+def convert(ctx: Context, datetime_string: str) -> datetime
+```
+
+Converts a ISO-8601 `datetime_string` into a `datetime.datetime` object.
+
+The converter is flexible in the formats it accepts, as it uses the `isoparse` method of
+`dateutil.parser`. In general, it accepts datetime strings that start with a date,
+optionally followed by a time. Specifying a timezone offset in the datetime string is
+supported, but the `datetime` object will be converted to UTC and will be returned without
+`tzinfo` as a timezone-unaware `datetime` object.
+
+See: https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse
+
+Formats that are guaranteed to be valid by our tests are:
+
+- `YYYY-mm-ddTHH:MM:SSZ` | `YYYY-mm-dd HH:MM:SSZ`
+- `YYYY-mm-ddTHH:MM:SS±HH:MM` | `YYYY-mm-dd HH:MM:SS±HH:MM`
+- `YYYY-mm-ddTHH:MM:SS±HHMM` | `YYYY-mm-dd HH:MM:SS±HHMM`
+- `YYYY-mm-ddTHH:MM:SS±HH` | `YYYY-mm-dd HH:MM:SS±HH`
+- `YYYY-mm-ddTHH:MM:SS` | `YYYY-mm-dd HH:MM:SS`
+- `YYYY-mm-ddTHH:MM` | `YYYY-mm-dd HH:MM`
+- `YYYY-mm-dd`
+- `YYYY-mm`
+- `YYYY`
+
+Note: ISO-8601 specifies a `T` as the separator between the date and the time part of the
+datetime string. The converter accepts both a `T` and a single space character.
+
+## InfractionSearchQuery
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L69)
+
+```python
+class InfractionSearchQuery()
+```
+
+A converter that checks if the argument is a Discord user, and if not, falls back to a string.
+
+### InfractionSearchQuery.convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L72)
+
+```python
+def convert(ctx: Context, arg: str) -> Union[discord.member.Member, str]
+```
+
+Check if the argument is a Discord user, and if not, falls back to a string.
+
+## Subreddit
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L82)
+
+```python
+class Subreddit()
+```
+
+Forces a string to begin with "r/" and checks if it's a valid subreddit.
+
+### Subreddit.convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L85)
+
+```python
+def convert(ctx: Context, sub: str) -> str
+```
+
+Force sub to begin with "r/" and check if it's a valid subreddit.
+
+If sub is a valid subreddit, return it prepended with "r/"
+
+## TagContentConverter
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L162)
+
+```python
+class TagContentConverter()
+```
+
+Ensure proposed tag content is not empty and contains at least one non-whitespace character.
+
+### TagContentConverter.convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L165)
+
+```python
+def convert(ctx: Context, tag_content: str) -> str
+```
+
+Ensure tag_content is non-empty and contains at least one non-whitespace character.
+
+If tag_content is valid, return the stripped version.
+
+## TagNameConverter
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L111)
+
+```python
+class TagNameConverter()
+```
+
+Ensure that a proposed tag name is valid.
+
+Valid tag names meet the following conditions:
+    * All ASCII characters
+    * Has at least one non-whitespace character
+    * Not solely numeric
+    * Shorter than 127 characters
+
+### TagNameConverter.convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L122)
+
+```python
+def convert(ctx: Context, tag_name: str) -> str
+```
+
+Lowercase & strip whitespace from proposed tag_name & ensure it's valid.
+
+## ValidPythonIdentifier
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L18)
+
+```python
+class ValidPythonIdentifier()
+```
+
+A converter that checks whether the given string is a valid Python identifier.
+
+This is used to have package names that correspond to how you would use the package in your
+code, e.g. `import package`.
+
+Raises `BadArgument` if the argument is not a valid Python identifier, and simply passes through
+the given argument otherwise.
+
+### ValidPythonIdentifier.convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L29)
+
+```python
+def convert(ctx: Context, argument: str) -> str
+```
+
+Checks whether the given string is a valid Python identifier.
+
+## ValidURL
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L37)
+
+```python
+class ValidURL()
+```
+
+Represents a valid webpage URL.
+
+This converter checks whether the given URL can be reached and requesting it returns a status
+code of 200. If not, `BadArgument` is raised.
+
+Otherwise, it simply passes through the given URL.
+
+### ValidURL.convert
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/converters.py#L47)
+
+```python
+def convert(ctx: Context, url: str) -> str
+```
+
+This converter checks whether the given URL can be reached with a status code of 200.

--- a/docs/bot/decorators.md
+++ b/docs/bot/decorators.md
@@ -1,0 +1,101 @@
+# Decorators
+
+> Auto-generated documentation for [bot.decorators](https://github.com/python-discord/bot/blob/master/bot/decorators.py) module.
+
+- [Index](../README.md#modules) / [Bot](index.md#bot) / Decorators
+  - [InChannelCheckFailure](#inchannelcheckfailure)
+  - [in_channel](#in_channel)
+  - [locked](#locked)
+  - [redirect_output](#redirect_output)
+  - [respect_role_hierarchy](#respect_role_hierarchy)
+  - [with_role](#with_role)
+  - [without_role](#without_role)
+
+## InChannelCheckFailure
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/decorators.py#L20)
+
+```python
+class InChannelCheckFailure(channels: int)
+```
+
+Raised when a check fails for a message being sent in a whitelisted channel.
+
+## in_channel
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/decorators.py#L30)
+
+```python
+def in_channel(channels: int) -> Callable
+```
+
+Checks that the message is in a whitelisted channel or optionally has a bypass role.
+
+## locked
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/decorators.py#L69)
+
+```python
+def locked() -> Callable
+```
+
+Allows the user to only run one instance of the decorated command at a time.
+
+Subsequent calls to the command from the same author are ignored until the command has completed invocation.
+
+This decorator must go before (below) the `command` decorator.
+
+## redirect_output
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/decorators.py#L101)
+
+```python
+def redirect_output(
+    destination_channel: int,
+    bypass_roles: Container[int] = None,
+) -> Callable
+```
+
+Changes the channel in the context of the command to redirect the output to a certain channel.
+
+Redirect is bypassed if the author has a role to bypass redirection.
+
+This decorator must go before (below) the `command` decorator.
+
+## respect_role_hierarchy
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/decorators.py#L149)
+
+```python
+def respect_role_hierarchy(target_arg: Union[int, str] = 0) -> Callable
+```
+
+Ensure the highest role of the invoking member is greater than that of the target member.
+
+If the condition fails, a warning is sent to the invoking context. A target which is not an
+instance of discord.Member will always pass.
+
+A value of 0 (i.e. position 0) for `target_arg` corresponds to the argument which comes after
+`ctx`. If the target argument is a kwarg, its name can instead be given.
+
+This decorator must go before (below) the `command` decorator.
+
+## with_role
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/decorators.py#L54)
+
+```python
+def with_role(role_ids: int) -> Callable
+```
+
+Returns True if the user has any one of the roles in role_ids.
+
+## without_role
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/decorators.py#L62)
+
+```python
+def without_role(role_ids: int) -> Callable
+```
+
+Returns True if the user does not have any of the roles in role_ids.

--- a/docs/bot/index.md
+++ b/docs/bot/index.md
@@ -1,0 +1,86 @@
+# Bot
+
+> Auto-generated documentation for [bot](https://github.com/python-discord/bot/blob/master/bot/__init__.py) module.
+
+- [Index](../README.md#modules) / Bot
+  - [monkeypatch_trace](#monkeypatch_trace)
+  - Modules
+    - [Api](api.md#api)
+    - Cogs
+      - [Alias](cogs/alias.md#alias)
+      - [AntiSpam](cogs/antispam.md#antispam)
+      - [Bot](cogs/bot.md#bot)
+      - [Clean](cogs/clean.md#clean)
+      - [Defcon](cogs/defcon.md#defcon)
+      - [Doc](cogs/doc.md#doc)
+      - [ErrorHandler](cogs/error_handler.md#errorhandler)
+      - [Eval](cogs/eval.md#eval)
+      - [Extensions](cogs/extensions.md#extensions)
+      - [Filtering](cogs/filtering.md#filtering)
+      - [Free](cogs/free.md#free)
+      - [Help](cogs/help.md#help)
+      - [Information](cogs/information.md#information)
+      - [Jams](cogs/jams.md#jams)
+      - [Logging](cogs/logging.md#logging)
+      - [Moderation](cogs/moderation/index.md#moderation)
+        - [Infractions](cogs/moderation/infractions.md#infractions)
+        - [Management](cogs/moderation/management.md#management)
+        - [ModLog](cogs/moderation/modlog.md#modlog)
+        - [Superstarify](cogs/moderation/superstarify.md#superstarify)
+        - [Utils](cogs/moderation/utils.md#utils)
+      - [OffTopicNames](cogs/off_topic_names.md#offtopicnames)
+      - [Reddit](cogs/reddit.md#reddit)
+      - [Reminders](cogs/reminders.md#reminders)
+      - [Security](cogs/security.md#security)
+      - [Site](cogs/site.md#site)
+      - [Snekbox](cogs/snekbox.md#snekbox)
+      - [Sync](cogs/sync/index.md#sync)
+        - [Cog](cogs/sync/cog.md#cog)
+        - [Syncers](cogs/sync/syncers.md#syncers)
+      - [Tags](cogs/tags.md#tags)
+      - [TokenRemover](cogs/token_remover.md#tokenremover)
+      - [Utils](cogs/utils.md#utils)
+      - [Verification](cogs/verification.md#verification)
+      - [Watchchannels](cogs/watchchannels/index.md#watchchannels)
+        - [BigBrother](cogs/watchchannels/bigbrother.md#bigbrother)
+        - [TalentPool](cogs/watchchannels/talentpool.md#talentpool)
+        - [WatchChannel](cogs/watchchannels/watchchannel.md#watchchannel)
+      - [Wolfram](cogs/wolfram.md#wolfram)
+    - [Constants](constants.md#constants)
+    - [Converters](converters.md#converters)
+    - [Decorators](decorators.md#decorators)
+    - [Interpreter](interpreter.md#interpreter)
+    - [Pagination](pagination.md#pagination)
+    - [Patches](patches/index.md#patches)
+      - [Message Edited At](patches/message_edited_at.md#message-edited-at)
+    - [Rules](rules/index.md#rules)
+      - [Attachments](rules/attachments.md#attachments)
+      - [Burst](rules/burst.md#burst)
+      - [Burst Shared](rules/burst_shared.md#burst-shared)
+      - [Chars](rules/chars.md#chars)
+      - [Discord Emojis](rules/discord_emojis.md#discord-emojis)
+      - [Duplicates](rules/duplicates.md#duplicates)
+      - [Links](rules/links.md#links)
+      - [Mentions](rules/mentions.md#mentions)
+      - [Newlines](rules/newlines.md#newlines)
+      - [Role Mentions](rules/role_mentions.md#role-mentions)
+    - [Utils](utils/index.md#utils)
+      - [Checks](utils/checks.md#checks)
+      - [Messages](utils/messages.md#messages)
+      - [Scheduling](utils/scheduling.md#scheduling)
+      - [Time](utils/time.md#time)
+
+## monkeypatch_trace
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/__init__.py#L13)
+
+```python
+def monkeypatch_trace(msg: str, args, kwargs) -> None
+```
+
+Log 'msg % args' with severity 'TRACE'.
+
+To pass exception information, use the keyword argument exc_info with
+a true value, e.g.
+
+logger.trace("Houston, we have an %s", "interesting problem", exc_info=1)

--- a/docs/bot/interpreter.md
+++ b/docs/bot/interpreter.md
@@ -1,0 +1,29 @@
+# Interpreter
+
+> Auto-generated documentation for [bot.interpreter](https://github.com/python-discord/bot/blob/master/bot/interpreter.py) module.
+
+- [Index](../README.md#modules) / [Bot](index.md#bot) / Interpreter
+  - [Interpreter](#interpreter)
+    - [Interpreter().run](#interpreterrun)
+
+## Interpreter
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/interpreter.py#L13)
+
+```python
+class Interpreter(bot: Bot)
+```
+
+Subclass InteractiveInterpreter to specify custom run functionality.
+
+Helper class for internal eval.
+
+### Interpreter().run
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/interpreter.py#L26)
+
+```python
+def run(code: str, ctx: Context, io: StringIO, args, kwargs) -> Any
+```
+
+Execute the provided source code as the bot & return the output.

--- a/docs/bot/pagination.md
+++ b/docs/bot/pagination.md
@@ -1,0 +1,170 @@
+# Pagination
+
+> Auto-generated documentation for [bot.pagination](https://github.com/python-discord/bot/blob/master/bot/pagination.py) module.
+
+- [Index](../README.md#modules) / [Bot](index.md#bot) / Pagination
+  - [EmptyPaginatorEmbed](#emptypaginatorembed)
+  - [ImagePaginator](#imagepaginator)
+    - [ImagePaginator().add_image](#imagepaginatoradd_image)
+    - [ImagePaginator().add_line](#imagepaginatoradd_line)
+    - [ImagePaginator.paginate](#imagepaginatorpaginate)
+  - [LinePaginator](#linepaginator)
+    - [LinePaginator().add_line](#linepaginatoradd_line)
+    - [LinePaginator.paginate](#linepaginatorpaginate)
+
+## EmptyPaginatorEmbed
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/pagination.py#L20)
+
+```python
+class EmptyPaginatorEmbed()
+```
+
+Raised when attempting to paginate with empty contents.
+
+## ImagePaginator
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/pagination.py#L286)
+
+```python
+class ImagePaginator(prefix: str = '', suffix: str = '')
+```
+
+Helper class that paginates images for embeds in messages.
+
+Close resemblance to LinePaginator, except focuses on images over text.
+
+Refer to ImagePaginator.paginate for documentation on how to use.
+
+### ImagePaginator().add_image
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/pagination.py#L310)
+
+```python
+def add_image(image: str = None) -> None
+```
+
+Adds an image to a page.
+
+### ImagePaginator().add_line
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/pagination.py#L301)
+
+```python
+def add_line(line: str = '') -> None
+```
+
+Adds a line to each page.
+
+### ImagePaginator.paginate
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/pagination.py#L314)
+
+```python
+def paginate(
+    pages: List[Tuple[str, str]],
+    ctx: Context,
+    embed: Embed,
+    prefix: str = '',
+    suffix: str = '',
+    timeout: int = 300,
+    exception_on_empty_embed: bool = False,
+) -> Union[discord.message.Message, NoneType]
+```
+
+Use a paginator and set of reactions to provide pagination over a set of title/image pairs.
+
+The reactions are used to switch page, or to finish with pagination.
+
+When used, this will send a message using `ctx.send()` and apply a set of reactions to it. These reactions may
+be used to change page, or to remove pagination from the message.
+
+- `Note` - Pagination will be removed automatically if no reaction is added for five minutes (300 seconds).
+
+#### Examples
+
+```python
+>>> embed = Embed()
+>>> embed.set_author(name="Some Operation", url=url, icon_url=icon)
+>>> await ImagePaginator.paginate(pages, ctx, embed)
+```
+
+## LinePaginator
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/pagination.py#L26)
+
+```python
+class LinePaginator(
+    prefix: str = '```',
+    suffix: str = '```',
+    max_size: int = 2000,
+    max_lines: int = None,
+) -> None
+```
+
+A class that aids in paginating code blocks for Discord messages.
+
+Available attributes include:
+* prefix: `str`
+    The prefix inserted to every page. e.g. three backticks.
+* suffix: `str`
+    The suffix appended at the end of every page. e.g. three backticks.
+* max_size: `int`
+    The maximum amount of codepoints allowed in a page.
+* max_lines: `int`
+    The maximum amount of lines allowed in a page.
+
+### LinePaginator().add_line
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/pagination.py#L58)
+
+```python
+def add_line(line: str = '') -> None
+```
+
+Adds a line to the current page.
+
+If the line exceeds the `self.max_size` then an exception is raised.
+
+This function overrides the `Paginator.add_line` from inside `discord.ext.commands`.
+
+It overrides in order to allow us to configure the maximum number of lines per page.
+
+### LinePaginator.paginate
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/pagination.py#L87)
+
+```python
+def paginate(
+    lines: Iterable[str],
+    ctx: Context,
+    embed: Embed,
+    prefix: str = '',
+    suffix: str = '',
+    max_lines: Union[int, NoneType] = None,
+    max_size: int = 500,
+    empty: bool = True,
+    restrict_to_user: User = None,
+    timeout: int = 300,
+    footer_text: str = None,
+    url: str = None,
+    exception_on_empty_embed: bool = False,
+) -> Union[discord.message.Message, NoneType]
+```
+
+Use a paginator and set of reactions to provide pagination over a set of lines.
+
+The reactions are used to switch page, or to finish with pagination.
+
+When used, this will send a message using `ctx.send()` and apply a set of reactions to it. These reactions may
+be used to change page, or to remove pagination from the message.
+
+Pagination will also be removed automatically if no reaction is added for five minutes (300 seconds).
+
+#### Examples
+
+```python
+>>> embed = Embed()
+>>> embed.set_author(name="Some Operation", url=url, icon_url=icon)
+>>> await LinePaginator.paginate((line for line in lines), ctx, embed)
+```

--- a/docs/bot/patches/index.md
+++ b/docs/bot/patches/index.md
@@ -1,0 +1,9 @@
+# Patches
+
+> Auto-generated documentation for [bot.patches](https://github.com/python-discord/bot/blob/master/bot/patches/__init__.py) module.
+
+Subpackage that contains patches for discord.py.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / Patches
+  - Modules
+    - [Message Edited At](message_edited_at.md#message-edited-at)

--- a/docs/bot/patches/message_edited_at.md
+++ b/docs/bot/patches/message_edited_at.md
@@ -1,0 +1,35 @@
+# message_edited_at patch.
+
+> Auto-generated documentation for [bot.patches.message_edited_at](https://github.com/python-discord/bot/blob/master/bot/patches/message_edited_at.py) module.
+
+Date: 2019-09-16
+Author: Scragly
+Added by: Ves Zappa
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Patches](index.md#patches) / message_edited_at patch.
+  - [_handle_edited_timestamp](#_handle_edited_timestamp)
+  - [apply_patch](#apply_patch)
+
+Due to a bug in our current version of discord.py (1.2.3), the edited_at timestamp of
+`discord.Messages` are not being handled correctly. This patch fixes that until a new
+release of discord.py is released (and we've updated to it).
+
+## _handle_edited_timestamp
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/patches/message_edited_at.py#L19)
+
+```python
+def _handle_edited_timestamp(value: str) -> None
+```
+
+Helper function that takes care of parsing the edited timestamp.
+
+## apply_patch
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/patches/message_edited_at.py#L24)
+
+```python
+def apply_patch() -> None
+```
+
+Applies the `edited_at` patch to the `discord.message.Message` class.

--- a/docs/bot/rules/attachments.md
+++ b/docs/bot/rules/attachments.md
@@ -1,0 +1,20 @@
+# Attachments
+
+> Auto-generated documentation for [bot.rules.attachments](https://github.com/python-discord/bot/blob/master/bot/rules/attachments.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Rules](index.md#rules) / Attachments
+  - [apply](#apply)
+
+## apply
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/rules/attachments.py#L6)
+
+```python
+def apply(
+    last_message: Message,
+    recent_messages: List[discord.message.Message],
+    config: Dict[str, int],
+) -> Union[Tuple[str, Iterable[discord.member.Member], Iterable[discord.message.Message]], NoneType]
+```
+
+Detects total attachments exceeding the limit sent by a single user.

--- a/docs/bot/rules/burst.md
+++ b/docs/bot/rules/burst.md
@@ -1,0 +1,22 @@
+# Burst
+
+> Auto-generated documentation for [bot.rules.burst](https://github.com/python-discord/bot/blob/master/bot/rules/burst.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Rules](index.md#rules) / Burst
+  - [apply](#apply)
+  - Modules
+    - [Burst Shared](burst_shared.md#burst-shared)
+
+## apply
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/rules/burst.py#L6)
+
+```python
+def apply(
+    last_message: Message,
+    recent_messages: List[discord.message.Message],
+    config: Dict[str, int],
+) -> Union[Tuple[str, Iterable[discord.member.Member], Iterable[discord.message.Message]], NoneType]
+```
+
+Detects repeated messages sent by a single user.

--- a/docs/bot/rules/burst_shared.md
+++ b/docs/bot/rules/burst_shared.md
@@ -1,0 +1,20 @@
+# Burst Shared
+
+> Auto-generated documentation for [bot.rules.burst_shared](https://github.com/python-discord/bot/blob/master/bot/rules/burst_shared.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Rules](index.md#rules) / Burst Shared
+  - [apply](#apply)
+
+## apply
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/rules/burst_shared.py#L6)
+
+```python
+def apply(
+    last_message: Message,
+    recent_messages: List[discord.message.Message],
+    config: Dict[str, int],
+) -> Union[Tuple[str, Iterable[discord.member.Member], Iterable[discord.message.Message]], NoneType]
+```
+
+Detects repeated messages sent by multiple users.

--- a/docs/bot/rules/chars.md
+++ b/docs/bot/rules/chars.md
@@ -1,0 +1,20 @@
+# Chars
+
+> Auto-generated documentation for [bot.rules.chars](https://github.com/python-discord/bot/blob/master/bot/rules/chars.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Rules](index.md#rules) / Chars
+  - [apply](#apply)
+
+## apply
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/rules/chars.py#L6)
+
+```python
+def apply(
+    last_message: Message,
+    recent_messages: List[discord.message.Message],
+    config: Dict[str, int],
+) -> Union[Tuple[str, Iterable[discord.member.Member], Iterable[discord.message.Message]], NoneType]
+```
+
+Detects total message char count exceeding the limit sent by a single user.

--- a/docs/bot/rules/discord_emojis.md
+++ b/docs/bot/rules/discord_emojis.md
@@ -1,0 +1,20 @@
+# Discord Emojis
+
+> Auto-generated documentation for [bot.rules.discord_emojis](https://github.com/python-discord/bot/blob/master/bot/rules/discord_emojis.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Rules](index.md#rules) / Discord Emojis
+  - [apply](#apply)
+
+## apply
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/rules/discord_emojis.py#L10)
+
+```python
+def apply(
+    last_message: Message,
+    recent_messages: List[discord.message.Message],
+    config: Dict[str, int],
+) -> Union[Tuple[str, Iterable[discord.member.Member], Iterable[discord.message.Message]], NoneType]
+```
+
+Detects total Discord emojis (excluding Unicode emojis) exceeding the limit sent by a single user.

--- a/docs/bot/rules/duplicates.md
+++ b/docs/bot/rules/duplicates.md
@@ -1,0 +1,20 @@
+# Duplicates
+
+> Auto-generated documentation for [bot.rules.duplicates](https://github.com/python-discord/bot/blob/master/bot/rules/duplicates.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Rules](index.md#rules) / Duplicates
+  - [apply](#apply)
+
+## apply
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/rules/duplicates.py#L6)
+
+```python
+def apply(
+    last_message: Message,
+    recent_messages: List[discord.message.Message],
+    config: Dict[str, int],
+) -> Union[Tuple[str, Iterable[discord.member.Member], Iterable[discord.message.Message]], NoneType]
+```
+
+Detects duplicated messages sent by a single user.

--- a/docs/bot/rules/index.md
+++ b/docs/bot/rules/index.md
@@ -1,0 +1,16 @@
+# Rules
+
+> Auto-generated documentation for [bot.rules](https://github.com/python-discord/bot/blob/master/bot/rules/__init__.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / Rules
+  - Modules
+    - [Attachments](attachments.md#attachments)
+    - [Burst](burst.md#burst)
+    - [Burst Shared](burst_shared.md#burst-shared)
+    - [Chars](chars.md#chars)
+    - [Discord Emojis](discord_emojis.md#discord-emojis)
+    - [Duplicates](duplicates.md#duplicates)
+    - [Links](links.md#links)
+    - [Mentions](mentions.md#mentions)
+    - [Newlines](newlines.md#newlines)
+    - [Role Mentions](role_mentions.md#role-mentions)

--- a/docs/bot/rules/links.md
+++ b/docs/bot/rules/links.md
@@ -1,0 +1,20 @@
+# Links
+
+> Auto-generated documentation for [bot.rules.links](https://github.com/python-discord/bot/blob/master/bot/rules/links.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Rules](index.md#rules) / Links
+  - [apply](#apply)
+
+## apply
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/rules/links.py#L10)
+
+```python
+def apply(
+    last_message: Message,
+    recent_messages: List[discord.message.Message],
+    config: Dict[str, int],
+) -> Union[Tuple[str, Iterable[discord.member.Member], Iterable[discord.message.Message]], NoneType]
+```
+
+Detects total links exceeding the limit sent by a single user.

--- a/docs/bot/rules/mentions.md
+++ b/docs/bot/rules/mentions.md
@@ -1,0 +1,20 @@
+# Mentions
+
+> Auto-generated documentation for [bot.rules.mentions](https://github.com/python-discord/bot/blob/master/bot/rules/mentions.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Rules](index.md#rules) / Mentions
+  - [apply](#apply)
+
+## apply
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/rules/mentions.py#L6)
+
+```python
+def apply(
+    last_message: Message,
+    recent_messages: List[discord.message.Message],
+    config: Dict[str, int],
+) -> Union[Tuple[str, Iterable[discord.member.Member], Iterable[discord.message.Message]], NoneType]
+```
+
+Detects total mentions exceeding the limit sent by a single user.

--- a/docs/bot/rules/newlines.md
+++ b/docs/bot/rules/newlines.md
@@ -1,0 +1,20 @@
+# Newlines
+
+> Auto-generated documentation for [bot.rules.newlines](https://github.com/python-discord/bot/blob/master/bot/rules/newlines.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Rules](index.md#rules) / Newlines
+  - [apply](#apply)
+
+## apply
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/rules/newlines.py#L7)
+
+```python
+def apply(
+    last_message: Message,
+    recent_messages: List[discord.message.Message],
+    config: Dict[str, int],
+) -> Union[Tuple[str, Iterable[discord.member.Member], Iterable[discord.message.Message]], NoneType]
+```
+
+Detects total newlines exceeding the set limit sent by a single user.

--- a/docs/bot/rules/role_mentions.md
+++ b/docs/bot/rules/role_mentions.md
@@ -1,0 +1,20 @@
+# Role Mentions
+
+> Auto-generated documentation for [bot.rules.role_mentions](https://github.com/python-discord/bot/blob/master/bot/rules/role_mentions.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Rules](index.md#rules) / Role Mentions
+  - [apply](#apply)
+
+## apply
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/rules/role_mentions.py#L6)
+
+```python
+def apply(
+    last_message: Message,
+    recent_messages: List[discord.message.Message],
+    config: Dict[str, int],
+) -> Union[Tuple[str, Iterable[discord.member.Member], Iterable[discord.message.Message]], NoneType]
+```
+
+Detects total role mentions exceeding the limit sent by a single user.

--- a/docs/bot/utils/checks.md
+++ b/docs/bot/utils/checks.md
@@ -1,0 +1,55 @@
+# Checks
+
+> Auto-generated documentation for [bot.utils.checks](https://github.com/python-discord/bot/blob/master/bot/utils/checks.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Utils](index.md#utils) / Checks
+  - [cooldown_with_role_bypass](#cooldown_with_role_bypass)
+  - [in_channel_check](#in_channel_check)
+  - [with_role_check](#with_role_check)
+  - [without_role_check](#without_role_check)
+
+## cooldown_with_role_bypass
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/checks.py#L49)
+
+```python
+def cooldown_with_role_bypass(
+    rate: int,
+    per: float,
+    type: BucketType = <BucketType.default: 0>,
+) -> Callable
+```
+
+Applies a cooldown to a command, but allows members with certain roles to be ignored.
+
+NOTE: this replaces the `Command.before_invoke` callback, which *might* introduce problems in the future.
+
+## in_channel_check
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/checks.py#L41)
+
+```python
+def in_channel_check(ctx: Context, channel_id: int) -> bool
+```
+
+Checks if the command was executed inside of the specified channel.
+
+## with_role_check
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/checks.py#L10)
+
+```python
+def with_role_check(ctx: Context, role_ids: int) -> bool
+```
+
+Returns True if the user has any one of the roles in role_ids.
+
+## without_role_check
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/checks.py#L27)
+
+```python
+def without_role_check(ctx: Context, role_ids: int) -> bool
+```
+
+Returns True if the user does not have any of the roles in role_ids.

--- a/docs/bot/utils/index.md
+++ b/docs/bot/utils/index.md
@@ -1,0 +1,91 @@
+# Utils
+
+> Auto-generated documentation for [bot.utils](https://github.com/python-discord/bot/blob/master/bot/utils/__init__.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / Utils
+  - [CaseInsensitiveDict](#caseinsensitivedict)
+    - [CaseInsensitiveDict().get](#caseinsensitivedictget)
+    - [CaseInsensitiveDict().pop](#caseinsensitivedictpop)
+    - [CaseInsensitiveDict().setdefault](#caseinsensitivedictsetdefault)
+    - [CaseInsensitiveDict().update](#caseinsensitivedictupdate)
+  - [CogABCMeta](#cogabcmeta)
+  - [chunks](#chunks)
+  - Modules
+    - [Checks](checks.md#checks)
+    - [Messages](messages.md#messages)
+    - [Scheduling](scheduling.md#scheduling)
+    - [Time](time.md#time)
+
+## CaseInsensitiveDict
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/__init__.py#L13)
+
+```python
+class CaseInsensitiveDict()
+```
+
+We found this class on StackOverflow. Thanks to m000 for writing it!
+
+https://stackoverflow.com/a/32888599/4022104
+
+### CaseInsensitiveDict().get
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/__init__.py#L49)
+
+```python
+def get(key: Hashable, args, kwargs) -> Any
+```
+
+Case insensitive get.
+
+### CaseInsensitiveDict().pop
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/__init__.py#L45)
+
+```python
+def pop(key: Hashable, args, kwargs) -> Any
+```
+
+Case insensitive pop.
+
+### CaseInsensitiveDict().setdefault
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/__init__.py#L53)
+
+```python
+def setdefault(key: Hashable, args, kwargs) -> Any
+```
+
+Case insensitive setdefault.
+
+### CaseInsensitiveDict().update
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/__init__.py#L57)
+
+```python
+def update(E: Any, F=None) -> None
+```
+
+Case insensitive update.
+
+## CogABCMeta
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/__init__.py#L7)
+
+```python
+class CogABCMeta()
+```
+
+Metaclass for ABCs meant to be implemented as Cogs.
+
+## chunks
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/__init__.py#L69)
+
+```python
+def chunks(iterable: Iterable, size: int) -> Generator[Any, NoneType, NoneType]
+```
+
+Generator that allows you to iterate over any indexable collection in `size`-length chunks.
+
+Found: https://stackoverflow.com/a/312464/4022104

--- a/docs/bot/utils/messages.md
+++ b/docs/bot/utils/messages.md
@@ -1,0 +1,46 @@
+# Messages
+
+> Auto-generated documentation for [bot.utils.messages](https://github.com/python-discord/bot/blob/master/bot/utils/messages.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Utils](index.md#utils) / Messages
+  - [send_attachments](#send_attachments)
+  - [wait_for_deletion](#wait_for_deletion)
+
+## send_attachments
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/messages.py#L54)
+
+```python
+def send_attachments(
+    message: Message,
+    destination: Union[discord.channel.TextChannel, discord.webhook.Webhook],
+) -> None
+```
+
+Re-uploads each attachment in a message to the given channel or webhook.
+
+Each attachment is sent as a separate message to more easily comply with the 8 MiB request size limit.
+If attachments are too large, they are instead grouped into a single embed which links to them.
+
+## wait_for_deletion
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/messages.py#L15)
+
+```python
+def wait_for_deletion(
+    message: Message,
+    user_ids: Sequence[discord.abc.Snowflake],
+    deletion_emojis: Sequence[str] = ('❌',),
+    timeout: float = 300,
+    attach_emojis: bool = True,
+    client: Union[discord.client.Client, NoneType] = None,
+) -> None
+```
+
+Wait for up to `timeout` seconds for a reaction by any of the specified `user_ids` to delete the message.
+
+An `attach_emojis` bool may be specified to determine whether to attach the given
+`deletion_emojis` to the message in the given `context`
+
+A `client` instance may be optionally specified, otherwise client will be taken from the
+guild of the message.

--- a/docs/bot/utils/scheduling.md
+++ b/docs/bot/utils/scheduling.md
@@ -1,0 +1,69 @@
+# Scheduling
+
+> Auto-generated documentation for [bot.utils.scheduling](https://github.com/python-discord/bot/blob/master/bot/utils/scheduling.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Utils](index.md#utils) / Scheduling
+  - [Scheduler](#scheduler)
+    - [Scheduler().cancel_task](#schedulercancel_task)
+    - [Scheduler().schedule_task](#schedulerschedule_task)
+  - [_silent_exception](#_silent_exception)
+  - [create_task](#create_task)
+
+## Scheduler
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/scheduling.py#L12)
+
+```python
+class Scheduler()
+```
+
+Task scheduler.
+
+### Scheduler().cancel_task
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/scheduling.py#L45)
+
+```python
+def cancel_task(task_id: str) -> None
+```
+
+Un-schedules a task.
+
+### Scheduler().schedule_task
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/scheduling.py#L32)
+
+```python
+def schedule_task(
+    loop: AbstractEventLoop,
+    task_id: str,
+    task_data: dict,
+) -> None
+```
+
+Schedules a task.
+
+`task_data` is passed to `Scheduler._scheduled_expiration`
+
+## _silent_exception
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/scheduling.py#L67)
+
+```python
+def _silent_exception(future: Future) -> None
+```
+
+Suppress future's exception.
+
+## create_task
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/scheduling.py#L58)
+
+```python
+def create_task(
+    loop: AbstractEventLoop,
+    coro_or_future: Union[Coroutine, _asyncio.Future],
+) -> Task
+```
+
+Creates an asyncio.Task object from a coroutine or future object.

--- a/docs/bot/utils/time.md
+++ b/docs/bot/utils/time.md
@@ -1,0 +1,102 @@
+# Time
+
+> Auto-generated documentation for [bot.utils.time](https://github.com/python-discord/bot/blob/master/bot/utils/time.py) module.
+
+- [Index](../../README.md#modules) / [Bot](../index.md#bot) / [Utils](index.md#utils) / Time
+  - [_stringify_time_unit](#_stringify_time_unit)
+  - [format_infraction](#format_infraction)
+  - [humanize_delta](#humanize_delta)
+  - [parse_rfc1123](#parse_rfc1123)
+  - [time_since](#time_since)
+  - [wait_until](#wait_until)
+
+## _stringify_time_unit
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/time.py#L12)
+
+```python
+def _stringify_time_unit(value: int, unit: str) -> str
+```
+
+Returns a string to represent a value and time unit, ensuring that it uses the right plural form of the unit.
+
+```python
+>>> _stringify_time_unit(1, "seconds")
+"1 second"
+>>> _stringify_time_unit(24, "hours")
+"24 hours"
+>>> _stringify_time_unit(0, "minutes")
+"less than a minute"
+```
+
+## format_infraction
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/time.py#L111)
+
+```python
+def format_infraction(timestamp: str) -> str
+```
+
+Format an infraction timestamp to a more readable ISO 8601 format.
+
+## humanize_delta
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/time.py#L31)
+
+```python
+def humanize_delta(
+    delta: relativedelta,
+    precision: str = 'seconds',
+    max_units: int = 6,
+) -> str
+```
+
+Returns a human-readable version of the relativedelta.
+
+precision specifies the smallest unit of time to include (e.g. "seconds", "minutes").
+max_units specifies the maximum number of units of time to include (e.g. 1 may include days but not hours).
+
+## parse_rfc1123
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/time.py#L90)
+
+```python
+def parse_rfc1123(stamp: str) -> datetime
+```
+
+Parse RFC1123 time string into datetime.
+
+## time_since
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/time.py#L75)
+
+```python
+def time_since(
+    past_datetime: datetime,
+    precision: str = 'seconds',
+    max_units: int = 6,
+) -> str
+```
+
+Takes a datetime and returns a human-readable string that describes how long ago that datetime was.
+
+precision specifies the smallest unit of time to include (e.g. "seconds", "minutes").
+max_units specifies the maximum number of units of time to include (e.g. 1 may include days but not hours).
+
+## wait_until
+
+[🔍 find in source code](https://github.com/python-discord/bot/blob/master/bot/utils/time.py#L96)
+
+```python
+def wait_until(
+    time: datetime,
+    start: Union[datetime.datetime, NoneType] = None,
+) -> None
+```
+
+Wait until a given time.
+
+#### Arguments
+
+- `time` - A datetime.datetime object to wait until.
+- `start` - The start from which to calculate the waiting duration. Defaults to UTC time.


### PR DESCRIPTION
### Summary

Since the project is growing, it would be nice to have an index of every object in the repo.It is compatible with [Github Pages](https://pages.github.com/), so they can be enabled in one click, no extra configuration required.

I have just finished working on my docstring documentation generator `handsdown` and think that it might be useful for Discord Bot as well.