### PR TITLE
Antispam rules: add unit test for mentions, improve unit tests for links and attachments, fix bug in attachments rule

### DIFF
--- a/bot/rules/attachments.py
+++ b/bot/rules/attachments.py
@@ -7,14 +7,14 @@ async def apply(
     last_message: Message, recent_messages: List[Message], config: Dict[str, int]
 ) -> Optional[Tuple[str, Iterable[Member], Iterable[Message]]]:
     """Detects total attachments exceeding the limit sent by a single user."""
-    relevant_messages = [last_message] + [
+    relevant_messages = tuple(
         msg
         for msg in recent_messages
         if (
             msg.author == last_message.author
             and len(msg.attachments) > 0
         )
-    ]
+    )
     total_recent_attachments = sum(len(msg.attachments) for msg in relevant_messages)
 
     if total_recent_attachments > config['max']:

--- a/tests/bot/rules/test_attachments.py
+++ b/tests/bot/rules/test_attachments.py
@@ -12,13 +12,16 @@ def msg(total_attachments: int) -> MockMessage:
 class AttachmentRuleTests(unittest.TestCase):
     """Tests applying the `attachments` antispam rule."""
 
+    def setUp(self):
+        self.config = {"max": 5}
+
     @async_test
     async def test_allows_messages_without_too_many_attachments(self):
         """Messages without too many attachments are allowed as-is."""
         cases = (
-            (msg(0), msg(0), msg(0)),
-            (msg(2), msg(2)),
-            (msg(0),),
+            [msg(0), msg(0), msg(0)],
+            [msg(2), msg(2)],
+            [msg(0)],
         )
 
         for recent_messages in cases:
@@ -29,7 +32,7 @@ class AttachmentRuleTests(unittest.TestCase):
                 recent_messages=recent_messages
             ):
                 self.assertIsNone(
-                    await attachments.apply(last_message, recent_messages, {'max': 5})
+                    await attachments.apply(last_message, recent_messages, self.config)
                 )
 
     @async_test
@@ -59,6 +62,6 @@ class AttachmentRuleTests(unittest.TestCase):
                 total=total
             ):
                 self.assertEqual(
-                    await attachments.apply(last_message, recent_messages, {'max': 5}),
+                    await attachments.apply(last_message, recent_messages, self.config),
                     (f"sent {total} attachments in 5s", ('lemon',), relevant_messages)
                 )

--- a/tests/bot/rules/test_attachments.py
+++ b/tests/bot/rules/test_attachments.py
@@ -21,7 +21,9 @@ class AttachmentRuleTests(unittest.TestCase):
             (msg(0),),
         )
 
-        for last_message, *recent_messages in cases:
+        for recent_messages in cases:
+            last_message = recent_messages[0]
+
             with self.subTest(
                 last_message=last_message,
                 recent_messages=recent_messages
@@ -39,14 +41,16 @@ class AttachmentRuleTests(unittest.TestCase):
             ([msg(1)] * 6, 6),
         )
 
