### PR TITLE
Separate message/embed deletion and reaction deletion emojis

### DIFF
--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -136,9 +136,9 @@ class Filtering(Cog):
             and not msg.author.bot                          # Author not a bot
         )
 
-        # If we're running the bot locally, ignore role whitelist
+        # If we're running the bot locally, ignore role whitelist and only listen to #dev-test
         if DEBUG_MODE:
-            filter_message = not msg.author.bot
+            filter_message = not msg.author.bot and msg.channel.id == Channels.devtest
 
         # If none of the above, we can start filtering.
         if filter_message:

--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -136,9 +136,9 @@ class Filtering(Cog):
             and not msg.author.bot                          # Author not a bot
         )
 
-        # If we're running the bot locally, ignore role whitelist and only listen to #dev-test
+        # If we're running the bot locally, ignore role whitelist
         if DEBUG_MODE:
-            filter_message = not msg.author.bot and msg.channel.id == Channels.devtest
+            filter_message = not msg.author.bot
 
         # If none of the above, we can start filtering.
         if filter_message:

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -10,20 +10,22 @@ from discord.ext.commands import Bot, CheckFailure, Cog as DiscordCog, Command, 
 from fuzzywuzzy import fuzz, process
 
 from bot import constants
-from bot.constants import Channels, STAFF_ROLES
+from bot.constants import Channels, Emojis, STAFF_ROLES
 from bot.decorators import redirect_output
 from bot.pagination import (
-    DELETE_EMOJI, FIRST_EMOJI, LAST_EMOJI,
+    DELETE_EMOJI as CLEAR_EMOJI, FIRST_EMOJI, LAST_EMOJI,
     LEFT_EMOJI, LinePaginator, RIGHT_EMOJI,
 )
 
+DELETE_EMOJI = Emojis.trashcan
 
 REACTIONS = {
     FIRST_EMOJI: 'first',
     LEFT_EMOJI: 'back',
     RIGHT_EMOJI: 'next',
     LAST_EMOJI: 'end',
-    DELETE_EMOJI: 'stop'
+    CLEAR_EMOJI: 'clear',
+    DELETE_EMOJI: 'stop',
 }
 
 Cog = namedtuple('Cog', ['name', 'description', 'commands'])
@@ -495,6 +497,11 @@ class HelpSession:
         """Event that is called when the user requests the last page."""
         if not self.is_last_page:
             await self.update_page(len(self._pages)-1)
+
+    async def do_clear(self) -> None:
+        """Event that is called when the user clears the emojis from the pagination."""
+        await self.message.clear_reactions()
+        await self.message.add_reaction(DELETE_EMOJI)
 
     async def do_stop(self) -> None:
         """Event that is called when the user requests to stop the help session."""

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -14,7 +14,7 @@ from bot.bot import Bot
 from bot.constants import Channels, Emojis, STAFF_ROLES
 from bot.decorators import redirect_output
 from bot.pagination import (
-    CLEAR_EMOJI, FIRST_EMOJI, LAST_EMOJI,
+    FIRST_EMOJI, LAST_EMOJI,
     LEFT_EMOJI, LinePaginator, RIGHT_EMOJI,
 )
 
@@ -25,7 +25,6 @@ REACTIONS = {
     LEFT_EMOJI: 'back',
     RIGHT_EMOJI: 'next',
     LAST_EMOJI: 'end',
-    CLEAR_EMOJI: 'clear',
     DELETE_EMOJI: 'stop',
 }
 
@@ -498,10 +497,6 @@ class HelpSession:
         """Event that is called when the user requests the last page."""
         if not self.is_last_page:
             await self.update_page(len(self._pages)-1)
