### PR TITLE
Show created date and duration in expired infraction log

### DIFF
--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -309,20 +309,21 @@ class InfractionScheduler(Scheduler):
         guild = self.bot.get_guild(constants.Guild.id)
         mod_role = guild.get_role(constants.Roles.moderator)
         user_id = infraction["user"]
+        actor = infraction["actor"]
         type_ = infraction["type"]
         id_ = infraction["id"]
         inserted_at = infraction["inserted_at"]
         expiry = infraction["expires_at"]
 
+        log.info(f"Marking infraction #{id_} as inactive (expired).")
+
         expiry = dateutil.parser.isoparse(expiry).replace(tzinfo=None) if expiry else None
         created = time.format_infraction_with_duration(inserted_at, expiry)
-
-        log.info(f"Marking infraction #{id_} as inactive (expired).")
 
         log_content = None
         log_text = {
             "Member": str(user_id),
-            "Actor": str(self.bot.user),
+            "Actor": str(self.bot.get_user(actor) or actor),
             "Reason": infraction["reason"],
             "Created": created,
         }

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -391,14 +391,19 @@ class InfractionScheduler(Scheduler):
         if send_log:
             log_title = f"expiration failed" if "Failure" in log_text else "expired"
 
+            user = self.bot.get_user(user_id)
+            avatar = user.avatar_url_as(static_format="png") if user else None
+
             log.trace(f"Sending deactivation mod log for infraction #{id_}.")
             await self.mod_log.send_log_message(
                 icon_url=utils.INFRACTION_ICONS[type_][1],
                 colour=Colours.soft_green,
                 title=f"Infraction {log_title}: {type_}",
+                thumbnail=avatar,
                 text="\n".join(f"{k}: {v}" for k, v in log_text.items()),
                 footer=f"ID: {id_}",
                 content=log_content,
+
             )
 
         return log_text

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -311,6 +311,11 @@ class InfractionScheduler(Scheduler):
         user_id = infraction["user"]
         type_ = infraction["type"]
         id_ = infraction["id"]
+        inserted_at = infraction["inserted_at"]
+        expiry = infraction["expires_at"]
+
+        expiry = dateutil.parser.isoparse(expiry).replace(tzinfo=None) if expiry else None
+        created = time.format_infraction_with_duration(inserted_at, expiry)
 
         log.info(f"Marking infraction #{id_} as inactive (expired).")
 
@@ -318,7 +323,8 @@ class InfractionScheduler(Scheduler):
         log_text = {
             "Member": str(user_id),
             "Actor": str(self.bot.user),
-            "Reason": infraction["reason"]
+            "Reason": infraction["reason"],
+            "Created": created,
         }
 
         try:

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -322,7 +322,7 @@ class InfractionScheduler(Scheduler):
 
         log_content = None
         log_text = {
-            "Member": str(user_id),
+            "Member": f"<@{user_id}>",
             "Actor": str(self.bot.get_user(actor) or actor),
             "Reason": infraction["reason"],
             "Created": created,


### PR DESCRIPTION
Closes #685

* Creation date is displayed in the log.
* The duration between the expiration and the creation is displayed as a humanised delta. If the infraction had no expiration, then the duration is relative to the current time rather than an expiration.
* The actual actor is displayed rather than always being the bot user.
* The member is displayed as a mention rather than an ID.

Before:
![bild](https://user-images.githubusercontent.com/1515135/74598415-16387700-5026-11ea-9695-fb77a2197d2f.png)

After:
![bild](https://user-images.githubusercontent.com/1515135/74598419-1cc6ee80-5026-11ea-9de9-894cc0d6f8b3.png)
