### PR TITLE
Allow "recent" as infraction ID for infraction edit command

### DIFF
--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 from discord.ext.commands import Context
 
 from bot import constants
-from bot.converters import InfractionSearchQuery
+from bot.converters import InfractionSearchQuery, string
 from bot.pagination import LinePaginator
 from bot.utils import time
 from bot.utils.checks import in_channel_check, with_role_check
@@ -20,15 +20,6 @@ from .modlog import ModLog
 log = logging.getLogger(__name__)
 
 UserConverter = t.Union[discord.User, utils.proxy_user]
-
-
-def permanent_duration(expires_at: str) -> str:
-    """Only allow an expiration to be 'permanent' if it is a string."""
-    expires_at = expires_at.lower()
-    if expires_at != "permanent":
-        raise commands.BadArgument
-    else:
-        return expires_at
 
 
 class ModManagement(commands.Cog):
@@ -61,7 +52,7 @@ class ModManagement(commands.Cog):
         self,
         ctx: Context,
         infraction_id: int,
-        duration: t.Union[utils.Expiry, permanent_duration, None],
+        duration: t.Union[utils.Expiry, string("permanent"), None],
         *,
         reason: str = None
     ) -> None:

--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -139,7 +139,8 @@ class ModManagement(commands.Cog):
                 New expiry: {new_infraction['expires_at'] or "Permanent"}
             """.rstrip()
 
-        await ctx.send(f":ok_hand: Updated infraction: {' & '.join(confirm_messages)}")
+        changes = ' & '.join(confirm_messages)
+        await ctx.send(f":ok_hand: Updated infraction #{infraction_id}: {changes}")
 
         # Get information about the infraction's user
         user_id = new_infraction['user']

--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 from discord.ext.commands import Context
 
 from bot import constants
-from bot.converters import InfractionSearchQuery, string
+from bot.converters import InfractionSearchQuery, allowed_strings
 from bot.pagination import LinePaginator
 from bot.utils import time
 from bot.utils.checks import in_channel_check, with_role_check
@@ -51,8 +51,8 @@ class ModManagement(commands.Cog):
     async def infraction_edit(
         self,
         ctx: Context,
-        infraction_id: t.Union[int, string("l", "last", "recent")],
-        duration: t.Union[utils.Expiry, string("p", "permanent"), None],
+        infraction_id: t.Union[int, allowed_strings("l", "last", "recent")],
+        duration: t.Union[utils.Expiry, allowed_strings("p", "permanent"), None],
         *,
         reason: str = None
     ) -> None:

--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -51,8 +51,8 @@ class ModManagement(commands.Cog):
     async def infraction_edit(
         self,
         ctx: Context,
-        infraction_id: t.Union[int, string("recent")],
-        duration: t.Union[utils.Expiry, string("permanent"), None],
+        infraction_id: t.Union[int, string("l", "last", "recent")],
+        duration: t.Union[utils.Expiry, string("p", "permanent"), None],
         *,
         reason: str = None
     ) -> None:
@@ -69,18 +69,18 @@ class ModManagement(commands.Cog):
         \u2003`M` - minutes∗
         \u2003`s` - seconds
 
-        Use "recent" as the infraction ID to specify that the ost recent infraction authored by the
-        command invoker should be edited.
+        Use "l", "last", or "recent" as the infraction ID to specify that the most recent infraction
+        authored by the command invoker should be edited.
 
-        Use "permanent" to mark the infraction as permanent. Alternatively, an ISO 8601 timestamp
-        can be provided for the duration.
+        Use "p" or "permanent" to mark the infraction as permanent. Alternatively, an ISO 8601
+        timestamp can be provided for the duration.
         """
         if duration is None and reason is None:
             # Unlike UserInputError, the error handler will show a specified message for BadArgument
             raise commands.BadArgument("Neither a new expiry nor a new reason was specified.")
 
         # Retrieve the previous infraction for its information.
-        if infraction_id == "recent":
+        if isinstance(infraction_id, str):
             params = {
                 "actor__id": ctx.author.id,
                 "ordering": "-inserted_at"
@@ -102,7 +102,7 @@ class ModManagement(commands.Cog):
         confirm_messages = []
         log_text = ""
 
-        if duration == "permanent":
+        if isinstance(duration, str):
             request_data['expires_at'] = None
             confirm_messages.append("marked as permanent")
         elif duration is not None:

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -1,8 +1,8 @@
 import logging
 import re
+import typing as t
 from datetime import datetime
 from ssl import CertificateError
-from typing import Union
 
 import dateutil.parser
 import dateutil.tz
@@ -13,6 +13,25 @@ from discord.ext.commands import BadArgument, Context, Converter
 
 
 log = logging.getLogger(__name__)
+
+
+def string(*values, preserve_case: bool = False) -> t.Callable[[str], str]:
+    """
+    Return a converter which only allows arguments equal to one of the given values.
+
+    Unless preserve_case is True, the argument is converter to lowercase. All values are then
+    expected to have already been given in lowercase too.
+    """
+    def converter(arg: str) -> str:
+        if not preserve_case:
+            arg = arg.lower()
+
+        if arg not in values:
+            raise BadArgument(f"Only the following values are allowed:\n```{', '.join(values)}```")
+        else:
+            return arg
+
+    return converter
 
 
 class ValidPythonIdentifier(Converter):
@@ -70,7 +89,7 @@ class InfractionSearchQuery(Converter):
     """A converter that checks if the argument is a Discord user, and if not, falls back to a string."""
 
     @staticmethod
-    async def convert(ctx: Context, arg: str) -> Union[discord.Member, str]:
+    async def convert(ctx: Context, arg: str) -> t.Union[discord.Member, str]:
         """Check if the argument is a Discord user, and if not, falls back to a string."""
         try:
             maybe_snowflake = arg.strip("<@!>")

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -15,11 +15,11 @@ from discord.ext.commands import BadArgument, Context, Converter
 log = logging.getLogger(__name__)
 
 
-def string(*values, preserve_case: bool = False) -> t.Callable[[str], str]:
+def allowed_strings(*values, preserve_case: bool = False) -> t.Callable[[str], str]:
     """
     Return a converter which only allows arguments equal to one of the given values.
 
-    Unless preserve_case is True, the argument is converter to lowercase. All values are then
+    Unless preserve_case is True, the argument is converted to lowercase. All values are then
     expected to have already been given in lowercase too.
     """
     def converter(arg: str) -> str:


### PR DESCRIPTION
Resolves #624 

Could support multiple phrases but I left it at "recent" to start with. The confirmation message now displays the infraction ID to reduce uncertainty as to which infraction was edited when "recent" is used.