### PR TITLE
Antimalware: fix paste service URL showing replacement field

### DIFF
--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -26,7 +26,7 @@ class AntiMalware(Cog):
             if filename.endswith('.py'):
                 embed.description = (
                     f"It looks like you tried to attach a Python file - please "
-                    f"use a code-pasting service such as {URLs.paste_service}"
+                    f"use a code-pasting service such as {URLs.site_schema}{URLs.site_paste}"
                 )
                 break  # Other detections irrelevant because we prioritize the .py message.
             if not filename.endswith(tuple(AntiMalwareConfig.whitelist)):


### PR DESCRIPTION
`{key}` was being shown at the end of the URL because the constants are expected to be used with `.format()` to make HTTP requests.