### PR TITLE
Fix invalid tag names being passed to the tag cog.

### DIFF
--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -98,10 +98,7 @@ class ErrorHandler(Cog):
                     )
                 else:
                     with contextlib.suppress(ResponseCodeError):
-                        await ctx.invoke(
-                            tags_get_command,
-                            tag_name=tag_name
-                        )
+                        await ctx.invoke(tags_get_command, tag_name=tag_name)
                 return
         elif isinstance(e, BadArgument):
             await ctx.send(f"Bad argument: {e}\n")

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -89,12 +89,20 @@ class ErrorHandler(Cog):
                     return
 
                 # Return to not raise the exception
-                with contextlib.suppress(BadArgument, ResponseCodeError):
-                    await ctx.invoke(
-                        tags_get_command,
-                        tag_name=await TagNameConverter.convert(ctx, ctx.invoked_with)
+                try:
+                    tag_name = await TagNameConverter.convert(ctx, ctx.invoked_with)
+                except BadArgument:
+                    log.debug(
+                        f"{ctx.author} tried to use an invalid command "
+                        f"and the fallback tag failed validation in TagNameConverter."
                     )
-                    return
+                else:
+                    with contextlib.suppress(ResponseCodeError):
+                        await ctx.invoke(
+                            tags_get_command,
+                            tag_name=tag_name
+                        )
+                return
         elif isinstance(e, BadArgument):
             await ctx.send(f"Bad argument: {e}\n")
             await ctx.invoke(*help_command)

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -20,6 +20,7 @@ from sentry_sdk import push_scope
 from bot.api import ResponseCodeError
 from bot.bot import Bot
 from bot.constants import Channels
+from bot.converters import TagNameConverter
 from bot.decorators import InChannelCheckFailure
 
 log = logging.getLogger(__name__)
@@ -88,8 +89,11 @@ class ErrorHandler(Cog):
                     return
 
                 # Return to not raise the exception
-                with contextlib.suppress(ResponseCodeError):
-                    await ctx.invoke(tags_get_command, tag_name=ctx.invoked_with)
+                with contextlib.suppress(BadArgument, ResponseCodeError):
+                    await ctx.invoke(
+                        tags_get_command,
+                        tag_name=await TagNameConverter.convert(ctx, ctx.invoked_with)
+                    )
                     return
         elif isinstance(e, BadArgument):
             await ctx.send(f"Bad argument: {e}\n")

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -141,14 +141,6 @@ class TagNameConverter(Converter):
     @staticmethod
     async def convert(ctx: Context, tag_name: str) -> str:
         """Lowercase & strip whitespace from proposed tag_name & ensure it's valid."""
-        def is_number(value: str) -> bool:
-            """Check to see if the input string is numeric."""
-            try:
-                float(value)
-            except ValueError:
-                return False
-            return True
-
         tag_name = tag_name.lower().strip()
 
         # The tag name has at least one invalid character.
@@ -162,12 +154,6 @@ class TagNameConverter(Converter):
             log.warning(f"{ctx.author} tried to create a tag with a name consisting only of whitespace. "
                         "Rejecting the request.")
             raise BadArgument("Tag names should not be empty, or filled with whitespace.")
-
-        # The tag name is a number of some kind, we don't allow that.
-        elif is_number(tag_name):
-            log.warning(f"{ctx.author} tried to create a tag with a digit as its name. "
-                        "Rejecting the request.")
-            raise BadArgument("Tag names can't be numbers.")
 
         # The tag name is longer than 127 characters.
         elif len(tag_name) > 127:

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -145,26 +145,18 @@ class TagNameConverter(Converter):
 
         # The tag name has at least one invalid character.
         if ascii(tag_name)[1:-1] != tag_name:
-            log.warning(f"{ctx.author} tried to put an invalid character in a tag name. "
-                        "Rejecting the request.")
             raise BadArgument("Don't be ridiculous, you can't use that character!")
 
         # The tag name is either empty, or consists of nothing but whitespace.
         elif not tag_name:
-            log.warning(f"{ctx.author} tried to create a tag with a name consisting only of whitespace. "
-                        "Rejecting the request.")
             raise BadArgument("Tag names should not be empty, or filled with whitespace.")
 
         # The tag name is longer than 127 characters.
         elif len(tag_name) > 127:
-            log.warning(f"{ctx.author} tried to request a tag name with over 127 characters. "
-                        "Rejecting the request.")
             raise BadArgument("Are you insane? That's way too long!")
 
         # The tag name is ascii but does not contain any letters.
         elif not any(character.isalpha() for character in tag_name):
-            log.warning(f"{ctx.author} tried to request a tag name without letters. "
-                        "Rejecting the request.")
             raise BadArgument("Tag names must contain at least one letter.")
 
         return tag_name
@@ -184,8 +176,6 @@ class TagContentConverter(Converter):
 
         # The tag contents should not be empty, or filled with whitespace.
         if not tag_content:
-            log.warning(f"{ctx.author} tried to create a tag containing only whitespace. "
-                        "Rejecting the request.")
             raise BadArgument("Tag contents should not be empty, or filled with whitespace.")
 
         return tag_content

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -175,6 +175,12 @@ class TagNameConverter(Converter):
                         "Rejecting the request.")
             raise BadArgument("Are you insane? That's way too long!")
 
+        # The tag name is ascii but does not contain any letters.
+        elif not any(character.isalpha() for character in tag_name):
+            log.warning(f"{ctx.author} tried to request a tag name without letters. "
+                        "Rejecting the request.")
+            raise BadArgument("Tag names must contain at least one letter.")
+
         return tag_name
 
 

--- a/tests/bot/test_converters.py
+++ b/tests/bot/test_converters.py
@@ -68,7 +68,7 @@ class ConverterTests(unittest.TestCase):
             ('👋', "Don't be ridiculous, you can't use that character!"),
             ('', "Tag names should not be empty, or filled with whitespace."),
             ('  ', "Tag names should not be empty, or filled with whitespace."),
-            ('42', "Tag names can't be numbers."),
+            ('42', "Tag names must contain at least one letter."),
             ('x' * 128, "Are you insane? That's way too long!"),
         )
 


### PR DESCRIPTION
The error handler fallback allowed any tag names through and tags not containing any letters were not restricted by the `TagNameConverter`, resulting in a `ZeroDivisionError` when fuzzy matched and passed through `REGEX_NON_ALPHABET`

Fixes #787 