### PR TITLE
Chain words before length check for OffTopicName conversion

### DIFF
--- a/bot/cogs/off_topic_names.py
+++ b/bot/cogs/off_topic_names.py
@@ -24,6 +24,9 @@ class OffTopicName(Converter):
         """Attempt to replace any invalid characters with their approximate Unicode equivalent."""
         allowed_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ!?'`-"
 
+        # Chain multiple words to a single one
+        argument = "-".join(argument.split())
+
         if not (2 <= len(argument) <= 96):
             raise BadArgument("Channel name must be between 2 and 96 chars long")
 
@@ -97,15 +100,12 @@ class OffTopicNames(Cog):
 
     @otname_group.command(name='add', aliases=('a',))
     @with_role(*MODERATION_ROLES)
-    async def add_command(self, ctx: Context, *names: OffTopicName) -> None:
+    async def add_command(self, ctx: Context, *, name: OffTopicName) -> None:
         """
         Adds a new off-topic name to the rotation.
 
         The name is not added if it is too similar to an existing name.
         """
-        # Chain multiple words to a single one
-        name = "-".join(names)
-
         existing_names = await self.bot.api_client.get('bot/off-topic-channel-names')
         close_match = difflib.get_close_matches(name, existing_names, n=1, cutoff=0.8)
 
@@ -123,10 +123,8 @@ class OffTopicNames(Cog):
 
     @otname_group.command(name='forceadd', aliases=('fa',))
     @with_role(*MODERATION_ROLES)
-    async def force_add_command(self, ctx: Context, *names: OffTopicName) -> None:
+    async def force_add_command(self, ctx: Context, *, name: OffTopicName) -> None:
         """Forcefully adds a new off-topic name to the rotation."""
-        # Chain multiple words to a single one
-        name = "-".join(names)
         await self._add_name(ctx, name)
 
     async def _add_name(self, ctx: Context, name: str) -> None:
@@ -138,10 +136,8 @@ class OffTopicNames(Cog):
 
     @otname_group.command(name='delete', aliases=('remove', 'rm', 'del', 'd'))
     @with_role(*MODERATION_ROLES)
-    async def delete_command(self, ctx: Context, *names: OffTopicName) -> None:
+    async def delete_command(self, ctx: Context, *, name: OffTopicName) -> None:
         """Removes a off-topic name from the rotation."""
-        # Chain multiple words to a single one
-        name = "-".join(names)
         await self.bot.api_client.delete(f'bot/off-topic-channel-names/{name}')
 
         log.info(f"{ctx.author} deleted the off-topic channel name '{name}'")


### PR DESCRIPTION
The previous feature for chaining multiple words passed to `!otn a` did so outside of the OffTopicName converter, resulting in a valid input like `!otn a is python 2 dead yet` rejected due to `is` being less than 3 characters long.

This fix amends that by chaining the words in the converter itself.