### PR TITLE
Check reminder user and channel before send and schedule.

### DIFF
--- a/bot/cogs/reminders.py
+++ b/bot/cogs/reminders.py
@@ -116,7 +116,6 @@ class Reminders(Scheduler, Cog):
         """Send the reminder."""
         is_valid, user, channel = self.ensure_valid_reminder(reminder)
         if not is_valid:
-            await self._delete_reminder(reminder["id"])
             return
 
         embed = discord.Embed()

--- a/bot/cogs/reminders.py
+++ b/bot/cogs/reminders.py
@@ -2,12 +2,12 @@ import asyncio
 import logging
 import random
 import textwrap
+import typing as t
 from datetime import datetime, timedelta
 from operator import itemgetter
-from typing import Optional
 
+import discord
 from dateutil.relativedelta import relativedelta
-from discord import Colour, Embed, Message
 from discord.ext.commands import Cog, Context, group
 
 from bot.bot import Bot
@@ -45,6 +45,10 @@ class Reminders(Scheduler, Cog):
         loop = asyncio.get_event_loop()
 
         for reminder in response:
+            is_valid, *_ = self.ensure_valid_reminder(reminder)
+            if not is_valid:
+                continue
+
             remind_at = datetime.fromisoformat(reminder['expiration'][:-1])
 
             # If the reminder is already overdue ...
@@ -55,11 +59,26 @@ class Reminders(Scheduler, Cog):
             else:
                 self.schedule_task(loop, reminder["id"], reminder)
 
+    def ensure_valid_reminder(self, reminder: dict) -> t.Tuple[bool, discord.User, discord.TextChannel]:
+        """Ensure reminder author and channel can be fetched otherwise delete the reminder."""
+        user = self.bot.get_user(reminder['author'])
+        channel = self.bot.get_channel(reminder['channel_id'])
+        is_valid = True
+        if not user or not channel:
+            is_valid = False
+            log.info(
+                f"Reminder {reminder['id']} invalid: "
+                f"User {reminder['author']}={user}, Channel {reminder['channel_id']}={channel}."
+            )
+            asyncio.create_task(self._delete_reminder(reminder['id']))
+
+        return is_valid, user, channel
+
     @staticmethod
     async def _send_confirmation(ctx: Context, on_success: str) -> None:
         """Send an embed confirming the reminder change was made successfully."""
-        embed = Embed()
-        embed.colour = Colour.green()
+        embed = discord.Embed()
+        embed.colour = discord.Colour.green()
         embed.title = random.choice(POSITIVE_REPLIES)
         embed.description = on_success
         await ctx.send(embed=embed)
@@ -95,11 +114,13 @@ class Reminders(Scheduler, Cog):
 
     async def send_reminder(self, reminder: dict, late: relativedelta = None) -> None:
         """Send the reminder."""
-        channel = self.bot.get_channel(reminder["channel_id"])
-        user = self.bot.get_user(reminder["author"])
+        is_valid, user, channel = self.ensure_valid_reminder(reminder)
+        if not is_valid:
+            await self._delete_reminder(reminder["id"])
+            return
 
