### PR TITLE
Schedule superstarify infractions for expiration

### DIFF
--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -1,8 +1,6 @@
 import logging
-import textwrap
 import typing as t
 from datetime import datetime
-from gettext import ngettext
 
 import dateutil.parser
 import discord
@@ -11,14 +9,11 @@ from discord.ext import commands
 from discord.ext.commands import Context, command
 
 from bot import constants
-from bot.api import ResponseCodeError
-from bot.constants import Colours, Event, STAFF_CHANNELS
+from bot.constants import Event
 from bot.decorators import respect_role_hierarchy
-from bot.utils import time
 from bot.utils.checks import with_role_check
-from bot.utils.scheduling import Scheduler
 from . import utils
-from .modlog import ModLog
+from .scheduler import InfractionScheduler
 from .utils import MemberObject
 
 log = logging.getLogger(__name__)
@@ -26,37 +21,17 @@ log = logging.getLogger(__name__)
 MemberConverter = t.Union[utils.UserTypes, utils.proxy_user]
 
 
-class Infractions(Scheduler, commands.Cog):
+class Infractions(InfractionScheduler, commands.Cog):
     """Apply and pardon infractions on users for moderation purposes."""
 
     category = "Moderation"
     category_description = "Server moderation tools."
 
     def __init__(self, bot: commands.Bot):
-        super().__init__()
+        super().__init__(bot)
 
-        self.bot = bot
         self.category = "Moderation"
         self._muted_role = discord.Object(constants.Roles.muted)
-
-        self.bot.loop.create_task(self.reschedule_infractions())
-
-    @property
-    def mod_log(self) -> ModLog:
-        """Get currently loaded ModLog cog instance."""
-        return self.bot.get_cog("ModLog")
-
-    async def reschedule_infractions(self) -> None:
-        """Schedule expiration for previous infractions."""
-        await self.bot.wait_until_ready()
-
-        infractions = await self.bot.api_client.get(
-            'bot/infractions',
-            params={'active': 'true'}
-        )
-        for infraction in infractions:
-            if infraction["expires_at"] is not None:
-                self.schedule_task(self.bot.loop, infraction["id"], infraction)
 
     @commands.Cog.listener()
     async def on_member_join(self, member: Member) -> None:
@@ -276,330 +251,6 @@ class Infractions(Scheduler, commands.Cog):
 
         action = ctx.guild.ban(user, reason=reason, delete_message_days=0)
         await self.apply_infraction(ctx, infraction, user, action)
