### PR TITLE
Add new duckies to the constants

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -270,6 +270,12 @@ class Emojis(metaclass=YAMLGetter):
     ducky_ninja: int
     ducky_devil: int
     ducky_tube: int
+    ducky_hunt: int
+    ducky_wizard: int
+    ducky_party: int
+    ducky_angel: int
+    ducky_maul: int
+    ducky_santa: int
 
     upvotes: str
     comments: str

--- a/config-default.yml
+++ b/config-default.yml
@@ -41,6 +41,12 @@ style:
         ducky_ninja:    &DUCKY_NINJA    637923502535606293
         ducky_devil:    &DUCKY_DEVIL    637925314982576139
         ducky_tube:     &DUCKY_TUBE     637881368008851456
+        ducky_hunt:     &DUCKY_HUNT     639355090909528084
+        ducky_wizard:   &DUCKY_WIZARD   639355996954689536
+        ducky_party:    &DUCKY_PARTY    639468753440210977
+        ducky_angel:    &DUCKY_ANGEL    640121935610511361
+        ducky_maul:     &DUCKY_MAUL     640137724958867467
+        ducky_santa:    &DUCKY_SANTA    655360331002019870
 
         upvotes:        "<:upvotes:638729835245731840>"
         comments:       "<:comments:638729835073765387>"
@@ -405,7 +411,7 @@ redirect_output:
 
 duck_pond:
     threshold: 5
-    custom_emojis: [*DUCKY_YELLOW, *DUCKY_BLURPLE, *DUCKY_CAMO, *DUCKY_DEVIL, *DUCKY_NINJA, *DUCKY_REGAL, *DUCKY_TUBE]
+    custom_emojis: [*DUCKY_YELLOW, *DUCKY_BLURPLE, *DUCKY_CAMO, *DUCKY_DEVIL, *DUCKY_NINJA, *DUCKY_REGAL, *DUCKY_TUBE, *DUCKY_HUNT, *DUCKY_WIZARD, *DUCKY_PARTY, *DUCKY_ANGEL, *DUCKY_MAUL, *DUCKY_SANTA]
 
 config:
     required_keys: ['bot.token']


### PR DESCRIPTION
We have added a bunch of cool new ducky emojis to our guild, but we did not add the IDs to the bot's constants. This means that features relying on it, like Duck Pond, don't work properly. This PR adds those IDs to the constants.