### PR TITLE
Move tools and questions guide to under resources

### DIFF
--- a/bot/cogs/site.py
+++ b/bot/cogs/site.py
@@ -59,7 +59,7 @@ class Site(Cog):
     @site_group.command(name="tools")
     async def site_tools(self, ctx: Context) -> None:
         """Info about the site's Tools page."""
-        tools_url = f"{PAGES_URL}/tools"
+        tools_url = f"{PAGES_URL}/resources/tools"
 
         embed = Embed(title="Tools")
         embed.set_footer(text=f"{tools_url}")
@@ -74,7 +74,7 @@ class Site(Cog):
     @site_group.command(name="help")
     async def site_help(self, ctx: Context) -> None:
         """Info about the site's Getting Help page."""
-        url = f"{PAGES_URL}/asking-good-questions"
+        url = f"{PAGES_URL}resources/guides/asking-good-questions"
 
         embed = Embed(title="Asking Good Questions")
         embed.set_footer(text=url)

--- a/bot/cogs/site.py
+++ b/bot/cogs/site.py
@@ -74,7 +74,7 @@ class Site(Cog):
     @site_group.command(name="help")
     async def site_help(self, ctx: Context) -> None:
         """Info about the site's Getting Help page."""
-        url = f"{PAGES_URL}resources/guides/asking-good-questions"
+        url = f"{PAGES_URL}/resources/guides/asking-good-questions"
 
         embed = Embed(title="Asking Good Questions")
         embed.set_footer(text=url)


### PR DESCRIPTION
After the wiki pages adjustment to the resources page, these two urls are needing to be updated to point to the new correct locations for each page.

Tools will be under resources, and Asking Good Questions is a guide, so will be under Guides.