-
-    # endregion
-    # region: Utility functions
-
-    async def _scheduled_task(self, infraction: utils.Infraction) -> None:
-        """
-        Marks an infraction expired after the delay from time of scheduling to time of expiration.
-
-        At the time of expiration, the infraction is marked as inactive on the website and the
-        expiration task is cancelled.
-        """
-        _id = infraction["id"]
-
-        expiry = dateutil.parser.isoparse(infraction["expires_at"]).replace(tzinfo=None)
-        await time.wait_until(expiry)
-
-        log.debug(f"Marking infraction {_id} as inactive (expired).")
-        await self.deactivate_infraction(infraction)
-
-    async def deactivate_infraction(
-        self,
-        infraction: utils.Infraction,
-        send_log: bool = True
-    ) -> t.Dict[str, str]:
-        """
-        Deactivate an active infraction and return a dictionary of lines to send in a mod log.
-
-        The infraction is removed from Discord, marked as inactive in the database, and has its
-        expiration task cancelled. If `send_log` is True, a mod log is sent for the
-        deactivation of the infraction.
-
-        Supported infraction types are mute and ban. Other types will raise a ValueError.
-        """
-        guild = self.bot.get_guild(constants.Guild.id)
-        mod_role = guild.get_role(constants.Roles.moderator)
-        user_id = infraction["user"]
-        _type = infraction["type"]
-        _id = infraction["id"]
-        reason = f"Infraction #{_id} expired or was pardoned."
-
-        log.debug(f"Marking infraction #{_id} as inactive (expired).")
-
-        log_content = None
-        log_text = {
-            "Member": str(user_id),
-            "Actor": str(self.bot.user),
-            "Reason": infraction["reason"]
-        }
-
-        try:
-            if _type == "mute":
-                user = guild.get_member(user_id)
-                if user:
-                    # Remove the muted role.
-                    self.mod_log.ignore(Event.member_update, user.id)
-                    await user.remove_roles(self._muted_role, reason=reason)
-
-                    # DM the user about the expiration.
-                    notified = await utils.notify_pardon(
-                        user=user,
-                        title="You have been unmuted.",
-                        content="You may now send messages in the server.",
-                        icon_url=utils.INFRACTION_ICONS["mute"][1]
-                    )
-
-                    log_text["Member"] = f"{user.mention}(`{user.id}`)"
-                    log_text["DM"] = "Sent" if notified else "**Failed**"
-                else:
-                    log.info(f"Failed to unmute user {user_id}: user not found")
-                    log_text["Failure"] = "User was not found in the guild."
-            elif _type == "ban":
-                user = discord.Object(user_id)
-                self.mod_log.ignore(Event.member_unban, user_id)
-                try:
-                    await guild.unban(user, reason=reason)
-                except discord.NotFound:
-                    log.info(f"Failed to unban user {user_id}: no active ban found on Discord")
-                    log_text["Note"] = "No active ban found on Discord."
-            else:
-                raise ValueError(
-                    f"Attempted to deactivate an unsupported infraction #{_id} ({_type})!"
-                )
-        except discord.Forbidden:
-            log.warning(f"Failed to deactivate infraction #{_id} ({_type}): bot lacks permissions")
-            log_text["Failure"] = f"The bot lacks permissions to do this (role hierarchy?)"
-            log_content = mod_role.mention
-        except discord.HTTPException as e:
-            log.exception(f"Failed to deactivate infraction #{_id} ({_type})")
-            log_text["Failure"] = f"HTTPException with code {e.code}."
-            log_content = mod_role.mention
-
-        # Check if the user is currently being watched by Big Brother.
-        try:
-            active_watch = await self.bot.api_client.get(
-                "bot/infractions",
-                params={
-                    "active": "true",
-                    "type": "watch",
-                    "user__id": user_id
-                }
-            )
-
-            log_text["Watching"] = "Yes" if active_watch else "No"
-        except ResponseCodeError:
-            log.exception(f"Failed to fetch watch status for user {user_id}")
-            log_text["Watching"] = "Unknown - failed to fetch watch status."
-
-        try:
-            # Mark infraction as inactive in the database.
-            await self.bot.api_client.patch(
-                f"bot/infractions/{_id}",
-                json={"active": False}
-            )
-        except ResponseCodeError as e:
-            log.exception(f"Failed to deactivate infraction #{_id} ({_type})")
-            log_line = f"API request failed with code {e.status}."
-            log_content = mod_role.mention
-
-            # Append to an existing failure message if possible
-            if "Failure" in log_text:
-                log_text["Failure"] += f" {log_line}"
-            else:
-                log_text["Failure"] = log_line
-
-        # Cancel the expiration task.
-        if infraction["expires_at"] is not None:
-            self.cancel_task(infraction["id"])
-
-        # Send a log message to the mod log.
-        if send_log:
-            log_title = f"expiration failed" if "Failure" in log_text else "expired"
-
-            await self.mod_log.send_log_message(
-                icon_url=utils.INFRACTION_ICONS[_type][1],
-                colour=Colours.soft_green,
-                title=f"Infraction {log_title}: {_type}",
-                text="\n".join(f"{k}: {v}" for k, v in log_text.items()),
-                footer=f"ID: {_id}",
-                content=log_content,
-            )
-
-        return log_text
-
-    async def apply_infraction(
-        self,
-        ctx: Context,
-        infraction: utils.Infraction,
-        user: MemberObject,
-        action_coro: t.Optional[t.Awaitable] = None
-    ) -> None:
-        """Apply an infraction to the user, log the infraction, and optionally notify the user."""
-        infr_type = infraction["type"]
-        icon = utils.INFRACTION_ICONS[infr_type][0]
-        reason = infraction["reason"]
-        expiry = infraction["expires_at"]
-
-        if expiry:
-            expiry = time.format_infraction(expiry)
-
-        # Default values for the confirmation message and mod log.
-        confirm_msg = f":ok_hand: applied"
-
-        # Specifying an expiry for a note or warning makes no sense.
-        if infr_type in ("note", "warning"):
-            expiry_msg = ""
-        else:
-            expiry_msg = f" until {expiry}" if expiry else " permanently"
-
-        dm_result = ""
-        dm_log_text = ""
-        expiry_log_text = f"Expires: {expiry}" if expiry else ""
-        log_title = "applied"
-        log_content = None
-
-        # DM the user about the infraction if it's not a shadow/hidden infraction.
-        if not infraction["hidden"]:
-            # Sometimes user is a discord.Object; make it a proper user.
-            await self.bot.fetch_user(user.id)
-
-            # Accordingly display whether the user was successfully notified via DM.
-            if await utils.notify_infraction(user, infr_type, expiry, reason, icon):
-                dm_result = ":incoming_envelope: "
-                dm_log_text = "\nDM: Sent"
-            else:
-                dm_log_text = "\nDM: **Failed**"
-                log_content = ctx.author.mention
-
-        if infraction["actor"] == self.bot.user.id:
-            end_msg = f" (reason: {infraction['reason']})"
-        elif ctx.channel.id not in STAFF_CHANNELS:
-            end_msg = ''
-        else:
-            infractions = await self.bot.api_client.get(
-                "bot/infractions",
-                params={"user__id": str(user.id)}
-            )
-            total = len(infractions)
-            end_msg = f" ({total} infraction{ngettext('', 's', total)} total)"
-
-        # Execute the necessary actions to apply the infraction on Discord.
-        if action_coro:
-            try:
-                await action_coro
-                if expiry:
-                    # Schedule the expiration of the infraction.
-                    self.schedule_task(ctx.bot.loop, infraction["id"], infraction)
-            except discord.Forbidden:
-                # Accordingly display that applying the infraction failed.
-                confirm_msg = f":x: failed to apply"
-                expiry_msg = ""
-                log_content = ctx.author.mention
-                log_title = "failed to apply"
-
-        # Send a confirmation message to the invoking context.
-        await ctx.send(
-            f"{dm_result}{confirm_msg} **{infr_type}** to {user.mention}{expiry_msg}{end_msg}."
-        )
-
-        # Send a log message to the mod log.
-        await self.mod_log.send_log_message(
-            icon_url=icon,
-            colour=Colours.soft_red,
-            title=f"Infraction {log_title}: {infr_type}",
-            thumbnail=user.avatar_url_as(static_format="png"),
-            text=textwrap.dedent(f"""
-                Member: {user.mention} (`{user.id}`)
-                Actor: {ctx.message.author}{dm_log_text}
-                Reason: {reason}
-                {expiry_log_text}
-            """),
-            content=log_content,
-            footer=f"ID {infraction['id']}"
-        )
-
-    async def pardon_infraction(self, ctx: Context, infr_type: str, user: MemberObject) -> None:
-        """Prematurely end an infraction for a user and log the action in the mod log."""
-        # Check the current active infraction
-        response = await self.bot.api_client.get(
-            'bot/infractions',
-            params={
-                'active': 'true',
-                'type': infr_type,
-                'user__id': user.id
-            }
-        )
-
-        if not response:
-            await ctx.send(f":x: There's no active {infr_type} infraction for user {user.mention}.")
-            return
-
-        # Deactivate the infraction and cancel its scheduled expiration task.
-        log_text = await self.deactivate_infraction(response[0], send_log=False)
-
-        log_text["Member"] = f"{user.mention}(`{user.id}`)"
-        log_text["Actor"] = str(ctx.message.author)
-        log_content = None
-        footer = f"ID: {response[0]['id']}"
-
-        # If multiple active infractions were found, mark them as inactive in the database
-        # and cancel their expiration tasks.
-        if len(response) > 1:
-            log.warning(f"Found more than one active {infr_type} infraction for user {user.id}")
-
-            footer = f"Infraction IDs: {', '.join(str(infr['id']) for infr in response)}"
-
-            log_note = f"Found multiple **active** {infr_type} infractions in the database."
-            if "Note" in log_text:
-                log_text["Note"] = f" {log_note}"
-            else:
-                log_text["Note"] = log_note
-
-            # deactivate_infraction() is not called again because:
-            #     1. Discord cannot store multiple active bans or assign multiples of the same role
-            #     2. It would send a pardon DM for each active infraction, which is redundant
-            for infraction in response[1:]:
-                _id = infraction['id']
-                try:
-                    # Mark infraction as inactive in the database.
-                    await self.bot.api_client.patch(
-                        f"bot/infractions/{_id}",
-                        json={"active": False}
-                    )
-                except ResponseCodeError:
-                    log.exception(f"Failed to deactivate infraction #{_id} ({infr_type})")
-                    # This is simpler and cleaner than trying to concatenate all the errors.
-                    log_text["Failure"] = "See bot's logs for details."
-
-                # Cancel pending expiration task.
-                if infraction["expires_at"] is not None:
-                    self.cancel_task(infraction["id"])
-
-        # Accordingly display whether the user was successfully notified via DM.
-        dm_emoji = ""
-        if log_text.get("DM") == "Sent":
-            dm_emoji = ":incoming_envelope: "
-        elif "DM" in log_text:
-            # Mention the actor because the DM failed to send.
-            log_content = ctx.author.mention
-
-        # Accordingly display whether the pardon failed.
-        if "Failure" in log_text:
-            confirm_msg = ":x: failed to pardon"
-            log_title = "pardon failed"
-            log_content = ctx.author.mention
-        else:
-            confirm_msg = f":ok_hand: pardoned"
-            log_title = "pardoned"
-
-        # Send a confirmation message to the invoking context.
-        await ctx.send(
-            f"{dm_emoji}{confirm_msg} infraction **{infr_type}** for {user.mention}. "
-            f"{log_text.get('Failure', '')}"
-        )
-
-        # Send a log message to the mod log.
-        await self.mod_log.send_log_message(
-            icon_url=utils.INFRACTION_ICONS[infr_type][1],
-            colour=Colours.soft_green,
-            title=f"Infraction {log_title}: {infr_type}",
-            thumbnail=user.avatar_url_as(static_format="png"),
-            text="\n".join(f"{k}: {v}" for k, v in log_text.items()),
-            footer=footer,
-            content=log_content,
-        )
 
     # endregion
 

