### PR TITLE
Ensure hidden_channels and bypass_roles use a list when not passed.

### DIFF
--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -38,6 +38,9 @@ def in_channel(
     Hidden channels are channels which will not be displayed in the InChannelCheckFailure error
     message.
     """
+    hidden_channels = hidden_channels or []
+    bypass_roles = bypass_roles or []
+
     def predicate(ctx: Context) -> bool:
         """In-channel checker predicate."""
         if ctx.channel.id in channels or ctx.channel.id in hidden_channels:


### PR DESCRIPTION
The `in_channel` decorator raised `'NoneType' is not iterable` when `hidden_channels` and `bypass_roles` weren't passed due to their default value being `None` but not checked against before iterating over.

This edit ensures said arguments are set to an empty list in cases where they have a value of `None` instead.

Error:
![image](https://user-images.githubusercontent.com/32289550/70411669-a27c5b80-1a31-11ea-91a3-f8c84f4f7b7c.png)

Working as intended, after the fix:
![image](https://user-images.githubusercontent.com/32289550/70411702-b45dfe80-1a31-11ea-8c9c-e5464052250a.png)
