### PR TITLE
Enhancements for `tests.helpers` and our test suite

### DIFF
--- a/tests/bot/cogs/test_information.py
+++ b/tests/bot/cogs/test_information.py
@@ -19,7 +19,7 @@ class InformationCogTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.moderator_role = helpers.MockRole(name="Moderator", role_id=constants.Roles.moderator)
+        cls.moderator_role = helpers.MockRole(name="Moderator", id=constants.Roles.moderator)
 
     def setUp(self):
         """Sets up fresh objects for each test."""
@@ -54,7 +54,7 @@ class InformationCogTests(unittest.TestCase):
         """Tests the `role info` command."""
         dummy_role = helpers.MockRole(
             name="Dummy",
-            role_id=112233445566778899,
+            id=112233445566778899,
             colour=discord.Colour.blurple(),
             position=10,
             members=[self.ctx.author],
@@ -63,7 +63,7 @@ class InformationCogTests(unittest.TestCase):
 
         admin_role = helpers.MockRole(
             name="Admins",
-            role_id=998877665544332211,
+            id=998877665544332211,
             colour=discord.Colour.red(),
             position=3,
             members=[self.ctx.author],
@@ -176,7 +176,7 @@ class UserInfractionHelperMethodTests(unittest.TestCase):
         self.bot = helpers.MockBot()
         self.bot.api_client.get = helpers.AsyncMock()
         self.cog = information.Information(self.bot)
-        self.member = helpers.MockMember(user_id=1234)
+        self.member = helpers.MockMember(id=1234)
 
     def test_user_command_helper_method_get_requests(self):
         """The helper methods should form the correct get requests."""
@@ -351,7 +351,7 @@ class UserEmbedTests(unittest.TestCase):
     @unittest.mock.patch(f"{COG_PATH}.basic_user_infraction_counts", new=helpers.AsyncMock(return_value=""))
     def test_create_user_embed_uses_string_representation_of_user_in_title_if_nick_is_not_available(self):
         """The embed should use the string representation of the user if they don't have a nick."""
-        ctx = helpers.MockContext(channel=helpers.MockTextChannel(channel_id=1))
+        ctx = helpers.MockContext(channel=helpers.MockTextChannel(id=1))
         user = helpers.MockMember()
         user.nick = None
         user.__str__ = unittest.mock.Mock(return_value="Mr. Hemlock")
@@ -363,7 +363,7 @@ class UserEmbedTests(unittest.TestCase):
     @unittest.mock.patch(f"{COG_PATH}.basic_user_infraction_counts", new=helpers.AsyncMock(return_value=""))
     def test_create_user_embed_uses_nick_in_title_if_available(self):
         """The embed should use the nick if it's available."""
-        ctx = helpers.MockContext(channel=helpers.MockTextChannel(channel_id=1))
+        ctx = helpers.MockContext(channel=helpers.MockTextChannel(id=1))
         user = helpers.MockMember()
         user.nick = "Cat lover"
         user.__str__ = unittest.mock.Mock(return_value="Mr. Hemlock")
@@ -375,8 +375,8 @@ class UserEmbedTests(unittest.TestCase):
     @unittest.mock.patch(f"{COG_PATH}.basic_user_infraction_counts", new=helpers.AsyncMock(return_value=""))
     def test_create_user_embed_ignores_everyone_role(self):
         """Created `!user` embeds should not contain mention of the @everyone-role."""
-        ctx = helpers.MockContext(channel=helpers.MockTextChannel(channel_id=1))
-        admins_role = helpers.MockRole('Admins')
+        ctx = helpers.MockContext(channel=helpers.MockTextChannel(id=1))
+        admins_role = helpers.MockRole(name='Admins')
         admins_role.colour = 100
 
         # A `MockMember` has the @Everyone role by default; we add the Admins to that.
@@ -391,15 +391,15 @@ class UserEmbedTests(unittest.TestCase):
     @unittest.mock.patch(f"{COG_PATH}.user_nomination_counts", new_callable=helpers.AsyncMock)
     def test_create_user_embed_expanded_information_in_moderation_channels(self, nomination_counts, infraction_counts):
         """The embed should contain expanded infractions and nomination info in mod channels."""
-        ctx = helpers.MockContext(channel=helpers.MockTextChannel(channel_id=50))
+        ctx = helpers.MockContext(channel=helpers.MockTextChannel(id=50))
 
-        moderators_role = helpers.MockRole('Moderators')
+        moderators_role = helpers.MockRole(name='Moderators')
         moderators_role.colour = 100
 
         infraction_counts.return_value = "expanded infractions info"
         nomination_counts.return_value = "nomination info"
 
-        user = helpers.MockMember(user_id=314, roles=[moderators_role], top_role=moderators_role)
+        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role)
         embed = asyncio.run(self.cog.create_user_embed(ctx, user))
 
         infraction_counts.assert_called_once_with(user)
@@ -426,14 +426,14 @@ class UserEmbedTests(unittest.TestCase):
     @unittest.mock.patch(f"{COG_PATH}.basic_user_infraction_counts", new_callable=helpers.AsyncMock)
     def test_create_user_embed_basic_information_outside_of_moderation_channels(self, infraction_counts):
         """The embed should contain only basic infraction data outside of mod channels."""
-        ctx = helpers.MockContext(channel=helpers.MockTextChannel(channel_id=100))
+        ctx = helpers.MockContext(channel=helpers.MockTextChannel(id=100))
 
-        moderators_role = helpers.MockRole('Moderators')
+        moderators_role = helpers.MockRole(name='Moderators')
         moderators_role.colour = 100
 
         infraction_counts.return_value = "basic infractions info"
 
-        user = helpers.MockMember(user_id=314, roles=[moderators_role], top_role=moderators_role)
+        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role)
         embed = asyncio.run(self.cog.create_user_embed(ctx, user))
 
         infraction_counts.assert_called_once_with(user)