--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -26,7 +26,7 @@ class Infractions(InfractionScheduler, commands.Cog):
     category_description = "Server moderation tools."
 
     def __init__(self, bot: commands.Bot):
-        super().__init__(bot)
+        super().__init__(bot, supported_infractions={"ban", "kick", "mute", "note", "warning"})
 
         self.category = "Moderation"
         self._muted_role = discord.Object(constants.Roles.muted)

--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -254,7 +254,7 @@ class Infractions(InfractionScheduler, commands.Cog):
             # DM the user about the expiration.
             notified = await utils.notify_pardon(
                 user=user,
-                title="You have been unmuted.",
+                title="You have been unmuted",
                 content="You may now send messages in the server.",
                 icon_url=utils.INFRACTION_ICONS["mute"][1]
             )

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -1,0 +1,368 @@
+import logging
+import textwrap
+import typing as t
+from gettext import ngettext
+
+import dateutil.parser
+import discord
+from discord.ext import commands
+from discord.ext.commands import Context
+
+from bot import constants
+from bot.api import ResponseCodeError
+from bot.constants import Colours, Event, STAFF_CHANNELS
+from bot.utils import time
+from bot.utils.scheduling import Scheduler
+from . import utils
+from .modlog import ModLog
+from .utils import MemberObject
+
+log = logging.getLogger(__name__)
+
+
+class InfractionScheduler(Scheduler):
+    """Handles the application, pardoning, and expiration of infractions."""
+
+    def __init__(self, bot: commands.Bot):
+        super().__init__()
+
+        self.bot = bot
+        self.bot.loop.create_task(self.reschedule_infractions())
+
+    @property
+    def mod_log(self) -> ModLog:
+        """Get the currently loaded ModLog cog instance."""
+        return self.bot.get_cog("ModLog")
+
+    async def reschedule_infractions(self) -> None:
+        """Schedule expiration for previous infractions."""
+        await self.bot.wait_until_ready()
+
+        infractions = await self.bot.api_client.get(
+            'bot/infractions',
+            params={'active': 'true'}
+        )
+        for infraction in infractions:
+            if infraction["expires_at"] is not None:
+                self.schedule_task(self.bot.loop, infraction["id"], infraction)
+
+    async def apply_infraction(
+        self,
+        ctx: Context,
+        infraction: utils.Infraction,
+        user: MemberObject,
+        action_coro: t.Optional[t.Awaitable] = None
+    ) -> None:
+        """Apply an infraction to the user, log the infraction, and optionally notify the user."""
+        infr_type = infraction["type"]
+        icon = utils.INFRACTION_ICONS[infr_type][0]
+        reason = infraction["reason"]
+        expiry = infraction["expires_at"]
+
+        if expiry:
+            expiry = time.format_infraction(expiry)
+
+        # Default values for the confirmation message and mod log.
+        confirm_msg = f":ok_hand: applied"
+
+        # Specifying an expiry for a note or warning makes no sense.
+        if infr_type in ("note", "warning"):
+            expiry_msg = ""
+        else:
+            expiry_msg = f" until {expiry}" if expiry else " permanently"
+
+        dm_result = ""
+        dm_log_text = ""
+        expiry_log_text = f"Expires: {expiry}" if expiry else ""
+        log_title = "applied"
+        log_content = None
+
+        # DM the user about the infraction if it's not a shadow/hidden infraction.
+        if not infraction["hidden"]:
+            # Sometimes user is a discord.Object; make it a proper user.
+            await self.bot.fetch_user(user.id)
+
+            # Accordingly display whether the user was successfully notified via DM.
+            if await utils.notify_infraction(user, infr_type, expiry, reason, icon):
+                dm_result = ":incoming_envelope: "
+                dm_log_text = "\nDM: Sent"
+            else:
+                dm_log_text = "\nDM: **Failed**"
+                log_content = ctx.author.mention
+
+        if infraction["actor"] == self.bot.user.id:
+            end_msg = f" (reason: {infraction['reason']})"
+        elif ctx.channel.id not in STAFF_CHANNELS:
+            end_msg = ""
+        else:
+            infractions = await self.bot.api_client.get(
+                "bot/infractions",
+                params={"user__id": str(user.id)}
+            )
+            total = len(infractions)
+            end_msg = f" ({total} infraction{ngettext('', 's', total)} total)"
+
+        # Execute the necessary actions to apply the infraction on Discord.
+        if action_coro:
+            try:
+                await action_coro
+                if expiry:
+                    # Schedule the expiration of the infraction.
+                    self.schedule_task(ctx.bot.loop, infraction["id"], infraction)
+            except discord.Forbidden:
+                # Accordingly display that applying the infraction failed.
+                confirm_msg = f":x: failed to apply"
+                expiry_msg = ""
+                log_content = ctx.author.mention
+                log_title = "failed to apply"
+
+        # Send a confirmation message to the invoking context.
+        await ctx.send(
+            f"{dm_result}{confirm_msg} **{infr_type}** to {user.mention}{expiry_msg}{end_msg}."
+        )
+
+        # Send a log message to the mod log.
+        await self.mod_log.send_log_message(
+            icon_url=icon,
+            colour=Colours.soft_red,
+            title=f"Infraction {log_title}: {infr_type}",
+            thumbnail=user.avatar_url_as(static_format="png"),
+            text=textwrap.dedent(f"""
+                Member: {user.mention} (`{user.id}`)
+                Actor: {ctx.message.author}{dm_log_text}
+                Reason: {reason}
+                {expiry_log_text}
+            """),
+            content=log_content,
+            footer=f"ID {infraction['id']}"
+        )
+
+    async def pardon_infraction(self, ctx: Context, infr_type: str, user: MemberObject) -> None:
+        """Prematurely end an infraction for a user and log the action in the mod log."""
+        # Check the current active infraction
+        response = await self.bot.api_client.get(
+            'bot/infractions',
+            params={
+                'active': 'true',
+                'type': infr_type,
+                'user__id': user.id
+            }
+        )
+
+        if not response:
+            await ctx.send(f":x: There's no active {infr_type} infraction for user {user.mention}.")
+            return
+
+        # Deactivate the infraction and cancel its scheduled expiration task.
+        log_text = await self.deactivate_infraction(response[0], send_log=False)
+
+        log_text["Member"] = f"{user.mention}(`{user.id}`)"
+        log_text["Actor"] = str(ctx.message.author)
+        log_content = None
+        footer = f"ID: {response[0]['id']}"
+
+        # If multiple active infractions were found, mark them as inactive in the database
+        # and cancel their expiration tasks.
+        if len(response) > 1:
+            log.warning(f"Found more than one active {infr_type} infraction for user {user.id}")
+
+            footer = f"Infraction IDs: {', '.join(str(infr['id']) for infr in response)}"
+
+            log_note = f"Found multiple **active** {infr_type} infractions in the database."
+            if "Note" in log_text:
+                log_text["Note"] = f" {log_note}"
+            else:
+                log_text["Note"] = log_note
+
+            # deactivate_infraction() is not called again because:
+            #     1. Discord cannot store multiple active bans or assign multiples of the same role
+            #     2. It would send a pardon DM for each active infraction, which is redundant
+            for infraction in response[1:]:
+                _id = infraction['id']
+                try:
+                    # Mark infraction as inactive in the database.
+                    await self.bot.api_client.patch(
+                        f"bot/infractions/{_id}",
+                        json={"active": False}
+                    )
+                except ResponseCodeError:
+                    log.exception(f"Failed to deactivate infraction #{_id} ({infr_type})")
+                    # This is simpler and cleaner than trying to concatenate all the errors.
+                    log_text["Failure"] = "See bot's logs for details."
+
+                # Cancel pending expiration task.
+                if infraction["expires_at"] is not None:
+                    self.cancel_task(infraction["id"])
+
+        # Accordingly display whether the user was successfully notified via DM.
+        dm_emoji = ""
+        if log_text.get("DM") == "Sent":
+            dm_emoji = ":incoming_envelope: "
+        elif "DM" in log_text:
+            # Mention the actor because the DM failed to send.
+            log_content = ctx.author.mention
+
+        # Accordingly display whether the pardon failed.
+        if "Failure" in log_text:
+            confirm_msg = ":x: failed to pardon"
+            log_title = "pardon failed"
+            log_content = ctx.author.mention
+        else:
+            confirm_msg = f":ok_hand: pardoned"
+            log_title = "pardoned"
+
+        # Send a confirmation message to the invoking context.
+        await ctx.send(
+            f"{dm_emoji}{confirm_msg} infraction **{infr_type}** for {user.mention}. "
+            f"{log_text.get('Failure', '')}"
+        )
+
+        # Send a log message to the mod log.
+        await self.mod_log.send_log_message(
+            icon_url=utils.INFRACTION_ICONS[infr_type][1],
+            colour=Colours.soft_green,
+            title=f"Infraction {log_title}: {infr_type}",
+            thumbnail=user.avatar_url_as(static_format="png"),
+            text="\n".join(f"{k}: {v}" for k, v in log_text.items()),
+            footer=footer,
+            content=log_content,
+        )
+
+    async def deactivate_infraction(
+        self,
+        infraction: utils.Infraction,
+        send_log: bool = True
+    ) -> t.Dict[str, str]:
+        """
+        Deactivate an active infraction and return a dictionary of lines to send in a mod log.
+
+        The infraction is removed from Discord, marked as inactive in the database, and has its
+        expiration task cancelled. If `send_log` is True, a mod log is sent for the
+        deactivation of the infraction.
+
+        Supported infraction types are mute and ban. Other types will raise a ValueError.
+        """
+        guild = self.bot.get_guild(constants.Guild.id)
+        mod_role = guild.get_role(constants.Roles.moderator)
+        user_id = infraction["user"]
+        _type = infraction["type"]
+        _id = infraction["id"]
+        reason = f"Infraction #{_id} expired or was pardoned."
+
+        log.debug(f"Marking infraction #{_id} as inactive (expired).")
+
+        log_content = None
+        log_text = {
+            "Member": str(user_id),
+            "Actor": str(self.bot.user),
+            "Reason": infraction["reason"]
+        }
+
+        try:
+            if _type == "mute":
+                user = guild.get_member(user_id)
+                if user:
+                    # Remove the muted role.
+                    self.mod_log.ignore(Event.member_update, user.id)
+                    await user.remove_roles(self._muted_role, reason=reason)
+
+                    # DM the user about the expiration.
+                    notified = await utils.notify_pardon(
+                        user=user,
+                        title="You have been unmuted.",
+                        content="You may now send messages in the server.",
+                        icon_url=utils.INFRACTION_ICONS["mute"][1]
+                    )
+
+                    log_text["Member"] = f"{user.mention}(`{user.id}`)"
+                    log_text["DM"] = "Sent" if notified else "**Failed**"
+                else:
+                    log.info(f"Failed to unmute user {user_id}: user not found")
+                    log_text["Failure"] = "User was not found in the guild."
+            elif _type == "ban":
+                user = discord.Object(user_id)
+                self.mod_log.ignore(Event.member_unban, user_id)
+                try:
+                    await guild.unban(user, reason=reason)
+                except discord.NotFound:
+                    log.info(f"Failed to unban user {user_id}: no active ban found on Discord")
+                    log_text["Note"] = "No active ban found on Discord."
+            else:
+                raise ValueError(
+                    f"Attempted to deactivate an unsupported infraction #{_id} ({_type})!"
+                )
+        except discord.Forbidden:
+            log.warning(f"Failed to deactivate infraction #{_id} ({_type}): bot lacks permissions")
+            log_text["Failure"] = f"The bot lacks permissions to do this (role hierarchy?)"
+            log_content = mod_role.mention
+        except discord.HTTPException as e:
+            log.exception(f"Failed to deactivate infraction #{_id} ({_type})")
+            log_text["Failure"] = f"HTTPException with code {e.code}."
+            log_content = mod_role.mention
+
+        # Check if the user is currently being watched by Big Brother.
+        try:
+            active_watch = await self.bot.api_client.get(
+                "bot/infractions",
+                params={
+                    "active": "true",
+                    "type": "watch",
+                    "user__id": user_id
+                }
+            )
+
+            log_text["Watching"] = "Yes" if active_watch else "No"
+        except ResponseCodeError:
+            log.exception(f"Failed to fetch watch status for user {user_id}")
+            log_text["Watching"] = "Unknown - failed to fetch watch status."
+
+        try:
+            # Mark infraction as inactive in the database.
+            await self.bot.api_client.patch(
+                f"bot/infractions/{_id}",
+                json={"active": False}
+            )
+        except ResponseCodeError as e:
+            log.exception(f"Failed to deactivate infraction #{_id} ({_type})")
+            log_line = f"API request failed with code {e.status}."
+            log_content = mod_role.mention
+
+            # Append to an existing failure message if possible
+            if "Failure" in log_text:
+                log_text["Failure"] += f" {log_line}"
+            else:
+                log_text["Failure"] = log_line
+
+        # Cancel the expiration task.
+        if infraction["expires_at"] is not None:
+            self.cancel_task(infraction["id"])
+
+        # Send a log message to the mod log.
+        if send_log:
+            log_title = f"expiration failed" if "Failure" in log_text else "expired"
+
+            await self.mod_log.send_log_message(
+                icon_url=utils.INFRACTION_ICONS[_type][1],
+                colour=Colours.soft_green,
+                title=f"Infraction {log_title}: {_type}",
+                text="\n".join(f"{k}: {v}" for k, v in log_text.items()),
+                footer=f"ID: {_id}",
+                content=log_content,
+            )
+
+        return log_text
+
+    async def _scheduled_task(self, infraction: utils.Infraction) -> None:
+        """
+        Marks an infraction expired after the delay from time of scheduling to time of expiration.
+
+        At the time of expiration, the infraction is marked as inactive on the website and the
+        expiration task is cancelled.
+        """
+        _id = infraction["id"]
+
+        expiry = dateutil.parser.isoparse(infraction["expires_at"]).replace(tzinfo=None)
+        await time.wait_until(expiry)
+
+        log.debug(f"Marking infraction {_id} as inactive (expired).")
+        await self.deactivate_infraction(infraction)

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -80,7 +80,7 @@ class InfractionScheduler(Scheduler):
         # DM the user about the infraction if it's not a shadow/hidden infraction.
         if not infraction["hidden"]:
             # Sometimes user is a discord.Object; make it a proper user.
