### PR TITLE
Enhancements and a bug fix for our test helpers

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -50,7 +50,15 @@ class ColourMixin:
 
 
 class CustomMockMixin:
-    """Ensures attributes of our mock types will be instantiated with the correct mock type."""
+    """
+    Provides common functionality for our custom Mock types.
+
+    The cooperative `__init__` automatically creates `AsyncMock` attributes for every coroutine
+    function `inspect` detects in the `spec` instance we provide. In addition, this mixin takes care
+    of making sure child mocks are instantiated with the correct class. By default, the mock of the
+    children will be `unittest.mock.MagicMock`, but this can be overwritten by setting the attribute
+    `child_mock_type` on the custom mock inheriting from this mixin.
+    """
 
     child_mock_type = unittest.mock.MagicMock
 
@@ -179,9 +187,6 @@ class MockRole(CustomMockMixin, unittest.mock.Mock, ColourMixin, HashableMixin):
     Instances of this class will follow the specifications of `discord.Role` instances. For more
     information, see the `MockGuild` docstring.
     """
-
-    child_mock_type = unittest.mock.MagicMock
-
     def __init__(self, name: str = "role", role_id: int = 1, position: int = 1, **kwargs) -> None:
         super().__init__(spec=role_instance, **kwargs)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -221,10 +221,10 @@ class DiscordMocksTests(unittest.TestCase):
     @unittest.mock.patch(f'{__name__}.DiscordMocksTests.subTest')
     def test_the_custom_mock_methods_test(self, subtest_mock):
         """The custom method test should raise AssertionError for invalid methods."""
-        class FakeMockBot(helpers.AttributeMock, unittest.mock.MagicMock):
+        class FakeMockBot(helpers.GetChildMockMixin, unittest.mock.MagicMock):
             """Fake MockBot class with invalid attribute/method `release_the_walrus`."""
 
-            attribute_mocktype = unittest.mock.MagicMock
+            child_mock_type = unittest.mock.MagicMock
 
             def __init__(self, **kwargs):
                 super().__init__(spec=helpers.bot_instance, **kwargs)
@@ -331,6 +331,18 @@ class MockObjectTests(unittest.TestCase):
                 self.assertFalse(instance_one != instance_two)
                 self.assertTrue(instance_one != instance_three)
 
+    def test_get_child_mock_mixin_accepts_mock_seal(self):
+        """The `GetChildMockMixin` should support `unittest.mock.seal`."""
+        class MyMock(helpers.GetChildMockMixin, unittest.mock.MagicMock):
+
+            child_mock_type = unittest.mock.MagicMock
+            pass
+
+        mock = MyMock()
+        unittest.mock.seal(mock)
+        with self.assertRaises(AttributeError, msg="MyMock.shirayuki"):
+            mock.shirayuki = "hello!"
+
     def test_spec_propagation_of_mock_subclasses(self):
         """Test if the `spec` does not propagate to attributes of the mock object."""
         test_values = (
@@ -346,7 +358,7 @@ class MockObjectTests(unittest.TestCase):
                 mock = mock_type()
                 self.assertTrue(isinstance(mock, mock_type))
                 attribute = getattr(mock, valid_attribute)
-                self.assertTrue(isinstance(attribute, mock_type.attribute_mocktype))
+                self.assertTrue(isinstance(attribute, mock_type.child_mock_type))
 
     def test_async_mock_provides_coroutine_for_dunder_call(self):
         """Test if AsyncMock objects have a coroutine for their __call__ method."""


### PR DESCRIPTION
I have made several changes to our test helpers defined in [`tests/helpers.py`](../blob/master/tests/helpers.py). These changes will make it easier to work with the mock objects as well as fixing a bug. **All changes are backwards compatible with all the current tests we have** and should be compatible with the tests that are currently being written as well.

## Better way of controlling child mock types

We previously used an override of the `__new__` method to prevent our custom mock types from instantiating their children with their own type instead of a general mock type like `MagicMock` or `Mock`.

As it turns out, the Python documentation [suggests another way of doing this](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock._get_child_mock) that does not involve overriding `__new__`. This commit implements this new method to make sure we're using the idiomatic way of handling this.

The suggested method is overriding the `_get_child_mock` method in the subclass. I've added this override to a `mixin` that we can apply to all of the custom mock types we define. If you want to use this mixin, please make sure that it comes before the general mock type in the MRO.

## AsyncMock's __call__ now returns the right mock type

Since mocks normally instantiate children with their own type, our `AsyncMock` type returned a new `AsyncMock` after it had been awaited. By using the mixin described in the previous section, it now returns a regular `MagicMock`.

## Automatically create AsyncMock attributes using `inspect`

Normally, attributes accessed on a mock are automatically created with an instance of either Mock or MagicMock. However, since those only support synchronous calls, this is not desirable for coroutine function methods. That's why our `__init__` methods previously had a long list of all the coroutines defined for a class to properly mock it with an `AsyncMock`. However, hard-coding such a list is prone to human error and not resilient to changes introduced by version upgrades.

Instead, I have now created a helper method in our `CustomMockMixin` (formerly `GetChildMockMixin`) that automatically inspects the `spec` instance we've passed for `coroutine functions` using the `inspect` module. It then automatically sets the according attributes with instances of the `AsyncMock` class.

There is one caveat: `discord.py` very rarely defines regular methods that return a coroutine object. Since the returned coroutine should still be awaited, these regular methods should also be mocked with an `AsyncMock`. However, since they are regular methods, `inspect` does not detect them and they have to be added manually. (The only case of this I've found so far is `Client.wait_for`.)

## Better handling of passed keyword arguments

Normally, a Mock type respects the keyword arguments passed and automatically sets them as attributes of the mock instance. However, some of custom Mock types set custom attributes, making this impossible:

```py
class MockMessage(unittest.mock.MagicMock):
    def __init__(self, **kwargs):
        super().__init__(spec=message_instance, **kwargs)
        self.author = MockMember()

guido = MockMember(name="Guido")
mocked_message = MockMessage(author=guido)
```

In this snippet, we attempt to set the `author` attribute to a mock instance with `name="Guido"`, but since `__init__` sets this attribute after the `super().__init__`, this will be lost. To solve this, I've made sure that we only instantiate a new mock if the attribute name was not present in `kwargs` by leveraging the default value of `.get`:

```py
class MockMessage(unittest.mock.MagicMock):
    def __init__(self, **kwargs):
        super().__init__(spec=message_instance, **kwargs)
        self.author = kwargs.get('author', MockMember())
```

## Added MockEmoji, MockPartialEmoji, MockReaction

I have added three new custom mock types, MockEmoij, MockPartialEmoji, and MockReaction after a request from @lemonsaurus. 