-        embed = Embed()
-        embed.colour = Colour.blurple()
+        embed = discord.Embed()
+        embed.colour = discord.Colour.blurple()
         embed.set_author(
             icon_url=Icons.remind_blurple,
             name="It has arrived!"
@@ -111,7 +132,7 @@ class Reminders(Scheduler, Cog):
             embed.description += f"\n[Jump back to when you created the reminder]({reminder['jump_url']})"
 
         if late:
-            embed.colour = Colour.red()
+            embed.colour = discord.Colour.red()
             embed.set_author(
                 icon_url=Icons.remind_red,
                 name=f"Sorry it arrived {humanize_delta(late, max_units=2)} late!"
@@ -129,20 +150,20 @@ class Reminders(Scheduler, Cog):
         await ctx.invoke(self.new_reminder, expiration=expiration, content=content)
 
     @remind_group.command(name="new", aliases=("add", "create"))
-    async def new_reminder(self, ctx: Context, expiration: Duration, *, content: str) -> Optional[Message]:
+    async def new_reminder(self, ctx: Context, expiration: Duration, *, content: str) -> t.Optional[discord.Message]:
         """
         Set yourself a simple reminder.
 
         Expiration is parsed per: http://strftime.org/
         """
-        embed = Embed()
+        embed = discord.Embed()
 
         # If the user is not staff, we need to verify whether or not to make a reminder at all.
         if without_role_check(ctx, *STAFF_ROLES):
 
             # If they don't have permission to set a reminder in this channel
             if ctx.channel.id not in WHITELISTED_CHANNELS:
-                embed.colour = Colour.red()
+                embed.colour = discord.Colour.red()
                 embed.title = random.choice(NEGATIVE_REPLIES)
                 embed.description = "Sorry, you can't do that here!"
 
@@ -159,7 +180,7 @@ class Reminders(Scheduler, Cog):
             # Let's limit this, so we don't get 10 000
             # reminders from kip or something like that :P
             if len(active_reminders) > MAXIMUM_REMINDERS:
-                embed.colour = Colour.red()
+                embed.colour = discord.Colour.red()
                 embed.title = random.choice(NEGATIVE_REPLIES)
                 embed.description = "You have too many active reminders!"
 
@@ -189,7 +210,7 @@ class Reminders(Scheduler, Cog):
         self.schedule_task(loop, reminder["id"], reminder)
 
     @remind_group.command(name="list")
-    async def list_reminders(self, ctx: Context) -> Optional[Message]:
+    async def list_reminders(self, ctx: Context) -> t.Optional[discord.Message]:
         """View a paginated embed of all reminders for your user."""
         # Get all the user's reminders from the database.
         data = await self.bot.api_client.get(
@@ -222,8 +243,8 @@ class Reminders(Scheduler, Cog):
 
             lines.append(text)
 
-        embed = Embed()
-        embed.colour = Colour.blurple()
+        embed = discord.Embed()
+        embed.colour = discord.Colour.blurple()
         embed.title = f"Reminders for {ctx.author}"
 
         # Remind the user that they have no reminders :^)
@@ -232,7 +253,7 @@ class Reminders(Scheduler, Cog):
             return await ctx.send(embed=embed)
 
         # Construct the embed and paginate it.
-        embed.colour = Colour.blurple()
+        embed.colour = discord.Colour.blurple()
 
         await LinePaginator.paginate(
             lines,


### PR DESCRIPTION
Closes #764.

## Description
On bot load, the reminders are retrieved from the site api and rescheduled to be sent at their expiry datetime. 

If someone creates a reminder, leaves the guild, and the reminder gets sent while they are no longer a member then the bot will raise an `AttributeError` due to user returning `None` and us not checking before attempting to get the user mention string.

This PR addresses this issue by checking that the user is present when going through reminders for rescheduling, as well as checking before the sending of reminders to ensure both resumed reminders and current-session reminders are appropriately reviewed.

As an extra precaution, the channel is also checked to be still present, just in case the channel has been deleted. We normally would archive channels, but a valid example where this could be useful is the temporary code jam team channels. We could potentially whitelist these channels for future events.

## Changes

A new method was created named `ensure_valid_reminder` that fetches the user and channel objects. This method is not a coroutine, as there's no significant reason to wait for the reminder to be deleted before moving on.

The method returns the result of it being valid or not as a bool, as well as the fetched user and channel objects to avoid needing to refetch again immediately after in the `send_reminder` method.

`from discord import x, y, z` was getting a bit long so I've adjusted it to `import discord` and made references use the discord namespace directly.

`from typing import x` has been adjusted to `import typing as t` to match the style applied in our projects more recently.