### PR TITLE
Display time left until expiration of infraction

### DIFF
--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -232,6 +232,12 @@ class ModManagement(commands.Cog):
         user_id = infraction["user"]
         hidden = infraction["hidden"]
         created = time.format_infraction(infraction["inserted_at"])
+
+        if active:
+            remaining = time.until_expiration(infraction["expires_at"]) or 'Expired.'
+        else:
+            remaining = 'Inactive.'
+
         if infraction["expires_at"] is None:
             expires = "*Permanent*"
         else:
@@ -247,6 +253,7 @@ class ModManagement(commands.Cog):
             Reason: {infraction["reason"] or "*None*"}
             Created: {created}
             Expires: {expires}
+            Remaining: {remaining}
             Actor: {actor.mention if actor else actor_id}
             ID: `{infraction["id"]}`
             {"**===============**" if active else "==============="}

--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -234,9 +234,9 @@ class ModManagement(commands.Cog):
         created = time.format_infraction(infraction["inserted_at"])
 
         if active:
-            remaining = time.until_expiration(infraction["expires_at"]) or 'Expired.'
+            remaining = time.until_expiration(infraction["expires_at"]) or "Expired"
         else:
-            remaining = 'Inactive.'
+            remaining = "Inactive"
 
         if infraction["expires_at"] is None:
             expires = "*Permanent*"

--- a/bot/utils/time.py
+++ b/bot/utils/time.py
@@ -113,7 +113,11 @@ def format_infraction(timestamp: str) -> str:
     return dateutil.parser.isoparse(timestamp).strftime(INFRACTION_FORMAT)
 
 
-def format_infraction_with_duration(expiry: str, date_from: datetime.datetime = None, max_units: int = 2) -> str:
+def format_infraction_with_duration(
+    expiry: Optional[str],
+    date_from: datetime.datetime = None,
+    max_units: int = 2
+) -> Optional[str]:
     """
     Format an infraction timestamp to a more readable ISO 8601 format WITH the duration.
 

--- a/bot/utils/time.py
+++ b/bot/utils/time.py
@@ -138,3 +138,23 @@ def format_infraction_with_duration(
     duration_formatted = f" ({duration})" if duration else ''
 
     return f"{expiry_formatted}{duration_formatted}"
+
+
+def until_expiration(expiry: Optional[str], max_units: int = 2) -> Optional[str]:
+    """
+    Get the remaining time until infraction's expiration, in a human-readable version of the relativedelta.
+
+    Unlike `humanize_delta`, this function will force the `precision` to be `seconds` by not passing it.
+    `max_units` specifies the maximum number of units of time to include (e.g. 1 may include days but not hours).
+    By default, max_units is 2.
+    """
+    if not expiry:
+        return None
+
+    now = datetime.datetime.utcnow()
+    since = dateutil.parser.isoparse(expiry).replace(tzinfo=None, microsecond=0)
+
+    if since < now:
+        return None
+
+    return humanize_delta(relativedelta(since, now), max_units=max_units)


### PR DESCRIPTION
#### Closes #669

Will show the remaining time until an infraction is expired.

Introduced 1 helper function in `time` module - `until_expiration` that makes use of the nicely, already made `humanize_delta` in the same module.

### Images:
An active infraction:
![image](https://user-images.githubusercontent.com/19921765/70124639-d826ea80-16a7-11ea-82a7-e2c34cde342f.png)

An infraction that has yet to expire, but is inactive:
![image](https://user-images.githubusercontent.com/19921765/70124702-effe6e80-16a7-11ea-8ab8-4876342ad21f.png)

