### PR TITLE
Properly sync users to the database when they update their information

### DIFF
--- a/bot/cogs/sync/cog.py
+++ b/bot/cogs/sync/cog.py
@@ -1,7 +1,7 @@
 import logging
-from typing import Callable, Iterable
+from typing import Callable, Dict, Iterable, Union
 
-from discord import Guild, Member, Role
+from discord import Guild, Member, Role, User
 from discord.ext import commands
 from discord.ext.commands import Cog, Context
 
@@ -50,6 +50,15 @@ class Sync(Cog):
                         f"`{syncer_name}` syncer finished, created `{total_created}`, updated `{total_updated}`, "
                         f"deleted `{total_deleted}`."
                     )
+
+    async def patch_user(self, user_id: int, updated_information: Dict[str, Union[str, int]]) -> None:
+        """Send a PATCH request to partially update a user in the database."""
+        try:
+            await self.bot.api_client.patch("bot/users/" + str(user_id), json=updated_information)
+        except ResponseCodeError as e:
+            if e.response.status != 404:
+                raise
+            log.warning("Unable to update user, got 404. Assuming race condition from join event.")
 
     @Cog.listener()
     async def on_guild_role_create(self, role: Role) -> None:
@@ -143,33 +152,21 @@ class Sync(Cog):
 
     @Cog.listener()
     async def on_member_update(self, before: Member, after: Member) -> None:
-        """Updates the user information if any of relevant attributes have changed."""
-        if (
-                before.name != after.name
-                or before.avatar != after.avatar
-                or before.discriminator != after.discriminator
-                or before.roles != after.roles
-        ):
-            try:
-                await self.bot.api_client.put(
-                    'bot/users/' + str(after.id),
-                    json={
-                        'avatar_hash': after.avatar,
-                        'discriminator': int(after.discriminator),
-                        'id': after.id,
-                        'in_guild': True,
-                        'name': after.name,
-                        'roles': sorted(role.id for role in after.roles)
-                    }
-                )
-            except ResponseCodeError as e:
-                if e.response.status != 404:
-                    raise
+        """Update the roles of the member in the database if a change is detected."""
+        if before.roles != after.roles:
+            updated_information = {"roles": sorted(role.id for role in after.roles)}
+            await self.patch_user(after.id, updated_information=updated_information)
 
-                log.warning(
-                    "Unable to update user, got 404. "
-                    "Assuming race condition from join event."
-                )
+    @Cog.listener()
+    async def on_user_update(self, before: User, after: User) -> None:
+        """Update the user information in the database if a relevant change is detected."""
+        if any(getattr(before, attr) != getattr(after, attr) for attr in ("name", "discriminator", "avatar")):
+            updated_information = {
+                "name": after.name,
+                "discriminator": int(after.discriminator),
+                "avatar_hash": after.avatar,
+            }
+            await self.patch_user(after.id, updated_information=updated_information)
 
     @commands.group(name='sync')
     @commands.has_permissions(administrator=True)


### PR DESCRIPTION
Today, we noticed that the synchronization utility that keeps our database up to date does not fire when a user updates their username, discriminator, or avatar. The reason turned out to be that we were using an [`on_member_update`](https://discordpy.readthedocs.io/en/latest/api.html#discord.on_member_update) event listener to detect those changes, while we should be using an [`on_user_update`](https://discordpy.readthedocs.io/en/latest/api.html#discord.on_user_update) event listener to watch for changes in these three attributes. This pull request remedies that by adding such an `on_user_update` listener in addition to the `on_member_update` listener.

This means that we now have two different event listeners:

- An `on_member_update` listener to detect role changes
- An `on_user_update` listener to detect changes in username, discriminator, and avatar hash

Since the `discord.User` instance we get in an `on_user_update` event listener does not contain the roles that the user has in our guild, we cannot send a full PUT request to replace the entire user row in the database. That's why the newly created utility method uses a PATCH request to only update the changes relevant to that event listener instead of the PUT request we were using before this.

This pull request closes #702 

---

Note: When experimenting with the `on_user_update` and `on_member_update` events, I noticed that the `on_member_update` events do fire when user account information is altered, but (seemingly) always after the `user_update` event has fired. The confusing part is that the `discord.Member` object passed as the `before` argument to the `on_member_update` listener already reflects the changes made, so you can't use this event to detect them!

I suspect that the reason is that by the time this `on_member_join` event listener gets called, the `Member` object in the cache has already been updated by the `user_update` event, meaning that `before` and `after` are equal! I did not confirm that this is the reason for this, but a DeepDiff does reveal that all of the attributes of `before` and `after` in the `on_member_update` are equal. That means it's impossible to detect the changes in it.

