### PR TITLE
Reduce log level of tag cooldown notice.

### DIFF
--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -116,8 +116,10 @@ class Tags(Cog):
 
         if _command_on_cooldown(tag_name):
             time_left = Cooldowns.tags - (time.time() - self.tag_cooldowns[tag_name]["time"])
-            log.warning(f"{ctx.author} tried to get the '{tag_name}' tag, but the tag is on cooldown. "
-                        f"Cooldown ends in {time_left:.1f} seconds.")
+            log.info(
+                f"{ctx.author} tried to get the '{tag_name}' tag, but the tag is on cooldown. "
+                f"Cooldown ends in {time_left:.1f} seconds."
+            )
             return
 
         await self._get_tags()


### PR DESCRIPTION
Closes #768.

## Description
When the tag command is used too often, it may hit cooldown. The log entry when this occurs is informative and by design rather than any potential concern, so should not be logged as a warning.

## Changes
The log level has been reduced to `info` and the code style has been adjusted to conform to our typical project style, with a correctly dropped line continuation.