### PR TITLE
Moderation: explicitly set active value when posting infractions

### DIFF
--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -203,7 +203,7 @@ class Infractions(InfractionScheduler, commands.Cog):
         if await utils.has_active_infraction(ctx, user, "mute"):
             return
 
-        infraction = await utils.post_infraction(ctx, user, "mute", reason, **kwargs)
+        infraction = await utils.post_infraction(ctx, user, "mute", reason, active=True, **kwargs)
         if infraction is None:
             return
 
@@ -220,7 +220,7 @@ class Infractions(InfractionScheduler, commands.Cog):
     @respect_role_hierarchy()
     async def apply_kick(self, ctx: Context, user: Member, reason: str, **kwargs) -> None:
         """Apply a kick infraction with kwargs passed to `post_infraction`."""
-        infraction = await utils.post_infraction(ctx, user, "kick", reason, **kwargs)
+        infraction = await utils.post_infraction(ctx, user, "kick", reason, active=False, **kwargs)
         if infraction is None:
             return
 
@@ -235,7 +235,7 @@ class Infractions(InfractionScheduler, commands.Cog):
         if await utils.has_active_infraction(ctx, user, "ban"):
             return
 
-        infraction = await utils.post_infraction(ctx, user, "ban", reason, **kwargs)
+        infraction = await utils.post_infraction(ctx, user, "ban", reason, active=True, **kwargs)
         if infraction is None:
             return
 

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -133,7 +133,7 @@ class Superstarify(InfractionScheduler, Cog):
 
         # Post the infraction to the API
         reason = reason or f"old nick: {member.display_name}"
-        infraction = await utils.post_infraction(ctx, member, "superstar", reason, duration)
+        infraction = await utils.post_infraction(ctx, member, "superstar", reason, duration, active=True)
         id_ = infraction["id"]
 
         old_nick = member.display_name

--- a/bot/cogs/watchchannels/bigbrother.py
+++ b/bot/cogs/watchchannels/bigbrother.py
@@ -65,7 +65,7 @@ class BigBrother(WatchChannel, Cog, name="Big Brother"):
             await ctx.send(":x: The specified user is already being watched.")
             return
 
-        response = await post_infraction(ctx, user, 'watch', reason, hidden=True)
+        response = await post_infraction(ctx, user, 'watch', reason, hidden=True, active=True)
 
         if response is not None:
             self.watched_users[user.id] = response


### PR DESCRIPTION
Required due to changes in the API making the active field required.
See python-discord/site/pull/317