@@ -459,10 +459,10 @@ class UserEmbedTests(unittest.TestCase):
         """The embed should be created with the colour of the top role, if a top role is available."""
         ctx = helpers.MockContext()
 
-        moderators_role = helpers.MockRole('Moderators')
+        moderators_role = helpers.MockRole(name='Moderators')
         moderators_role.colour = 100
 
-        user = helpers.MockMember(user_id=314, roles=[moderators_role], top_role=moderators_role)
+        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role)
         embed = asyncio.run(self.cog.create_user_embed(ctx, user))
 
         self.assertEqual(embed.colour, discord.Colour(moderators_role.colour))
@@ -472,7 +472,7 @@ class UserEmbedTests(unittest.TestCase):
         """The embed should be created with a blurple colour if the user has no assigned roles."""
         ctx = helpers.MockContext()
 
-        user = helpers.MockMember(user_id=217)
+        user = helpers.MockMember(id=217)
         embed = asyncio.run(self.cog.create_user_embed(ctx, user))
 
         self.assertEqual(embed.colour, discord.Colour.blurple())
@@ -482,7 +482,7 @@ class UserEmbedTests(unittest.TestCase):
         """The embed thumbnail should be set to the user's avatar in `png` format."""
         ctx = helpers.MockContext()
 
-        user = helpers.MockMember(user_id=217)
+        user = helpers.MockMember(id=217)
         user.avatar_url_as.return_value = "avatar url"
         embed = asyncio.run(self.cog.create_user_embed(ctx, user))
 
@@ -499,13 +499,13 @@ class UserCommandTests(unittest.TestCase):
         self.bot = helpers.MockBot()
         self.cog = information.Information(self.bot)
 
-        self.moderator_role = helpers.MockRole("Moderators", role_id=2, position=10)
-        self.flautist_role = helpers.MockRole("Flautists", role_id=3, position=2)
-        self.bassist_role = helpers.MockRole("Bassists", role_id=4, position=3)
+        self.moderator_role = helpers.MockRole(name="Moderators", id=2, position=10)
+        self.flautist_role = helpers.MockRole(name="Flautists", id=3, position=2)
+        self.bassist_role = helpers.MockRole(name="Bassists", id=4, position=3)
 
