### PR TITLE
Whitelist Discord Testers invite link

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -193,6 +193,7 @@ filter:
         - 544525886180032552  # kennethreitz.org
         - 590806733924859943  # Discord Hack Week
         - 423249981340778496  # Kivy
+        - 197038439483310086  # Discord Testers
 
     domain_blacklist:
         - pornhub.com


### PR DESCRIPTION
Hi, this PR add the Discord Testers invite link to the guild invite whitelist. This server is own by the discord devs and is used to report bugs related to discord clients. 