### PR TITLE
Moderation: fix task cancellation for permanent infraction when editing

### DIFF
--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -129,7 +129,9 @@ class ModManagement(commands.Cog):
 
         # Re-schedule infraction if the expiration has been updated
         if 'expires_at' in request_data:
-            self.infractions_cog.cancel_task(new_infraction['id'])
+            # A scheduled task should only exist if the old infraction wasn't permanent
+            if old_infraction['expires_at']:
+                self.infractions_cog.cancel_task(new_infraction['id'])
 
             # If the infraction was not marked as permanent, schedule a new expiration task
             if request_data['expires_at']:


### PR DESCRIPTION
A task should not be cancelled if an infraction is permanent because tasks don't exist for permanent infractions.

Fixes [BOT-1V](https://sentry.io/organizations/python-discord/issues/1535669757/?referrer=github_integration)