-        for messages, total in cases:
-            last_message, *recent_messages = messages
-            relevant_messages = [last_message] + [
+        for recent_messages, total in cases:
+            last_message = recent_messages[0]
+            relevant_messages = tuple(
                 msg
                 for msg in recent_messages
-                if msg.author == last_message.author
-                and len(msg.attachments) > 0
-            ]
+                if (
+                    msg.author == last_message.author
+                    and len(msg.attachments) > 0
+                )
+            )
 
             with self.subTest(
                 last_message=last_message,

--- a/tests/bot/rules/test_attachments.py
+++ b/tests/bot/rules/test_attachments.py
@@ -1,26 +1,17 @@
 import asyncio
 import unittest
-from dataclasses import dataclass
-from typing import Any, List
 
 from bot.rules import attachments
+from tests.helpers import MockMessage
 
 
-# Using `MagicMock` sadly doesn't work for this usecase
-# since it's __eq__ compares the MagicMock's ID. We just
-# want to compare the actual attributes we set.
-@dataclass
-class FakeMessage:
-    author: str
-    attachments: List[Any]
-
-
-def msg(total_attachments: int) -> FakeMessage:
-    return FakeMessage(author='lemon', attachments=list(range(total_attachments)))
+def msg(total_attachments: int) -> MockMessage:
+    """Builds a message with `total_attachments` attachments."""
+    return MockMessage(author='lemon', attachments=list(range(total_attachments)))
 
 
 class AttachmentRuleTests(unittest.TestCase):
-    """Tests applying the `attachment` antispam rule."""
+    """Tests applying the `attachments` antispam rule."""
 
     def test_allows_messages_without_too_many_attachments(self):
         """Messages without too many attachments are allowed as-is."""
@@ -38,13 +29,25 @@ class AttachmentRuleTests(unittest.TestCase):
     def test_disallows_messages_with_too_many_attachments(self):
         """Messages with too many attachments trigger the rule."""
         cases = (
-            ((msg(4), msg(0), msg(6)), [msg(4), msg(6)], 10),
-            ((msg(6),), [msg(6)], 6),
-            ((msg(1),) * 6, [msg(1)] * 6, 6),
+            ([msg(4), msg(0), msg(6)], 10),
+            ([msg(6)], 6),
+            ([msg(1)] * 6, 6),
         )
-        for messages, relevant_messages, total in cases:
-            with self.subTest(messages=messages, relevant_messages=relevant_messages, total=total):
-                last_message, *recent_messages = messages
+        for messages, total in cases:
+            last_message, *recent_messages = messages
+            relevant_messages = [last_message] + [
+                msg
+                for msg in recent_messages
+                if msg.author == last_message.author
+                and len(msg.attachments) > 0
+            ]
+
+            with self.subTest(
+                last_message=last_message,
+                recent_messages=recent_messages,
+                relevant_messages=relevant_messages,
+                total=total
+            ):
                 coro = attachments.apply(last_message, recent_messages, {'max': 5})
                 self.assertEqual(
                     asyncio.run(coro),

--- a/tests/bot/rules/test_attachments.py
+++ b/tests/bot/rules/test_attachments.py
@@ -92,7 +92,7 @@ class AttachmentRuleTests(unittest.TestCase):
                     culprit,
                     relevant_messages
                 )
-                self.assertEqual(
+                self.assertTupleEqual(
                     await attachments.apply(last_message, recent_messages, self.config),
                     desired_output
                 )

--- a/tests/bot/rules/test_links.py
+++ b/tests/bot/rules/test_links.py
@@ -18,7 +18,7 @@ class Case(NamedTuple):
 
 
 def msg(author: str, total_links: int) -> FakeMessage:
-    """Makes a message with *total_links* links."""
+    """Makes a message with `total_links` links."""
     content = " ".join(["https://pydis.com"] * total_links)
     return FakeMessage(author=author, content=content)
 

--- a/tests/bot/rules/test_mentions.py
+++ b/tests/bot/rules/test_mentions.py
@@ -19,7 +19,7 @@ class Case(NamedTuple):
 
 def msg(author: str, total_mentions: int) -> FakeMessage:
     """Makes a message with `total_mentions` mentions."""
-    return FakeMessage(author=author, mentions=[None] * total_mentions)
+    return FakeMessage(author=author, mentions=list(range(total_mentions)))
 
 
 class TestMentions(unittest.TestCase):

--- a/tests/bot/rules/test_mentions.py
+++ b/tests/bot/rules/test_mentions.py
@@ -18,6 +18,7 @@ class Case(NamedTuple):
 
 
 def msg(author: str, total_mentions: int) -> FakeMessage:
+    """Makes a message with `total_mentions` mentions."""
     return FakeMessage(author=author, mentions=[None] * total_mentions)
 
 

--- a/tests/bot/rules/test_mentions.py
+++ b/tests/bot/rules/test_mentions.py
@@ -1,0 +1,98 @@
+import unittest
+from typing import List, NamedTuple, Tuple
+
+from bot.rules import mentions
+from tests.helpers import async_test
+
+
+class FakeMessage(NamedTuple):
+    author: str
+    mentions: List[None]
+
+
+class Case(NamedTuple):
+    recent_messages: List[FakeMessage]
+    relevant_messages: Tuple[FakeMessage]
+    culprit: str
+    total_mentions: int
+
+
+def msg(author: str, total_mentions: int) -> FakeMessage:
+    return FakeMessage(author=author, mentions=[None] * total_mentions)
+
+
+class TestMentions(unittest.TestCase):
+    """Tests applying the `mentions` antispam rule."""
+
+    def setUp(self):
+        self.config = {
+            "max": 2,
+            "interval": 10
+        }
+
+    @async_test
+    async def test_mentions_within_limit(self):
+        """Messages with an allowed amount of mentions."""
+        cases = (
+            [msg("bob", 0)],
+            [msg("bob", 2)],
+            [msg("bob", 1), msg("bob", 1)],
+            [msg("bob", 1), msg("alice", 2)]
+        )
+
+        for recent_messages in cases:
+            last_message = recent_messages[0]
+
+            with self.subTest(
+                last_message=last_message,
+                recent_messages=recent_messages,
+                config=self.config
+            ):
+                self.assertIsNone(
+                    await mentions.apply(last_message, recent_messages, self.config)
+                )
+
+    @async_test
+    async def test_mentions_exceeding_limit(self):
+        """Messages with a higher than allowed amount of mentions."""
+        cases = (
+            Case(
+                [msg("bob", 3)],
+                (msg("bob", 3),),
+                ("bob",),
+                3
+            ),
+            Case(
+                [msg("alice", 2), msg("alice", 0), msg("alice", 1)],
+                (msg("alice", 2), msg("alice", 0), msg("alice", 1)),
+                ("alice",),
+                3
+            ),
+            Case(
+                [msg("bob", 2), msg("alice", 3), msg("bob", 2)],
+                (msg("bob", 2), msg("bob", 2)),
+                ("bob",),
+                4
+            )
+        )
+
+        for recent_messages, relevant_messages, culprit, total_mentions in cases:
+            last_message = recent_messages[0]
+
+            with self.subTest(
+                last_message=last_message,
+                recent_messages=recent_messages,
+                relevant_messages=relevant_messages,
+                culprit=culprit,
+                total_mentions=total_mentions,
+                cofig=self.config
+            ):
+                desired_output = (
+                    f"sent {total_mentions} mentions in {self.config['interval']}s",
+                    culprit,
+                    relevant_messages
+                )
+                self.assertTupleEqual(
+                    await mentions.apply(last_message, recent_messages, self.config),
+                    desired_output
+                )

--- a/tests/bot/rules/test_mentions.py
+++ b/tests/bot/rules/test_mentions.py
@@ -6,7 +6,7 @@ from tests.helpers import MockMessage, async_test
 
 
 class Case(NamedTuple):
-    recent_messages: List[MockMessage, ...]
+    recent_messages: List[MockMessage]
     culprit: Tuple[str]
     total_mentions: int
 

--- a/tests/bot/rules/test_mentions.py
+++ b/tests/bot/rules/test_mentions.py
@@ -7,7 +7,7 @@ from tests.helpers import async_test
 
 class FakeMessage(NamedTuple):
     author: str
-    mentions: List[None]
+    mentions: List[int]
 
 
 class Case(NamedTuple):


### PR DESCRIPTION
This PR addresses several problems.

- [x] Implement unit test for `bot.rules.mentions`, using the `MockMessage` helper to correctly represent mocked `discord.Message` instances. Closes #601. Gives 100% coverage. See 
0eade46.
- [x] Adjust unit tests for `bot.rules.links` and `bot.rules.attachments` to use `MockMessage` helper instead of a `namedtuple("FakeMessage", ["author", "content"])` that was a nasty oversimplification of actual Message instances. After #660 the mocking system is now more safe as it prevents setting attributes that do not exist for the mocked objects. See 2a9b1fc and a2617d1.
- [x] Small docstring adjustment - use backticks instead of asterisks when referring to args. See 32caead.

Additionally, we have discovered that there is an inconsistency / bug in the behaviour of `bot.rules.attachments`. Snippets below explain.

All rules have the same function signature, taking the following args:

```python
last_message: Message, recent_messages: List[Message], config: Dict[str, int]
```

The [antispam cog](https://github.com/python-discord/bot/blob/c04df6472b2450d273475df94fa4917116b451e0/bot/cogs/antispam.py#L171) calls them in `on_message` by providing the `message` that triggers the event, and a history of messages up to a certain point in time. This history, however, includes the `message` instance itself. So let's say `last_message == recent_messages[0]`. Within the rule, the first thing we do is build a tuple `relevant_messages` which is made up of all messages _m_ where `m.author == last_message.author`, and so this is the only way the `last_message` arg is used - to see which user we're checking (slight deviation in burst rule which applies to all users):

```python
relevant_messages = tuple(
    msg
    for msg in recent_messages
    if msg.author == last_message.author
)
```

The `attachments` rule however deviates from this pattern by always including the `last_message` in `relevant_messages`, _and then_ looping over `recent_messages`. The result of this is that the `last_message` potentially gets included twice, and its attachments then count twice in the sum.

```python
relevant_messages = [last_message] + [
    msg
    for msg in recent_messages
    if (
        msg.author == last_message.author
        and len(msg.attachments) > 0
    )
]
```

Therefore, a test case that has `last_message == recent_messages[0]` will fail, for example

```python
last_message = msg(4)
recent_messages = [msg(4), msg(0), msg(6)]
expected_total = 10
```

... fails with ...

```python
- ('sent 14 attachments in 5s',
?         ^

+ ('sent 10 attachments in 5s',
?         ^
```

... and also the `relevant_messages` containing a duplicate.

So why wasn't the rule failing on the [unit test written for it](https://github.com/python-discord/bot/blob/c04df6472b2450d273475df94fa4917116b451e0/tests/bot/rules/test_attachments.py)?

The unit test incorrectly makes the assumption [here](https://github.com/python-discord/bot/blob/c04df6472b2450d273475df94fa4917116b451e0/tests/bot/rules/test_attachments.py#L33) and [here](https://github.com/python-discord/bot/blob/c04df6472b2450d273475df94fa4917116b451e0/tests/bot/rules/test_attachments.py#L47) that `last_message` is not present in `recent_messages`, therefore making the same mistake as the rule itself.

This PR therefore also contains the following.

- [x] Fix the `attachments` rule to understand `last_message` to be part of `recent_messages` and build `relevant_messages` accordingly. See 54598dd.
- [x] Adjust the unit test to emulate the behaviour of the `on_message` event calling the rule. See eef447a.
- [x] Add slightly more complex test cases. Test the `attachments` rule against multiple authors, not just a hardcoded `lemon`. See 01731a8.

Always happy to hear any feedback.