-
-    async def do_clear(self) -> None:
-        """Event that is called when the user clears the emojis from the pagination."""
-        await self.message.clear_reactions()
 
     async def do_stop(self) -> None:
         """Event that is called when the user requests to stop the help session."""

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -13,7 +13,7 @@ from bot import constants
 from bot.constants import Channels, Emojis, STAFF_ROLES
 from bot.decorators import redirect_output
 from bot.pagination import (
-    DELETE_EMOJI as CLEAR_EMOJI, FIRST_EMOJI, LAST_EMOJI,
+    CLEAR_EMOJI, FIRST_EMOJI, LAST_EMOJI,
     LEFT_EMOJI, LinePaginator, RIGHT_EMOJI,
 )
 
@@ -501,7 +501,6 @@ class HelpSession:
     async def do_clear(self) -> None:
         """Event that is called when the user clears the emojis from the pagination."""
         await self.message.clear_reactions()
-        await self.message.add_reaction(DELETE_EMOJI)
 
     async def do_stop(self) -> None:
         """Event that is called when the user requests to stop the help session."""

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -254,6 +254,8 @@ class Emojis(metaclass=YAMLGetter):
     status_idle: str
     status_dnd: str
 
+    trashcan: str
+
     bullet: str
     new: str
     pencil: str

--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -397,7 +397,7 @@ class ImagePaginator(Paginator):
 
             # Clear reaction press - [:x:]
             if reaction.emoji == CLEAR_EMOJI:
-                log.debug("Got delete reaction")
+                 log.debug("Got clear reaction")
                 break
 
             # Delete reaction press - [:trashcan:]

--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -397,7 +397,7 @@ class ImagePaginator(Paginator):
 
             # Clear reaction press - [:x:]
             if reaction.emoji == CLEAR_EMOJI:
-                 log.debug("Got clear reaction")
+                log.debug("Got clear reaction")
                 break
 
             # Delete reaction press - [:trashcan:]

--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -12,10 +12,9 @@ FIRST_EMOJI = "\u23EE"   # [:track_previous:]
 LEFT_EMOJI = "\u2B05"    # [:arrow_left:]
 RIGHT_EMOJI = "\u27A1"   # [:arrow_right:]
 LAST_EMOJI = "\u23ED"    # [:track_next:]
-CLEAR_EMOJI = "\u274c"  # [:x:]
 DELETE_EMOJI = constants.Emojis.trashcan  # [:trashcan:]
 
-PAGINATION_EMOJI = [FIRST_EMOJI, LEFT_EMOJI, RIGHT_EMOJI, LAST_EMOJI, CLEAR_EMOJI, DELETE_EMOJI]
+PAGINATION_EMOJI = [FIRST_EMOJI, LEFT_EMOJI, RIGHT_EMOJI, LAST_EMOJI, DELETE_EMOJI]
 
 log = logging.getLogger(__name__)
 
@@ -206,10 +205,6 @@ class LinePaginator(Paginator):
                 log.debug("Timed out waiting for a reaction")
                 break  # We're done, no reactions for the last 5 minutes
 
-            if reaction.emoji == CLEAR_EMOJI:
-                log.debug("Got clear reaction")
-                break
-
             if str(reaction.emoji) == DELETE_EMOJI:
                 log.debug("Got delete reaction")
                 return await message.delete()
@@ -394,11 +389,6 @@ class ImagePaginator(Paginator):
 
             # Deletes the users reaction
             await message.remove_reaction(reaction.emoji, user)