-        self.author = helpers.MockMember(user_id=1, name="syntaxaire")
-        self.moderator = helpers.MockMember(user_id=2, name="riffautae", roles=[self.moderator_role])
-        self.target = helpers.MockMember(user_id=3, name="__fluzz__")
+        self.author = helpers.MockMember(id=1, name="syntaxaire")
+        self.moderator = helpers.MockMember(id=2, name="riffautae", roles=[self.moderator_role])
+        self.target = helpers.MockMember(id=3, name="__fluzz__")
 
     def test_regular_member_cannot_target_another_member(self, constants):
         """A regular user should not be able to use `!user` targeting another user."""
@@ -523,7 +523,7 @@ class UserCommandTests(unittest.TestCase):
         constants.STAFF_ROLES = [self.moderator_role.id]
         constants.Channels.bot = 50
 
-        ctx = helpers.MockContext(author=self.author, channel=helpers.MockTextChannel(channel_id=100))
+        ctx = helpers.MockContext(author=self.author, channel=helpers.MockTextChannel(id=100))
 
         msg = "Sorry, but you may only use this command within <#50>."
         with self.assertRaises(InChannelCheckFailure, msg=msg):
@@ -535,7 +535,7 @@ class UserCommandTests(unittest.TestCase):
         constants.STAFF_ROLES = [self.moderator_role.id]
         constants.Channels.bot = 50
 
-        ctx = helpers.MockContext(author=self.author, channel=helpers.MockTextChannel(channel_id=50))
+        ctx = helpers.MockContext(author=self.author, channel=helpers.MockTextChannel(id=50))
 
         asyncio.run(self.cog.user_info.callback(self.cog, ctx))
 
@@ -548,7 +548,7 @@ class UserCommandTests(unittest.TestCase):
         constants.STAFF_ROLES = [self.moderator_role.id]
         constants.Channels.bot = 50
 
-        ctx = helpers.MockContext(author=self.author, channel=helpers.MockTextChannel(channel_id=50))
+        ctx = helpers.MockContext(author=self.author, channel=helpers.MockTextChannel(id=50))
 
         asyncio.run(self.cog.user_info.callback(self.cog, ctx, self.author))
 
@@ -561,7 +561,7 @@ class UserCommandTests(unittest.TestCase):
         constants.STAFF_ROLES = [self.moderator_role.id]
         constants.Channels.bot = 50
 
-        ctx = helpers.MockContext(author=self.moderator, channel=helpers.MockTextChannel(channel_id=200))
+        ctx = helpers.MockContext(author=self.moderator, channel=helpers.MockTextChannel(id=200))
 
         asyncio.run(self.cog.user_info.callback(self.cog, ctx))
 
@@ -574,7 +574,7 @@ class UserCommandTests(unittest.TestCase):
         constants.MODERATION_ROLES = [self.moderator_role.id]
         constants.STAFF_ROLES = [self.moderator_role.id]
 
-        ctx = helpers.MockContext(author=self.moderator, channel=helpers.MockTextChannel(channel_id=50))
+        ctx = helpers.MockContext(author=self.moderator, channel=helpers.MockTextChannel(id=50))
 
         asyncio.run(self.cog.user_info.callback(self.cog, ctx, self.target))
 

--- a/tests/bot/cogs/test_token_remover.py
+++ b/tests/bot/cogs/test_token_remover.py
@@ -24,7 +24,7 @@ class TokenRemoverTests(unittest.TestCase):
         self.bot.get_cog.return_value.send_log_message = AsyncMock()
         self.cog = TokenRemover(bot=self.bot)
 
-        self.msg = MockMessage(message_id=555, content='')
+        self.msg = MockMessage(id=555, content='')
         self.msg.author.__str__ = MagicMock()
         self.msg.author.__str__.return_value = 'lemon'
         self.msg.author.bot = False

