### PR TITLE
Kick users from voice when they get muted

### DIFF
--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -208,8 +208,13 @@ class Infractions(InfractionScheduler, commands.Cog):
 
         self.mod_log.ignore(Event.member_update, user.id)
 
-        action = user.add_roles(self._muted_role, reason=reason)
-        await self.apply_infraction(ctx, infraction, user, action)
+        async def action() -> None:
+            await user.add_roles(self._muted_role, reason=reason)
+
+            log.trace(f"Attempting to kick {user} from voice because they've been muted.")
+            await user.move_to(None, reason=reason)
+
+        await self.apply_infraction(ctx, infraction, user, action())
 
     @respect_role_hierarchy()
     async def apply_kick(self, ctx: Context, user: Member, reason: str, **kwargs) -> None:

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -329,7 +329,7 @@ class InfractionScheduler(Scheduler):
             log_content = mod_role.mention
         except discord.HTTPException as e:
             log.exception(f"Failed to deactivate infraction #{id_} ({type_})")
-            log_text["Failure"] = f"HTTPException with code {e.code}."
+            log_text["Failure"] = f"HTTPException with status {e.status} and code {e.code}."
             log_content = mod_role.mention
 
         # Check if the user is currently being watched by Big Brother.

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -146,14 +146,18 @@ class InfractionScheduler(Scheduler):
                 if expiry:
                     # Schedule the expiration of the infraction.
                     self.schedule_task(ctx.bot.loop, infraction["id"], infraction)
-            except discord.Forbidden:
+            except discord.HTTPException as e:
                 # Accordingly display that applying the infraction failed.
                 confirm_msg = f":x: failed to apply"
                 expiry_msg = ""
                 log_content = ctx.author.mention
                 log_title = "failed to apply"
 
-                log.warning(f"Failed to apply {infr_type} infraction #{id_} to {user}.")
+                log_msg = f"Failed to apply {infr_type} infraction #{id_} to {user}"
+                if isinstance(e, discord.Forbidden):
+                    log.warning(f"{log_msg}: bot lacks permissions.")
+                else:
+                    log.exception(log_msg)
 
         # Send a confirmation message to the invoking context.
         log.trace(f"Sending infraction #{id_} confirmation message.")
@@ -324,7 +328,7 @@ class InfractionScheduler(Scheduler):
                     f"Attempted to deactivate an unsupported infraction #{id_} ({type_})!"
                 )
         except discord.Forbidden:
-            log.warning(f"Failed to deactivate infraction #{id_} ({type_}): bot lacks permissions")
+            log.warning(f"Failed to deactivate infraction #{id_} ({type_}): bot lacks permissions.")
             log_text["Failure"] = f"The bot lacks permissions to do this (role hierarchy?)"
             log_content = mod_role.mention
         except discord.HTTPException as e:


### PR DESCRIPTION
Closes #644

If the kick fails, the bot will send a message saying that applying the infraction failed. I felt that's adequate compared to a specific message for a voice channel kick failure. A specific message can be done easily if it's sent separately from the usual "confirmation message". However, integrating it into the confirmation message would require more thought and effort as it wasn't designed to be extensible to such degree.