### PR TITLE
Log voice channel events

### DIFF
--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -25,7 +25,11 @@ CHANNEL_CHANGES_SUPPRESSED = ("_overwrites", "position")
 MEMBER_CHANGES_SUPPRESSED = ("status", "activities", "_client_status", "nick")
 ROLE_CHANGES_UNSUPPORTED = ("colour", "permissions")
 
-VOICE_STATE_ATTRIBUTES = {"self_video": "Broadcasting", "channel.name": "Channel"}
+VOICE_STATE_ATTRIBUTES = {
+    "channel.name": "Channel",
+    "self_stream": "Streaming",
+    "self_video": "Broadcasting",
+}
 
 
 class ModLog(Cog, name="ModLog"):

--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -759,7 +759,10 @@ class ModLog(Cog, name="ModLog"):
         after: discord.VoiceState
     ) -> None:
         """Log member voice state changes to the voice log channel."""
-        if member.guild.id != GuildConstant.id:
+        if (
+            member.guild.id != GuildConstant.id
+            or (before.channel and before.channel.id in GuildConstant.ignored)
+        ):
             return
 
         if member.id in self._ignored[Event.voice_state_update]:

--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -25,7 +25,7 @@ CHANNEL_CHANGES_SUPPRESSED = ("_overwrites", "position")
 MEMBER_CHANGES_SUPPRESSED = ("status", "activities", "_client_status", "nick")
 ROLE_CHANGES_UNSUPPORTED = ("colour", "permissions")
 
-VOICE_STATE_ATTRIBUTES = {"self_video": "Broadcasting", "afk": "AFK"}
+VOICE_STATE_ATTRIBUTES = {"self_video": "Broadcasting", "afk": "AFK", "channel.name": "Channel"}
 
 
 class ModLog(Cog, name="ModLog"):
@@ -769,7 +769,13 @@ class ModLog(Cog, name="ModLog"):
             self._ignored[Event.voice_state_update].remove(member.id)
             return
 
-        diff = DeepDiff(before, after, exclude_paths="root.session_id")
+        # Exclude all channel attributes except the name.
+        diff = DeepDiff(
+            before,
+            after,
+            exclude_paths="root.session_id",
+            exclude_regex_paths=r"root\.channel\.(?!name)",
+        )
 
         # A type change seems to always take precedent over a value change. Furthermore, it will
         # include the value change along with the type change anyway. Therefore, it's OK to

--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -207,7 +207,7 @@ class ModLog(Cog, name="ModLog"):
                 new = value["new_value"]
                 old = value["old_value"]
 
-                changes.append(f"**{key.title()}:** `{old}` **->** `{new}`")
+                changes.append(f"**{key.title()}:** `{old}` **→** `{new}`")
 
             done.append(key)
 
@@ -285,7 +285,7 @@ class ModLog(Cog, name="ModLog"):
                 new = value["new_value"]
                 old = value["old_value"]
 
-                changes.append(f"**{key.title()}:** `{old}` **->** `{new}`")
+                changes.append(f"**{key.title()}:** `{old}` **→** `{new}`")
 
             done.append(key)
 
@@ -335,7 +335,7 @@ class ModLog(Cog, name="ModLog"):
             new = value["new_value"]
             old = value["old_value"]
 
-            changes.append(f"**{key.title()}:** `{old}` **->** `{new}`")
+            changes.append(f"**{key.title()}:** `{old}` **→** `{new}`")
 
             done.append(key)
 
@@ -488,23 +488,23 @@ class ModLog(Cog, name="ModLog"):
                 old = value.get("old_value")
 
                 if new and old:
-                    changes.append(f"**{key.title()}:** `{old}` **->** `{new}`")
+                    changes.append(f"**{key.title()}:** `{old}` **→** `{new}`")
 
             done.append(key)
 
         if before.name != after.name:
             changes.append(
-                f"**Username:** `{before.name}` **->** `{after.name}`"
+                f"**Username:** `{before.name}` **→** `{after.name}`"
             )
 
         if before.discriminator != after.discriminator:
             changes.append(
-                f"**Discriminator:** `{before.discriminator}` **->** `{after.discriminator}`"
+                f"**Discriminator:** `{before.discriminator}` **→** `{after.discriminator}`"
             )
 
         if before.display_name != after.display_name:
             changes.append(
-                f"**Display name:** `{before.display_name}` **->** `{after.display_name}`"
+                f"**Display name:** `{before.display_name}` **→** `{after.display_name}`"
             )
 
         if not changes:
@@ -781,7 +781,7 @@ class ModLog(Cog, name="ModLog"):
             attr = attr[5:]  # Remove "root." prefix
             attr = VOICE_STATE_ATTRIBUTES.get(attr, attr.replace("_", " ").capitalize())
 
-            changes.append(f"**{attr}:** `{values['old_value']}` **->** `{values['new_value']}`")
+            changes.append(f"**{attr}:** `{values['old_value']}` **→** `{values['new_value']}`")
 
         if not changes:
             return

