### PR TITLE
Allow for throw away words after the rules command call

### DIFF
--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -4,8 +4,8 @@ from typing import Union
 
 from discord import Colour, Embed, Member, User
 from discord.ext.commands import (
-    Cog, Command, Context, clean_content,
-    command, Greedy, group,
+    Cog, Command, Context, Greedy,
+    clean_content, command, group,
 )
 
 from bot.bot import Bot

--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -3,7 +3,10 @@ import logging
 from typing import Union
 
 from discord import Colour, Embed, Member, User
-from discord.ext.commands import Cog, Command, Context, clean_content, command, group
+from discord.ext.commands import (
+    Cog, Command, Context, clean_content,
+    command, Greedy, group,
+)
 
 from bot.bot import Bot
 from bot.cogs.extensions import Extension
@@ -81,7 +84,7 @@ class Alias (Cog):
         await self.invoke(ctx, "site faq")
 
     @command(name="rules", aliases=("rule",), hidden=True)
-    async def site_rules_alias(self, ctx: Context, *rules: int) -> None:
+    async def site_rules_alias(self, ctx: Context, rules: Greedy[int], *_: str) -> None:
         """Alias for invoking <prefix>site rules."""
         await self.invoke(ctx, "site rules", *rules)
 


### PR DESCRIPTION
fixes #723 
This simply catches all strings after a sequence of ints. This allows us to write a message after the list of rules we wish to display. 
Example:
`!rules 5 6 We do not allow for paid work, and that will break ToS of x and y` 

Disclaimer, didn't get site to respond properly so haven't tested this with bot+site.