-            await self.bot.fetch_user(user.id)
+            user = await self.bot.fetch_user(user.id)
 
             # Accordingly display whether the user was successfully notified via DM.
             if await utils.notify_infraction(user, infr_type, expiry, reason, icon):

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -362,10 +362,7 @@ class InfractionScheduler(Scheduler):
         At the time of expiration, the infraction is marked as inactive on the website and the
         expiration task is cancelled.
         """
-        _id = infraction["id"]
-
         expiry = dateutil.parser.isoparse(infraction["expires_at"]).replace(tzinfo=None)
         await time.wait_until(expiry)
 
-        log.debug(f"Marking infraction {_id} as inactive (expired).")
         await self.deactivate_infraction(infraction)

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -24,18 +24,18 @@ log = logging.getLogger(__name__)
 class InfractionScheduler(Scheduler):
     """Handles the application, pardoning, and expiration of infractions."""
 
-    def __init__(self, bot: Bot):
+    def __init__(self, bot: Bot, supported_infractions: t.Container[str]):
         super().__init__()
 
         self.bot = bot
-        self.bot.loop.create_task(self.reschedule_infractions())
+        self.bot.loop.create_task(self.reschedule_infractions(supported_infractions))
 
     @property
     def mod_log(self) -> ModLog:
         """Get the currently loaded ModLog cog instance."""
         return self.bot.get_cog("ModLog")
 
-    async def reschedule_infractions(self) -> None:
+    async def reschedule_infractions(self, supported_infractions: t.Container[str]) -> None:
         """Schedule expiration for previous infractions."""
         await self.bot.wait_until_ready()
 
@@ -44,7 +44,7 @@ class InfractionScheduler(Scheduler):
             params={'active': 'true'}
         )
         for infraction in infractions:
-            if infraction["expires_at"] is not None:
+            if infraction["expires_at"] is not None and infraction["type"] in supported_infractions:
                 self.schedule_task(self.bot.loop, infraction["id"], infraction)
 
     async def reapply_infraction(

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -170,7 +170,7 @@ class Superstarify(InfractionScheduler, Cog):
             title="Member Achieved Superstardom",
             thumbnail=member.avatar_url_as(static_format="png"),
             text=textwrap.dedent(f"""
