### PR TITLE
Stop scheduling expiration of permanent infractions on edit

### DIFF
--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -130,8 +130,11 @@ class ModManagement(commands.Cog):
         # Re-schedule infraction if the expiration has been updated
         if 'expires_at' in request_data:
             self.infractions_cog.cancel_task(new_infraction['id'])
-            loop = asyncio.get_event_loop()
-            self.infractions_cog.schedule_task(loop, new_infraction['id'], new_infraction)
+
+            # If the infraction was not marked as permanent, schedule a new expiration task
+            if request_data['expires_at']:
+                loop = asyncio.get_event_loop()
+                self.infractions_cog.schedule_task(loop, new_infraction['id'], new_infraction)
 
             log_text += f"""
                 Previous expiry: {old_infraction['expires_at'] or "Permanent"}


### PR DESCRIPTION
The infraction edit command defined in `bot.cogs.moderation.management` contained a bug causing it to attempt to schedule an expiration task when turning a temporary infraction into a permanent infraction. Since the "expires_at" field of a permanent infraction is `None`, this caused an exception to occur in the scheduler:

```py
Traceback (most recent call last):
  File "/bot/bot/cogs/moderation/scheduler.py", line 415, in _scheduled_task
    expiry = dateutil.parser.isoparse(infraction["expires_at"]).replace(tzinfo=None)
  File "/usr/local/lib/python3.7/site-packages/dateutil/parser/isoparser.py", line 37, in func
    return f(self, str_in, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/dateutil/parser/isoparser.py", line 134, in isoparse
    components, pos = self._parse_isodate(dt_str)
  File "/usr/local/lib/python3.7/site-packages/dateutil/parser/isoparser.py", line 208, in _parse_isodate
    return self._parse_isodate_common(dt_str)
  File "/usr/local/lib/python3.7/site-packages/dateutil/parser/isoparser.py", line 213, in _parse_isodate_common
    len_str = len(dt_str)
TypeError: object of type 'NoneType' has no len()
```

I have solved this by adding a check that makes sure we only schedule an expiration task when the `"expires_at"` field has a truthy value (which all valid datetime strings are) using `if request_data['expires_at']`.

Note: While it's tempting to just skip the entire scheduling block for permanent infractions, it's essential to unschedule existing expiration tasks for this infraction as we're turning a temporary infraction to a permanent infraction. We don't want a lingering expiration task to "accidentally" overturn a permanent infraction.

This commit closes #751