### PR TITLE
Add handling for empty PEP metadata values

### DIFF
--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -62,14 +62,12 @@ class Utils(Cog):
                 pep_embed.set_thumbnail(url="https://www.python.org/static/opengraph-icon-200x200.png")
 
                 # Add the interesting information
-                if "Status" in pep_header:
-                    pep_embed.add_field(name="Status", value=pep_header["Status"])
-                if "Python-Version" in pep_header:
-                    pep_embed.add_field(name="Python-Version", value=pep_header["Python-Version"])
-                if "Created" in pep_header:
-                    pep_embed.add_field(name="Created", value=pep_header["Created"])
-                if "Type" in pep_header:
-                    pep_embed.add_field(name="Type", value=pep_header["Type"])
+                fields_to_check = ("Status", "Python-Version", "Created", "Type")
+                for field in fields_to_check:
+                    # Check for a PEP metadata field that is present but has an empty value
+                    # embed field values can't contain an empty string
+                    if pep_header.get(field, ""):
+                        pep_embed.add_field(name=field, value=pep_header[field])
 
             elif response.status != 404:
                 # any response except 200 and 404 is expected


### PR DESCRIPTION
Some PEPs have a metadata field that is present but has an empty value (e.g. PEP 249), causing an exception to be raised when attempting to add it as an embed field value, which cannot be empty.

This refactors the information parsing to prevent the field from being added if there is no value to provide, as well as cut down on copy+paste when populating fields in the embed.

Closes #720 