-                Member: {member.mentiom} (`{member.id}`)
+                Member: {member.mention} (`{member.id}`)
                 Actor: {ctx.message.author}
                 Reason: {reason}
                 Expires: {expiry_str}

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -100,10 +100,16 @@ class Superstarify(InfractionScheduler, Cog):
 
             await self.reapply_infraction(infraction, action)
 
-    @command(name='superstarify', aliases=('force_nick', 'star'))
-    async def superstarify(self, ctx: Context, member: Member, duration: utils.Expiry, reason: str = None) -> None:
+    @command(name="superstarify", aliases=("force_nick", "star"))
+    async def superstarify(
+        self,
+        ctx: Context,
+        member: Member,
+        duration: utils.Expiry,
+        reason: str = None
+    ) -> None:
         """
-        Force a random superstar name (like Taylor Swift) to be the user's nickname for a specified duration.
+        Temporarily force a random superstar name (like Taylor Swift) to be the user's nickname.
 
         A unit of time should be appended to the duration.
         Units (∗case-sensitive):
@@ -125,7 +131,7 @@ class Superstarify(InfractionScheduler, Cog):
 
         # Post the infraction to the API
         reason = reason or f"old nick: {member.display_name}"
-        infraction = await utils.post_infraction(ctx, member, "superstar", reason, expires_at=duration)
+        infraction = await utils.post_infraction(ctx, member, "superstar", reason, duration)
 
         forced_nick = self.get_nick(infraction["id"], member.id)
         expiry_str = format_infraction(infraction["expires_at"])
@@ -140,8 +146,8 @@ class Superstarify(InfractionScheduler, Cog):
             user=member,
             infr_type="Superstarify",
             expires_at=expiry_str,
-            reason=f"Your nickname didn't comply with our [nickname policy]({NICKNAME_POLICY_URL}).",
-            icon_url=utils.INFRACTION_ICONS["superstar"][0]
+            icon_url=utils.INFRACTION_ICONS["superstar"][0],
+            reason=f"Your nickname didn't comply with our [nickname policy]({NICKNAME_POLICY_URL})."
         )
 
         # Send an embed with the infraction information to the invoking context.
@@ -174,7 +180,7 @@ class Superstarify(InfractionScheduler, Cog):
             footer=f"ID {infraction['id']}"
         )
 
-    @command(name='unsuperstarify', aliases=('release_nick', 'unstar'))
+    @command(name="unsuperstarify", aliases=("release_nick", "unstar"))
     async def unsuperstarify(self, ctx: Context, member: Member) -> None:
         """Remove the superstarify infraction and allow the user to change their nickname."""
         await self.pardon_infraction(ctx, "superstar", member)

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -200,7 +200,7 @@ class Superstarify(InfractionScheduler, Cog):
         # DM the user about the expiration.
         notified = await utils.notify_pardon(
             user=user,
-            title="You are no longer superstarified.",
+            title="You are no longer superstarified",
             content="You may now change your nickname on the server.",
             icon_url=utils.INFRACTION_ICONS["superstar"][1]
         )

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -190,11 +190,14 @@ class Superstarify(InfractionScheduler, Cog):
 
     async def _pardon_action(self, infraction: utils.Infraction) -> t.Optional[t.Dict[str, str]]:
         """Pardon a superstar infraction and return a log dict."""
+        if infraction["type"] != "superstar":
+            return
+
         guild = self.bot.get_guild(constants.Guild.id)
         user = guild.get_member(infraction["user"])
 
         # Don't bother sending a notification if the user left the guild.
-        if infraction["type"] != "superstar" or not user:
+        if not user:
             return {}
 
         # DM the user about the expiration.

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -135,6 +135,7 @@ class Superstarify(InfractionScheduler, Cog):
         expiry_str = format_infraction(infraction["expires_at"])
 
         # Apply the infraction and schedule the expiration task.
+        self.mod_log.ignore(constants.Event.member_update, member.id)
         await member.edit(nick=forced_nick, reason=reason)
         self.schedule_task(ctx.bot.loop, infraction["id"], infraction)
 

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -170,7 +170,7 @@ class Superstarify(InfractionScheduler, Cog):
         await self.mod_log.send_log_message(
             icon_url=utils.INFRACTION_ICONS["superstar"][0],
             colour=Colour.gold(),
-            title="Member Achieved Superstardom",
+            title="Member achieved superstardom",
             thumbnail=member.avatar_url_as(static_format="png"),
             text=textwrap.dedent(f"""
                 Member: {member.mention} (`{member.id}`)

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -47,7 +47,7 @@ class Superstarify(InfractionScheduler, Cog):
             }
         )
 
