### PR TITLE
Watchchannels: show username in response for already watched users

### DIFF
--- a/bot/cogs/watchchannels/bigbrother.py
+++ b/bot/cogs/watchchannels/bigbrother.py
@@ -62,7 +62,7 @@ class BigBrother(WatchChannel, Cog, name="Big Brother"):
             return
 
         if user.id in self.watched_users:
-            await ctx.send(":x: The specified user is already being watched.")
+            await ctx.send(f":x: {user} is already being watched.")
             return
 
         response = await post_infraction(ctx, user, 'watch', reason, hidden=True)

--- a/bot/cogs/watchchannels/talentpool.py
+++ b/bot/cogs/watchchannels/talentpool.py
@@ -69,7 +69,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
             return
 
         if user.id in self.watched_users:
-            await ctx.send(":x: The specified user is already being watched in the talent pool")
+            await ctx.send(f":x: {user} is already being watched in the talent pool")
             return
 
         # Manual request with `raise_for_status` as False because we want the actual response


### PR DESCRIPTION
Resolves #713 

Makes it clear which user it is in the case of an ID being used to invoke the command.