### PR TITLE
Forward pings in checkpoint to mod-alerts and reword periodic checkpoint ping

### DIFF
--- a/bot/cogs/verification.py
+++ b/bot/cogs/verification.py
@@ -90,27 +90,26 @@ class Verification(Cog):
         if ctx.command is not None and ctx.command.name == "accept":
             return  # They used the accept command
 
-        if ctx.channel.id == Channels.verification:  # We're in the verification channel
-            for role in ctx.author.roles:
-                if role.id == Roles.verified:
-                    log.warning(f"{ctx.author} posted '{ctx.message.content}' "
-                                "in the verification channel, but is already verified.")
-                    return  # They're already verified
+        for role in ctx.author.roles:
+            if role.id == Roles.verified:
+                log.warning(f"{ctx.author} posted '{ctx.message.content}' "
+                            "in the verification channel, but is already verified.")
+                return  # They're already verified
 
-            log.debug(f"{ctx.author} posted '{ctx.message.content}' in the verification "
-                      "channel. We are providing instructions how to verify.")
-            await ctx.send(
-                f"{ctx.author.mention} Please type `!accept` to verify that you accept our rules, "
-                f"and gain access to the rest of the server.",
-                delete_after=20
-            )
+        log.debug(f"{ctx.author} posted '{ctx.message.content}' in the verification "
+                  "channel. We are providing instructions how to verify.")
+        await ctx.send(
+            f"{ctx.author.mention} Please type `!accept` to verify that you accept our rules, "
+            f"and gain access to the rest of the server.",
+            delete_after=20
+        )
 
-            log.trace(f"Deleting the message posted by {ctx.author}")
+        log.trace(f"Deleting the message posted by {ctx.author}")
 
-            try:
-                await ctx.message.delete()
-            except NotFound:
-                log.trace("No message found, it must have been deleted by another bot.")
+        try:
+            await ctx.message.delete()
+        except NotFound:
+            log.trace("No message found, it must have been deleted by another bot.")
 
     @command(name='accept', aliases=('verify', 'verified', 'accepted'), hidden=True)
     @without_role(Roles.verified)

--- a/bot/cogs/verification.py
+++ b/bot/cogs/verification.py
@@ -31,7 +31,7 @@ If you'd like to unsubscribe from the announcement notifications, simply send `!
 
 PERIODIC_PING = (
     f"@everyone To verify that you have read our rules, please type `{BotConfig.prefix}accept`."
-    f" Ping <@&{Roles.admin}> if you encounter any problems during the verification process."
+    f" If you encounter any problems during the verification process, ping the <@&{Roles.admin}> role in this channel."
 )
 
 


### PR DESCRIPTION
# Abstract

This PR rewords the periodic ping to `#checkpoint` so it is no longer "ambiguous" to new users.
It also forwards all messages sent in `#checkpoint` that contained a user or role mention to `#mod-alerts`.

# Motivation

## Rewording of periodic ping
Consensus from staff is that the previous wording of the message might be the cause for so many users both running `!accept` and pinging the admins. Full context in issue: [#160](https://github.com/python-discord/organisation/issues/160#issuecomment-549073858)

## Forwarding to mod-alerts
It was also agreed that if/when a user does mention the `@Admins` role, that it should be forwarded to `#mod-alerts` so moderators don't have to dig in the message log channel for the deleted message. I decided to implement this for any user or role mention instead of just the admin role, as we probably want mods to know if the user is mentioning other roles or users in `#checkpoint` as well.

# Specification

The embed in `#mod-alerts` confirms which user sent the message in `#checkpoint` and displays their original message. This confirmation is also logged, sans the original text of the message.

# Kaizen
I've limited the `on_message` listener to only the `#checkpoint` channel since that's all it should care about. There was a check later in the listener that finally verifies what channel the message came in, so I've removed it now that it would be redundant.

Closes #649 