### PR TITLE
Adding PyGame and Ren'Py to the invite white list

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -202,6 +202,8 @@ filter:
         - 590806733924859943  # Discord Hack Week
         - 423249981340778496  # Kivy
         - 197038439483310086  # Discord Testers
+        - 286633898581164032  # Ren'Py
+        - 349505959032389632  # PyGame
 
     domain_blacklist:
         - pornhub.com


### PR DESCRIPTION
With the addition of the #game-development channel, I would expect we'll see an increase in people needing specific help with the various engines and libraries that Python has to offer.  As part of this, I'm adding the servers for PyGame and Ren'Py to the white list to help people get to the proper resources they might need.