-
-            # Clear reaction press - [:x:]
-            if reaction.emoji == CLEAR_EMOJI:
-                log.debug("Got clear reaction")
-                break
 
             # Delete reaction press - [:trashcan:]
             if str(reaction.emoji) == DELETE_EMOJI:

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -15,7 +15,7 @@ MAX_SIZE = 1024 * 1024 * 8  # 8 Mebibytes
 async def wait_for_deletion(
     message: Message,
     user_ids: Sequence[Snowflake],
-    deletion_emojis: Sequence[str] = (Emojis.cross_mark,),
+    deletion_emojis: Sequence[str] = None,
     timeout: float = 60 * 5,
     attach_emojis: bool = True,
     client: Optional[Client] = None
@@ -33,6 +33,10 @@ async def wait_for_deletion(
         raise ValueError("Message must be sent on a guild")
 
     bot = client or message.guild.me
+
+    if deletion_emojis is None:
+        default_emoji = bot.get_emoji(int(Emojis.trashcan)) or Emojis.cross_mark
+        deletion_emojis = (default_emoji,)
 
     if attach_emojis:
         for emoji in deletion_emojis:

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -39,7 +39,7 @@ async def wait_for_deletion(
             await message.add_reaction(emoji)
 
     def check(reaction: Reaction, user: Member) -> bool:
-        """Check that the deletion emoji is reacted by the approprite user."""
+         """Check that the deletion emoji is reacted by the appropriate user."""
         return (
             reaction.message.id == message.id
             and str(reaction.emoji) in deletion_emojis

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -39,7 +39,7 @@ async def wait_for_deletion(
             await message.add_reaction(emoji)
 
     def check(reaction: Reaction, user: Member) -> bool:
-         """Check that the deletion emoji is reacted by the appropriate user."""
+        """Check that the deletion emoji is reacted by the appropriate user."""
         return (
             reaction.message.id == message.id
             and str(reaction.emoji) in deletion_emojis

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -15,7 +15,7 @@ MAX_SIZE = 1024 * 1024 * 8  # 8 Mebibytes
 async def wait_for_deletion(
     message: Message,
     user_ids: Sequence[Snowflake],
-    deletion_emojis: Sequence[str] = None,
+    deletion_emojis: Sequence[str] = (Emojis.trashcan,),
     timeout: float = 60 * 5,
     attach_emojis: bool = True,
     client: Optional[Client] = None
@@ -34,10 +34,6 @@ async def wait_for_deletion(
 
     bot = client or message.guild.me
 
-    if deletion_emojis is None:
-        default_emoji = bot.get_emoji(int(Emojis.trashcan)) or Emojis.cross_mark
-        deletion_emojis = (default_emoji,)
-
     if attach_emojis:
         for emoji in deletion_emojis:
             await message.add_reaction(emoji)
@@ -46,7 +42,7 @@ async def wait_for_deletion(
         """Check that the deletion emoji is reacted by the approprite user."""
         return (
             reaction.message.id == message.id
-            and reaction.emoji in deletion_emojis
+            and str(reaction.emoji) in deletion_emojis
             and user.id in user_ids
         )
 

--- a/config-default.yml
+++ b/config-default.yml
@@ -32,6 +32,8 @@ style:
         status_dnd:     "<:status_dnd:470326272082313216>"
         status_offline: "<:status_offline:470326266537705472>"
 
+        trashcan: "637136429717389331"
+
         bullet:     "\u2022"
         pencil:     "\u270F"
         new:        "\U0001F195"

--- a/config-default.yml
+++ b/config-default.yml
@@ -32,7 +32,7 @@ style:
         status_dnd:     "<:status_dnd:470326272082313216>"
         status_offline: "<:status_offline:470326266537705472>"
 
-        trashcan: "637136429717389331"
+        trashcan: "<:trashcan:637136429717389331>"
 
         bullet:     "\u2022"
         pencil:     "\u270F"


### PR DESCRIPTION
**Closes:** #297 and #514 

Currently, we use a red X for both message/embed deletion and reaction removal. Certain members are hence confused about the meaning of the reaction.

The PR adds a new emoji, `:trashcan:` for deletion of embed or message.
For regular pagination, the red X clears the reactions added by the bot, while the trashcan deletes the embed. The help cog has similar functionality.
![image](https://user-images.githubusercontent.com/41782385/67648789-a8cae280-f971-11e9-8f56-48165fd6ab30.png)

Replies that use `wait_for_deletion` like `snekbox` now use the trashcan emoji instead of the red X, indicating that it is for message removal.
![image](https://user-images.githubusercontent.com/41782385/67648807-b718fe80-f971-11e9-8ae6-cfb978e080cb.png)
