### PR TITLE
Update filetype whitelist to include audio formats

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -374,6 +374,9 @@ anti_malware:
         - '.ai'   # Illustrator
         - '.aep'  # After Effects
         - '.xcf'  # GIMP
+        - '.mp3'
+        - '.wav'
+        - '.ogg'
 
 
 reddit:


### PR DESCRIPTION
Discord has a built-in player for all of these and they are really just stripped down videos, which are allowed.