--- a/tests/bot/test_api.py
+++ b/tests/bot/test_api.py
@@ -121,7 +121,9 @@ class LoggingHandlerTests(LoggingTestCase):
 
     def test_schedule_queued_tasks_for_nonempty_queue(self):
         """`APILoggingHandler` should schedule logs when the queue is not empty."""
-        with self.assertLogs(level=logging.DEBUG) as logs, patch('asyncio.create_task') as create_task:
+        log = logging.getLogger("bot.api")
+
+        with self.assertLogs(logger=log, level=logging.DEBUG) as logs, patch('asyncio.create_task') as create_task:
             self.log_handler.queue = [555]
             self.log_handler.schedule_queued_tasks()
             self.assertListEqual(self.log_handler.queue, [])

--- a/tests/bot/utils/test_checks.py
+++ b/tests/bot/utils/test_checks.py
@@ -22,7 +22,7 @@ class ChecksTests(unittest.TestCase):
 
     def test_with_role_check_with_guild_and_required_role(self):
         """`with_role_check` returns `True` if `Context.author` has the required role."""
-        self.ctx.author.roles.append(MockRole(role_id=10))
+        self.ctx.author.roles.append(MockRole(id=10))
         self.assertTrue(checks.with_role_check(self.ctx, 10))
 
     def test_without_role_check_without_guild(self):
@@ -33,13 +33,13 @@ class ChecksTests(unittest.TestCase):
     def test_without_role_check_returns_false_with_unwanted_role(self):
         """`without_role_check` returns `False` if `Context.author` has unwanted role."""
         role_id = 42
-        self.ctx.author.roles.append(MockRole(role_id=role_id))
+        self.ctx.author.roles.append(MockRole(id=role_id))
         self.assertFalse(checks.without_role_check(self.ctx, role_id))
 
     def test_without_role_check_returns_true_without_unwanted_role(self):
         """`without_role_check` returns `True` if `Context.author` does not have unwanted role."""
         role_id = 42