--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -25,7 +25,7 @@ CHANNEL_CHANGES_SUPPRESSED = ("_overwrites", "position")
 MEMBER_CHANGES_SUPPRESSED = ("status", "activities", "_client_status", "nick")
 ROLE_CHANGES_UNSUPPORTED = ("colour", "permissions")
 
-VOICE_STATE_ATTRIBUTES = {"self_video": "Broadcasting", "afk": "AFK", "channel.name": "Channel"}
+VOICE_STATE_ATTRIBUTES = {"self_video": "Broadcasting", "channel.name": "Channel"}
 
 
 class ModLog(Cog, name="ModLog"):
@@ -773,7 +773,7 @@ class ModLog(Cog, name="ModLog"):
         diff = DeepDiff(
             before,
             after,
-            exclude_paths="root.session_id",
+            exclude_paths=("root.session_id", "root.afk"),
             exclude_regex_paths=r"root\.channel\.(?!name)",
         )
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -544,6 +544,8 @@ class Event(Enum):
     message_delete = "message_delete"
     message_edit = "message_edit"
 
+    voice_state_update = "voice_state_update"
+
 
 # Debug mode
 DEBUG_MODE = True if 'local' in os.environ.get("SITE_URL", "local") else False

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -325,6 +325,10 @@ class Icons(metaclass=YAMLGetter):
     superstarify: str
     unsuperstarify: str
 
+    voice_state_blue: str
+    voice_state_green: str
+    voice_state_red: str
+
 
 class CleanMessages(metaclass=YAMLGetter):
     section = "bot"

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -379,6 +379,7 @@ class Channels(metaclass=YAMLGetter):
     userlog: int
     user_event_a: int
     verification: int
+    voice_log: int
 
 
 class Webhooks(metaclass=YAMLGetter):

--- a/config-default.yml
+++ b/config-default.yml
@@ -92,6 +92,10 @@ style:
         superstarify: "https://cdn.discordapp.com/emojis/636288153044516874.png"
         unsuperstarify: "https://cdn.discordapp.com/emojis/636288201258172446.png"
 
+        voice_state_blue: "https://cdn.discordapp.com/emojis/656899769662439456.png"
+        voice_state_green: "https://cdn.discordapp.com/emojis/656899770094452754.png"
+        voice_state_red: "https://cdn.discordapp.com/emojis/656899769905709076.png"
+
 guild:
     id: 267624335836053506
 

--- a/config-default.yml
+++ b/config-default.yml
@@ -101,6 +101,7 @@ guild:
     channels:
         admins:            &ADMINS        365960823622991872
         admin_spam:        &ADMIN_SPAM    563594791770914816
+        admins_voice:      &ADMINS_VOICE  500734494840717332
         announcements:                    354619224620138496
         big_brother_logs:  &BBLOGS        468507907357409333
         bot:                              267659945086812160
@@ -131,13 +132,15 @@ guild:
         python:                           267624335836053506
         reddit:                           458224812528238616
         staff_lounge:      &STAFF_LOUNGE  464905259261755392
+        staff_voice:       &STAFF_VOICE   412375055910043655
         talent_pool:       &TALENT_POOL   534321732593647616
         userlog:                          528976905546760203
         user_event_a:      &USER_EVENT_A  592000283102674944
         verification:                     352442727016693763
+        voice_log:                        640292421988646961
 
     staff_channels: [*ADMINS, *ADMIN_SPAM, *MOD_SPAM, *MODS, *HELPERS, *ORGANISATION, *DEFCON]
-    ignored: [*ADMINS, *MESSAGE_LOG, *MODLOG]
+    ignored: [*ADMINS, *MESSAGE_LOG, *MODLOG, *ADMINS_VOICE, *STAFF_VOICE]
 
     roles:
         admin:             &ADMIN_ROLE      267628507062992896


### PR DESCRIPTION
Closes #645.

* Use a red icon when leaving or mute/deafened. 
* Use a green icon when joining or unmuted/undeafened. 
* Use a blue icon when changing channels, broadcasting, streaming, or any other possible change.

![bild](https://user-images.githubusercontent.com/1515135/71107797-abc6a000-2176-11ea-98cd-da766a771c57.png)

## Need Feedback

* The state has an `afk` attribute but I chose to omit it. See commit message for details.
* `Broadcasting` may be a poor name given the "Go Live" streaming feature. The former is for using a camera while the latter is for sharing one's screen. Can anyone think of a better name than `Broadcasting`? Perhaps `video` was fine all along.
* Should broadcasting or streaming use green/red icons instead of blue?
* Should _self_ deaf/mute be using green/red or should they be blue so that only moderator's mutes/deafs are green/red?
* A change is currently only ignored if it is the `before` state which has the ignored channel. For example, this means joining an ignored channel will log a state change, but leaving an ignored channel will not log anything. Something along the lines of the following channel changes may be more comprehensive to ignore:

    1. None → ignored
    2. ignored → None
    3. ignored → ignored

    However, I believe this would require relatively more complicated logic.