### PR TITLE
Enhance Reddit webhook embeds

### DIFF
--- a/bot/cogs/reddit.py
+++ b/bot/cogs/reddit.py
@@ -9,7 +9,7 @@ from discord import Colour, Embed, TextChannel
 from discord.ext.commands import Bot, Cog, Context, group
 from discord.ext.tasks import loop
 
-from bot.constants import Channels, ERROR_REPLIES, Reddit as RedditConfig, STAFF_ROLES, Webhooks
+from bot.constants import Channels, ERROR_REPLIES, Emojis, Reddit as RedditConfig, STAFF_ROLES, Webhooks
 from bot.converters import Subreddit
 from bot.decorators import with_role
 from bot.pagination import LinePaginator
@@ -117,9 +117,9 @@ class Reddit(Cog):
             link = self.URL + data["permalink"]
 
             embed.description += (
-                f"[**{title}**]({link})\n"
+                f"**[{title}]({link})**\n"
                 f"{text}"
-                f"| {ups} upvotes | {comments} comments | u/{author} | {subreddit} |\n\n"
+                f"{Emojis.upvotes} {ups} {Emojis.comments} {comments} {Emojis.user} {author}\n\n"
             )
 
         embed.colour = Colour.blurple()

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -259,6 +259,10 @@ class Emojis(metaclass=YAMLGetter):
     pencil: str
     cross_mark: str
 
+    upvotes: str
+    comments: str
+    user: str
+
 
 class Icons(metaclass=YAMLGetter):
     section = "style"

--- a/config-default.yml
+++ b/config-default.yml
@@ -37,6 +37,10 @@ style:
         new:        "\U0001F195"
         cross_mark: "\u274C"
 
+        upvotes:        "<:upvotes:638706000714792962>"
+        comments:       "<:comments:638706001159258132>"
+        user:           "<:user:638706001217978368>"
+
     icons:
         crown_blurple: "https://cdn.discordapp.com/emojis/469964153289965568.png"
         crown_green:   "https://cdn.discordapp.com/emojis/469964154719961088.png"


### PR DESCRIPTION
I have made some visual changes to the embed generated for the Reddit webhook. The changes I've made boil down to:

- Moved bold markdown to outside of the link markdown to prevent breakage on Android.

- Removed redundant mentions of the subreddit from the embed description, since the name of the subreddit is already displayed in the `author` field of the webhook.

- Stylized the meta-data line by replacing text with emoji-based icons for upvotes, comments, and user.

The emojis were uploaded to the `Emojis II` guild and the IDs have been added to the constants files. In addition, I've set the reddit logo as the default avatar for the webhook in the guild.

## Screenshots

#### Desktop, linux client

![Embed example on desktop](https://user-images.githubusercontent.com/33516116/67769018-fc156180-fa53-11e9-986b-7a44b5eb97d7.png)

#### Mobile, Android client

![Embed example on mobile](https://user-images.githubusercontent.com/33516116/67769191-4696de00-fa54-11e9-9c11-7391f3b1632c.png)

**Note:** We discussed several variants of the meta data line in the #dev-contrib channel; in the end, we settled on this one.

---

This pull request closes #634