-        self.ctx.author.roles.append(MockRole(role_id=role_id))
+        self.ctx.author.roles.append(MockRole(id=role_id))
         self.assertTrue(checks.without_role_check(self.ctx, role_id + 10))
 
     def test_in_channel_check_for_correct_channel(self):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -227,7 +227,8 @@ class MockMember(CustomMockMixin, unittest.mock.Mock, ColourMixin, HashableMixin
         if roles:
             self.roles.extend(roles)
 
-        self.mention = f"@{self.name}"
+        if 'mention' not in kwargs:
+            self.mention = f"@{self.name}"
 
 
 # Create a Bot instance to get a realistic MagicMock of `discord.ext.commands.Bot`
@@ -250,6 +251,11 @@ class MockBot(CustomMockMixin, unittest.mock.MagicMock):
         # and should therefore be awaited. (The documentation calls it a coroutine as well, which
         # is technically incorrect, since it's a regular def.)
         self.wait_for = AsyncMock()
+
+        # Since calling `create_task` on our MockBot does not actually schedule the coroutine object
+        # as a task in the asyncio loop, this `side_effect` calls `close()` on the coroutine object
+        # to prevent "has not been awaited"-warnings.
+        self.loop.create_task.side_effect = lambda coroutine: coroutine.close()
 
 
 # Create a TextChannel instance to get a realistic MagicMock of `discord.TextChannel`

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -74,7 +74,10 @@ class CustomMockMixin:
     child_mock_type = unittest.mock.MagicMock
 
     def __init__(self, spec: Any = None, **kwargs):
+        name = kwargs.pop('name', None)  # `name` has special meaning for Mock classes, so we need to set it manually.
         super().__init__(spec=spec, **kwargs)
+        if name:
+            self.name = name
         if spec:
             self._extract_coroutine_methods_from_spec_instance(spec)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,11 +3,22 @@ from __future__ import annotations
 import asyncio
 import functools
 import inspect
+import logging
 import unittest.mock
 from typing import Any, Iterable, Optional
 
 import discord
 from discord.ext.commands import Bot, Context
+
+
+for logger in logging.Logger.manager.loggerDict.values():
+    # Set all loggers to CRITICAL by default to prevent screen clutter during testing
+
+    if not isinstance(logger, logging.Logger):
+        # There might be some logging.PlaceHolder objects in there
+        continue
+
+    logger.setLevel(logging.CRITICAL)
 
 
 def async_test(wrapped):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -202,6 +202,18 @@ class DiscordMocksTests(unittest.TestCase):
                 mock = mock_type(mention=mention)
                 self.assertEqual(mock.mention, mention)
 
+    def test_create_test_on_mock_bot_closes_passed_coroutine(self):
+        """`bot.loop.create_task` should close the passed coroutine object to prevent warnings."""
+        async def dementati():
+            """Dummy coroutine for testing purposes."""
+
+        coroutine_object = dementati()
+
+        bot = helpers.MockBot()
+        bot.loop.create_task(coroutine_object)
+        with self.assertRaises(RuntimeError, msg="cannot reuse already awaited coroutine"):
+            asyncio.run(coroutine_object)
+
 
 class MockObjectTests(unittest.TestCase):
     """Tests the mock objects and mixins we've defined."""


### PR DESCRIPTION
This pull request introduces several enhancements to our testing suite to make running tests easier and reduce the number of developer surprises. It does come with a couple of **breaking changes** that may influence currently open PRs (I haven't checked yet, but they should be easy to resolve).

## Enhancements

#### Stricter custom mock types

One of the reasons for using custom mock types is because they follow the specifications of the actual objects they're mocking. However, as @kwzrd remarked, the `spec` method we used for that only provided partial protection: `spec` does not prevent setting attributes that should not exist on the object we are mocking. I have solved this by using the stricter `spec_set` option that makes sure the validity of attributes is also checked when they are set (as opposed to only when they are accessed).

#### Prevent logging when running individual tests

As you may have noticed, logging messages were not suppressed when running an individual test file (instead of the entire test suite), making the output extremely messy. This is now no longer the case.

#### Prevent RuntimeWarning after `MockBot.loop.create_task`

When "scheduling" a coroutine object with `MockBot.loop.create_task`, the coroutine object is not actually scheduled as a task since we're mocking the `create_task` method and we're not actually running an event loop. While this is typically what we want, this triggers `RuntimeWarnings` since the coroutine object was never awaited. I've solved this by setting a default `side_effect` for `MockBot.loop.create_task` that calls `stop()` on the passed coroutine object.

#### Allow `name` attribute to be set with `__init__`

The `name` kwarg has a special meaning in the `__init__` methods of `Mock` and `MagicMock` preventing us from setting a `name` attribute during initialization of our custom mock types that inherit from these classes. This is not desirable, as `discord.py` objects frequently have a `name` attribute and we want to be able to set it when initializing the mock. I've added special handling of the `name` kwarg to prevent it from being passed to the `__init__` of the parent classes. 

*Note: This does prevent us from using that special `name` handling of Mock/MagicMock, but I don't think that option is useful for us in the first place. Being able to set the `name` atttribute of the mock is much more useful and actually in use a lot in our current tests.*

#### Use actual attribute names instead of 'safe' surrogates

Previously, I used surrogates like `message_id` to set the `id` attribute of mocks in `__init__` to prevent eclipsing the built-in `id`. Since I've now switched to `kwargs`-only approach in the `__init__`, this is no longer necessary, as no eclipsing will occur. This means we can now just pass the attributes by their actual name to prevent "developer surprise". (My apologies for those hours of frustration, @lemonsaurus...)

#### Allow all attributes to be set during initialization of the mock

Due to a mistake, some attributes could not be set during initialization of a custom mock type as the attributes were overwritten by default values. This is no longer the case.

## Breaking changes

- Our custom mocks can no longer be initialized with positional arguments to set attributes. This means you always have to set attributes with a keyword argument (e.g, `name="Helpers"`).
- All attributes must now be set using the actual attribute name. Surrogate names like `user_id` or `message_id` no longer work and will result in an `AttributeError` since they are not valid attributes of the types being mocked.