### PR TITLE
Fix paginator erroring on clearing reactions from non-existing messages.

### DIFF
--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -301,6 +301,7 @@ class ImagePaginator(Paginator):
         self._current_page = [prefix]
         self.images = []
         self._pages = []
+        self._count = 0
 
     def add_line(self, line: str = '', *, empty: bool = False) -> None:
         """Adds a line to each page."""

--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
-from typing import Iterable, List, Optional, Tuple
+import typing as t
+from contextlib import suppress
 
-from discord import Embed, Member, Message, Reaction
+import discord
 from discord.abc import User
 from discord.ext.commands import Context, Paginator
 
@@ -89,12 +90,12 @@ class LinePaginator(Paginator):
     @classmethod
     async def paginate(
         cls,
-        lines: Iterable[str],
+        lines: t.List[str],
         ctx: Context,
-        embed: Embed,
+        embed: discord.Embed,
         prefix: str = "",
         suffix: str = "",
-        max_lines: Optional[int] = None,
+        max_lines: t.Optional[int] = None,
         max_size: int = 500,
         empty: bool = True,
         restrict_to_user: User = None,
@@ -102,7 +103,7 @@ class LinePaginator(Paginator):
         footer_text: str = None,
         url: str = None,
         exception_on_empty_embed: bool = False
-    ) -> Optional[Message]:
+    ) -> t.Optional[discord.Message]:
         """
         Use a paginator and set of reactions to provide pagination over a set of lines.
 
@@ -114,11 +115,11 @@ class LinePaginator(Paginator):
         Pagination will also be removed automatically if no reaction is added for five minutes (300 seconds).
 
         Example:
-        >>> embed = Embed()
+        >>> embed = discord.Embed()
         >>> embed.set_author(name="Some Operation", url=url, icon_url=icon)
-        >>> await LinePaginator.paginate((line for line in lines), ctx, embed)
+        >>> await LinePaginator.paginate([line for line in lines], ctx, embed)
         """
-        def event_check(reaction_: Reaction, user_: Member) -> bool:
+        def event_check(reaction_: discord.Reaction, user_: discord.Member) -> bool:
             """Make sure that this reaction is what we want to operate on."""
             no_restrictions = (
                 # Pagination is not restricted
@@ -281,8 +282,9 @@ class LinePaginator(Paginator):
 
                 await message.edit(embed=embed)
 
-        log.debug("Ending pagination and removing all reactions...")
-        await message.clear_reactions()
+        log.debug("Ending pagination and clearing reactions.")
+        with suppress(discord.NotFound):
+            await message.clear_reactions()
 
 
 class ImagePaginator(Paginator):
@@ -316,13 +318,13 @@ class ImagePaginator(Paginator):
     @classmethod
     async def paginate(
         cls,
-        pages: List[Tuple[str, str]],
-        ctx: Context, embed: Embed,
+        pages: t.List[t.Tuple[str, str]],
+        ctx: Context, embed: discord.Embed,
         prefix: str = "",
         suffix: str = "",
         timeout: int = 300,
         exception_on_empty_embed: bool = False
-    ) -> Optional[Message]:
+    ) -> t.Optional[discord.Message]:
         """
         Use a paginator and set of reactions to provide pagination over a set of title/image pairs.
 
@@ -334,11 +336,11 @@ class ImagePaginator(Paginator):
         Note: Pagination will be removed automatically if no reaction is added for five minutes (300 seconds).
 
         Example:
-        >>> embed = Embed()
+        >>> embed = discord.Embed()
         >>> embed.set_author(name="Some Operation", url=url, icon_url=icon)
         >>> await ImagePaginator.paginate(pages, ctx, embed)
         """
-        def check_event(reaction_: Reaction, member: Member) -> bool:
+        def check_event(reaction_: discord.Reaction, member: discord.Member) -> bool:
             """Checks each reaction added, if it matches our conditions pass the wait_for."""
             return all((
                 # Reaction is on the same message sent
@@ -445,5 +447,6 @@ class ImagePaginator(Paginator):
 
             await message.edit(embed=embed)
 
-        log.debug("Ending pagination and removing all reactions...")
-        await message.clear_reactions()
+        log.debug("Ending pagination and clearing reactions.")
+        with suppress(discord.NotFound):
+            await message.clear_reactions()


### PR DESCRIPTION
Closes #770 

## Description
A paginator session will eventually timeout and clear it's reactions so it can stop listening to events to paginate to. Sometimes we delete these messages entirely, but the paginator session still is waiting for the timeout. When it finally come time for it to clear itself and stop listening to events, it gets instead a `discord.NotFound` exception as there's no longer a message to clear reactions from. 

## Changes
For now, this is a simple PR that addresses this immediate bug to prevent an error output from being sent and to have the exception handled and suppressed rather than letting it propagate all the way to our logs.

This is done by just wrapping the `message.clear_reactions` attempt in a `contextlib.suppress` context. 

While I was here, I changed the `from discord import x, y, z` import to `import discord` and referenced it's namespace directory, and same for the `typing` lib, using the same style we're using for newer areas of our projects, `import typing as t`.

I also addressed a minor inspection squiggle by ensuring a class attribute was defined on initialisation: `ImagePaginator._count`.