-        if active_superstarifies:
+        if not active_superstarifies:
             return
 
         infraction = active_superstarifies[0]

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from discord import Colour, Embed, Member
 from discord.errors import Forbidden
-from discord.ext.commands import Cog, Context, command
+from discord.ext.commands import Bot, Cog, Context, command
 
 from bot import constants
 from bot.utils.checks import with_role_check
@@ -24,6 +24,9 @@ with Path("bot/resources/stars.json").open(encoding="utf-8") as stars_file:
 
 class Superstarify(InfractionScheduler, Cog):
     """A set of commands to moderate terrible nicknames."""
+
+    def __init__(self, bot: Bot):
+        super().__init__(bot, supported_infractions={"superstar"})
 
     @Cog.listener()
     async def on_member_update(self, before: Member, after: Member) -> None:

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -192,7 +192,7 @@ class Superstarify(InfractionScheduler, Cog):
         user = guild.get_member(infraction["user"])
 
         # Don't bother sending a notification if the user left the guild.
-        if infraction["type"] != "mute" or not user:
+        if infraction["type"] != "superstar" or not user:
             return {}
 
         # DM the user about the expiration.

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -152,15 +152,17 @@ class Superstarify(InfractionScheduler, Cog):
         )
 
         # Send an embed with the infraction information to the invoking context.
