### PR TITLE
Add grabify (IP logger) domains to banned domains

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -284,6 +284,30 @@ filter:
     domain_blacklist:
         - pornhub.com
         - liveleak.com
+        - grabify.link
+        - bmwforum.co
+        - leancoding.co
+        - spottyfly.com
+        - stopify.co
+        - yoütu.be
+        - discörd.com
+        - minecräft.com
+        - freegiftcards.co
+        - disçordapp.com
+        - fortnight.space
+        - fortnitechat.site
+        - joinmy.site
+        - curiouscat.club
+        - catsnthings.fun
+        - yourtube.site
+        - youtubeshort.watch
+        - catsnthing.com
+        - youtubeshort.pro
+        - canadianlumberjacks.online
+        - poweredbydialup.club
+        - poweredbydialup.online
+        - poweredbysecurity.org
+        - poweredbysecurity.online
 
     word_watchlist:
         - goo+ks*


### PR DESCRIPTION
This bans Grabify URLs which are used to track IPs as a domain shortener.

Grabify: https://grabify.link/track/6WFYB8