### PR TITLE
Wrong annotation for Tags._fuzzy_search

### DIFF
--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -42,7 +42,7 @@ class Tags(Cog):
             self._last_fetch = time_now
 
     @staticmethod
-    def _fuzzy_search(search: str, target: str) -> int:
+    def _fuzzy_search(search: str, target: str) -> float:
         """A simple scoring algorithm based on how many letters are found / total, with order in mind."""
         current, index = 0, 0
         _search = REGEX_NON_ALPHABET.sub('', search.lower())


### PR DESCRIPTION
## Description
Wrong annotation for Tags._fuzzy_search

The returned value from _fuzzy_search is a float
The current type annotation is an int,
solved this problem by switching it into a float

Resolves #789