-        embed = Embed()
-        embed.title = "Congratulations!"
-        embed.description = (
-            f"Your previous nickname, **{old_nick}**, "
-            f"was so bad that we have decided to change it. "
-            f"Your new nickname will be **{forced_nick}**.\n\n"
-            f"You will be unable to change your nickname until \n**{expiry_str}**.\n\n"
-            "If you're confused by this, please read our "
-            f"[official nickname policy]({NICKNAME_POLICY_URL})."
+        embed = Embed(
+            title="Congratulations!",
+            colour=constants.Colours.soft_orange,
+            description=(
+                f"Your previous nickname, **{old_nick}**, "
+                f"was so bad that we have decided to change it. "
+                f"Your new nickname will be **{forced_nick}**.\n\n"
+                f"You will be unable to change your nickname until **{expiry_str}**.\n\n"
+                "If you're confused by this, please read our "
+                f"[official nickname policy]({NICKNAME_POLICY_URL})."
+            )
         )
         await ctx.send(embed=embed)
 

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -133,6 +133,7 @@ class Superstarify(InfractionScheduler, Cog):
         reason = reason or f"old nick: {member.display_name}"
         infraction = await utils.post_infraction(ctx, member, "superstar", reason, duration)
 
+        old_nick = member.display_name
         forced_nick = self.get_nick(infraction["id"], member.id)
         expiry_str = format_infraction(infraction["expires_at"])
 
@@ -154,7 +155,7 @@ class Superstarify(InfractionScheduler, Cog):
         embed = Embed()
         embed.title = "Congratulations!"
         embed.description = (
-            f"Your previous nickname, **{member.display_name}**, "
+            f"Your previous nickname, **{old_nick}**, "
             f"was so bad that we have decided to change it. "
             f"Your new nickname will be **{forced_nick}**.\n\n"
             f"You will be unable to change your nickname until \n**{expiry_str}**.\n\n"
@@ -174,7 +175,7 @@ class Superstarify(InfractionScheduler, Cog):
                 Actor: {ctx.message.author}
                 Reason: {reason}
                 Expires: {expiry_str}
-                Old nickname: `{member.display_name}`
+                Old nickname: `{old_nick}`
                 New nickname: `{forced_nick}`
             """),
             footer=f"ID {infraction['id']}"

--- a/bot/cogs/moderation/utils.py
+++ b/bot/cogs/moderation/utils.py
@@ -15,11 +15,12 @@ log = logging.getLogger(__name__)
 
 # apply icon, pardon icon
 INFRACTION_ICONS = {
-    "mute": (Icons.user_mute, Icons.user_unmute),
-    "kick": (Icons.sign_out, None),
     "ban": (Icons.user_ban, Icons.user_unban),
-    "warning": (Icons.user_warn, None),
+    "kick": (Icons.sign_out, None),
+    "mute": (Icons.user_mute, Icons.user_unmute),
     "note": (Icons.user_warn, None),
+    "superstar": (Icons.superstarify, Icons.unsuperstarify),
+    "warning": (Icons.user_warn, None),
 }
 RULES_URL = "https://pythondiscord.com/pages/rules"
 APPEALABLE_INFRACTIONS = ("ban", "mute")

--- a/bot/cogs/moderation/utils.py
+++ b/bot/cogs/moderation/utils.py
@@ -127,7 +127,7 @@ async def notify_infraction(
         colour=Colours.soft_red
     )
 
-    embed.set_author(name="Infraction Information", icon_url=icon_url, url=RULES_URL)
+    embed.set_author(name="Infraction information", icon_url=icon_url, url=RULES_URL)
     embed.title = f"Please review our rules over at {RULES_URL}"
     embed.url = RULES_URL
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -308,6 +308,9 @@ class Icons(metaclass=YAMLGetter):
 
     questionmark: str
 
+    superstarify: str
+    unsuperstarify: str
+
 
 class CleanMessages(metaclass=YAMLGetter):
     section = "bot"

--- a/config-default.yml
+++ b/config-default.yml
@@ -82,6 +82,9 @@ style:
 
         questionmark: "https://cdn.discordapp.com/emojis/512367613339369475.png"
 
+        superstarify: "https://cdn.discordapp.com/emojis/636288153044516874.png"
+        unsuperstarify: "https://cdn.discordapp.com/emojis/636288201258172446.png"
+
 guild:
     id: 267624335836053506
 


### PR DESCRIPTION
Fixes #472.

A new class `InfractionScheduler` was created and most of the meat of the infractions cog (utility functions for applying/pardoning) was moved there. Superstarify now partially makes use of those functions too, but not fully so that things such as the embed sent when a superstar is applied is retained.

Superstar icons for the mod log were added.

Being consistent with mute infractions, users will not be DM'd about a re-applied superstar infraction when they re-join the server. They will still be DM'd if they try to edit their nickname.
