### PR TITLE
Use timedelta to correctly calculate next midnight

### DIFF
--- a/bot/cogs/reddit.py
+++ b/bot/cogs/reddit.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import random
 import textwrap
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List
 
 from discord import Colour, Embed, TextChannel
@@ -130,7 +130,8 @@ class Reddit(Cog):
         """Post the top 5 posts daily, and the top 5 posts weekly."""
         # once we upgrade to d.py 1.3 this can be removed and the loop can use the `time=datetime.time.min` parameter
         now = datetime.utcnow()
-        midnight_tomorrow = now.replace(day=now.day + 1, hour=0, minute=0, second=0)
+        tomorrow = now + timedelta(days=1)
+        midnight_tomorrow = tomorrow.replace(hour=0, minute=0, second=0)
         seconds_until = (midnight_tomorrow - now).total_seconds()
 
         await asyncio.sleep(seconds_until)


### PR DESCRIPTION
Based this PR on issue #636 
I'm pretty new to this project, so I made the change pretty straight forward, but looking around, I found the following function in `bot/utils/time.py`:

```python
# Hey, this could actually be used in the off_topic_names and reddit cogs :)
async def wait_until(time: datetime.datetime, start: Optional[datetime.datetime] = None) -> None:
    """
    Wait until a given time.

    :param time: A datetime.datetime object to wait until.
    :param start: The start from which to calculate the waiting duration. Defaults to UTC time.
    """
```

I can update this PR if the maintainers would prefer to use it, instead.