### PR TITLE
Cache all Python dependencies in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - task: UsePythonVersion@0
         displayName: 'Set Python version'
-        name: PythonVersion
+        name: python
         inputs:
           versionSpec: '3.8.x'
           addToPath: true
@@ -34,11 +34,11 @@ jobs:
       - task: Cache@2
         displayName: 'Restore Python environment'
         inputs:
-          key: python | $(Agent.OS) | "$(PythonVersion.pythonLocation)" | 0 | ./Pipfile | ./Pipfile.lock
+          key: python | $(Agent.OS) | "$(python.pythonLocation)" | 0 | ./Pipfile | ./Pipfile.lock
           restoreKeys: |
-            python | "$(PythonVersion.pythonLocation)" | 0 | ./Pipfile.lock
-            python | "$(PythonVersion.pythonLocation)" | 0 | ./Pipfile
-            python | "$(PythonVersion.pythonLocation)" | 0
+            python | "$(python.pythonLocation)" | 0 | ./Pipfile.lock
+            python | "$(python.pythonLocation)" | 0 | ./Pipfile
+            python | "$(python.pythonLocation)" | 0
           cacheHitVar: PY_ENV_RESTORED
           path: $(PYTHONUSERBASE)
 
@@ -59,16 +59,16 @@ jobs:
       # pipenv entirely, which is too dumb to know it should use the system interpreter rather than
       # creating a new venv.
       - script: |
-          printf '%s\n%s' '#!/bin/bash' '"${@:2}"' > $(PythonVersion.pythonLocation)/bin/pipenv \
-          && chmod +x $(PythonVersion.pythonLocation)/bin/pipenv
+          printf '%s\n%s' '#!/bin/bash' '"${@:2}"' > $(python.pythonLocation)/bin/pipenv \
+          && chmod +x $(python.pythonLocation)/bin/pipenv
         displayName: 'Mock pipenv binary'
 
       - task: Cache@2
         displayName: 'Restore pre-commit environment'
         inputs:
-          key: pre-commit | "$(PythonVersion.pythonLocation)" | 0 | .pre-commit-config.yaml
+          key: pre-commit | "$(python.pythonLocation)" | 0 | .pre-commit-config.yaml
           restoreKeys: |
-            pre-commit | "$(PythonVersion.pythonLocation)" | 0
+            pre-commit | "$(python.pythonLocation)" | 0
           path: $(PRE_COMMIT_HOME)
 
       # pre-commit's venv doesn't allow user installs - not that they're really needed anyway.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,7 @@
 
 variables:
   PIP_NO_CACHE_DIR: false
+  PIP_USER: 1
   PIPENV_HIDE_EMOJIS: 1
   PIPENV_IGNORE_VIRTUALENVS: 1
   PIPENV_NOSPIN: 1
@@ -41,17 +42,16 @@ jobs:
           cacheHitVar: PY_ENV_RESTORED
           path: $(PYTHONUSERBASE)
 
+      - script: echo '##vso[task.prependpath]$(PYTHONUSERBASE)/bin'
+        displayName: 'Prepend PATH'
+
       - script: pip install pipenv
         displayName: 'Install pipenv'
         condition: and(succeeded(), ne(variables.PY_ENV_RESTORED, 'true'))
 
-      # PIP_USER=1 will install packages to the user site.
-      - script: export PIP_USER=1; pipenv install --dev --deploy --system
+      - script: pipenv install --dev --deploy --system
         displayName: 'Install project using pipenv'
         condition: and(succeeded(), ne(variables.PY_ENV_RESTORED, 'true'))
-
-      - script: echo '##vso[task.prependpath]$(PYTHONUSERBASE)/bin'
-        displayName: 'Prepend PATH'
 
       # Create an executable shell script which replaces the original pipenv binary.
       # The shell script ignores the first argument and executes the rest of the args as a command.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,7 @@
 # https://aka.ms/yaml
 
 variables:
+  PIP_NO_CACHE_DIR: false
   PIPENV_HIDE_EMOJIS: 1
   PIPENV_IGNORE_VIRTUALENVS: 1
   PIPENV_NOSPIN: 1
@@ -12,7 +13,6 @@ jobs:
       vmImage: ubuntu-18.04
 
     variables:
-      PIP_CACHE_DIR: ".cache/pip"
       PRE_COMMIT_HOME: $(Pipeline.Workspace)/pre-commit-cache
       BOT_API_KEY: foo
       BOT_SENTRY_DSN: blah
@@ -29,11 +29,24 @@ jobs:
           versionSpec: '3.8.x'
           addToPath: true
 
+      - task: Cache@2
+        displayName: 'Restore Python environment'
+        inputs:
+          key: python | $(Agent.OS) | "$(PythonVersion.pythonLocation)" | ./Pipfile | ./Pipfile.lock
+          restoreKeys: |
+            python | "$(PythonVersion.pythonLocation)" | ./Pipfile.lock
+            python | "$(PythonVersion.pythonLocation)" | ./Pipfile
+            python | "$(PythonVersion.pythonLocation)"
+          cacheHitVar: PY_ENV_RESTORED
+          path: $(PythonVersion.pythonLocation)
+
       - script: pip install pipenv
         displayName: 'Install pipenv'
+        condition: and(succeeded(), ne(variables.PY_ENV_RESTORED, 'true'))
 
       - script: pipenv install --dev --deploy --system
         displayName: 'Install project using pipenv'
+        condition: and(succeeded(), ne(variables.PY_ENV_RESTORED, 'true'))
 
       # Create an executable shell script which replaces the original pipenv binary.
       # The shell script ignores the first argument and executes the rest of the args as a command.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,8 @@ jobs:
             pre-commit | "$(PythonVersion.pythonLocation)" | 0
           path: $(PRE_COMMIT_HOME)
 
-      - script: pre-commit run --all-files
+      # pre-commit's venv doesn't allow user installs - not that they're really needed anyway.
+      - script: export PIP_USER=0; pre-commit run --all-files
         displayName: 'Run pre-commit hooks'
 
       - script: coverage run -m xmlrunner

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,11 +33,11 @@ jobs:
       - task: Cache@2
         displayName: 'Restore Python environment'
         inputs:
-          key: python | $(Agent.OS) | "$(PythonVersion.pythonLocation)" | ./Pipfile | ./Pipfile.lock
+          key: python | $(Agent.OS) | "$(PythonVersion.pythonLocation)" | 0 | ./Pipfile | ./Pipfile.lock
           restoreKeys: |
-            python | "$(PythonVersion.pythonLocation)" | ./Pipfile.lock
-            python | "$(PythonVersion.pythonLocation)" | ./Pipfile
-            python | "$(PythonVersion.pythonLocation)"
+            python | "$(PythonVersion.pythonLocation)" | 0 | ./Pipfile.lock
+            python | "$(PythonVersion.pythonLocation)" | 0 | ./Pipfile
+            python | "$(PythonVersion.pythonLocation)" | 0
           cacheHitVar: PY_ENV_RESTORED
           path: $(PYTHONUSERBASE)
 
@@ -66,9 +66,9 @@ jobs:
       - task: Cache@2
         displayName: 'Restore pre-commit environment'
         inputs:
-          key: pre-commit | "$(PythonVersion.pythonLocation)" | .pre-commit-config.yaml
+          key: pre-commit | "$(PythonVersion.pythonLocation)" | 0 | .pre-commit-config.yaml
           restoreKeys: |
-            pre-commit | "$(PythonVersion.pythonLocation)"
+            pre-commit | "$(PythonVersion.pythonLocation)" | 0
           path: $(PRE_COMMIT_HOME)
 
       - script: pre-commit run --all-files

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,9 @@ jobs:
         displayName: 'Install project using pipenv'
         condition: and(succeeded(), ne(variables.PY_ENV_RESTORED, 'true'))
 
+      - script: echo '##vso[task.prependpath]$(PYTHONUSERBASE)/bin'
+        displayName: 'Prepend PATH'
+
       # Create an executable shell script which replaces the original pipenv binary.
       # The shell script ignores the first argument and executes the rest of the args as a command.
       # It makes the `pipenv run flake8` command in the pre-commit hook work by circumventing

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,8 @@ variables:
   PIPENV_HIDE_EMOJIS: 1
   PIPENV_IGNORE_VIRTUALENVS: 1
   PIPENV_NOSPIN: 1
+  PRE_COMMIT_HOME: $(Pipeline.Workspace)/pre-commit-cache
+  PYTHONUSERBASE: $(Pipeline.Workspace)/py-user-base
 
 jobs:
   - job: test
@@ -13,7 +15,6 @@ jobs:
       vmImage: ubuntu-18.04
 
     variables:
-      PRE_COMMIT_HOME: $(Pipeline.Workspace)/pre-commit-cache
       BOT_API_KEY: foo
       BOT_SENTRY_DSN: blah
       BOT_TOKEN: bar
@@ -38,13 +39,14 @@ jobs:
             python | "$(PythonVersion.pythonLocation)" | ./Pipfile
             python | "$(PythonVersion.pythonLocation)"
           cacheHitVar: PY_ENV_RESTORED
-          path: $(PythonVersion.pythonLocation)
+          path: $(PYTHONUSERBASE)
 
       - script: pip install pipenv
         displayName: 'Install pipenv'
         condition: and(succeeded(), ne(variables.PY_ENV_RESTORED, 'true'))
 
-      - script: pipenv install --dev --deploy --system
+      # PIP_USER=1 will install packages to the user site.
+      - script: export PIP_USER=1; pipenv install --dev --deploy --system
         displayName: 'Install project using pipenv'
         condition: and(succeeded(), ne(variables.PY_ENV_RESTORED, 'true'))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,12 @@ jobs:
     variables:
       PIP_CACHE_DIR: ".cache/pip"
       PRE_COMMIT_HOME: $(Pipeline.Workspace)/pre-commit-cache
+      BOT_API_KEY: foo
+      BOT_SENTRY_DSN: blah
+      BOT_TOKEN: bar
+      REDDIT_CLIENT_ID: spam
+      REDDIT_SECRET: ham
+      WOLFRAM_API_KEY: baz
 
     steps:
       - task: UsePythonVersion@0
@@ -50,7 +56,7 @@ jobs:
       - script: pre-commit run --all-files
         displayName: 'Run pre-commit hooks'
 
-      - script: BOT_API_KEY=foo BOT_SENTRY_DSN=blah BOT_TOKEN=bar WOLFRAM_API_KEY=baz REDDIT_CLIENT_ID=spam REDDIT_SECRET=ham coverage run -m xmlrunner
+      - script: coverage run -m xmlrunner
         displayName: Run tests
 
       - script: coverage report -m && coverage xml -o coverage.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,10 +35,6 @@ jobs:
         displayName: 'Restore Python environment'
         inputs:
           key: python | $(Agent.OS) | "$(python.pythonLocation)" | 0 | ./Pipfile | ./Pipfile.lock
-          restoreKeys: |
-            python | "$(python.pythonLocation)" | 0 | ./Pipfile.lock
-            python | "$(python.pythonLocation)" | 0 | ./Pipfile
-            python | "$(python.pythonLocation)" | 0
           cacheHitVar: PY_ENV_RESTORED
           path: $(PYTHONUSERBASE)
 
@@ -67,8 +63,6 @@ jobs:
         displayName: 'Restore pre-commit environment'
         inputs:
           key: pre-commit | "$(python.pythonLocation)" | 0 | .pre-commit-config.yaml
-          restoreKeys: |
-            pre-commit | "$(python.pythonLocation)" | 0
           path: $(PRE_COMMIT_HOME)
 
       # pre-commit's venv doesn't allow user installs - not that they're really needed anyway.


### PR DESCRIPTION
[Caching](https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops) of Python dependencies to reduce frequency of using pipenv to install dependencies in CI.

## What is a cache?

A cache saves a directory for re-use in a later build. In summary, the cache works by using a key to determine if there is a cache hit or miss. The key can comprise of strings and file hashes. When there's a cache hit, the cached directory is restored. When there's a miss, there will be a job that runs at the end to upload the directory to the cache (i.e. creating a new cache). 

There are also partial cache hits which perform both a restore and an upload. Partial restores can be useful if only one dependency changed and the rest can still be re-used. As a result, **a potential issue is that removed packages may linger in the cache.** Support for partial restores may need to be removed. Please comment if you have any suggestions on this.

## How its used

Dependencies are redirected to be installed to the [user base](https://docs.python.org/3/library/site.html?highlight=site#site.USER_BASE) directory, which gets cached. Because nothing else uses the user site, it is useful for caching _only_ our dependencies, which keeps the cache slim and the operations quick.

## Benchmarks

Only the affected build steps were benchmarked.

### Old times

* Installing pipenv: 5-10s
* Installing dependencies: 34s

Total: 39s

### New times

**Cache Miss**:

Example build [here](https://dev.azure.com/python-discord/Python%20Discord/_build/results?buildId=6405&view=logs&j=5264e576-3c6f-51f6-f055-fab409685f20&t=74cc461b-e097-4214-b1b6-8481db81983d) (note that pre-commit also has a cache miss).

* Restoring cache: 3s (realises there's a miss so it does nothing)
* Installing pipenv: 5-10s
* Installing dependencies: 33s
* Saving cache: 13-16s

Total: 55s (16s slower)

**Cache Hit**:

Example build [here](https://dev.azure.com/python-discord/Python%20Discord/_build/results?buildId=6415&view=logs&j=5264e576-3c6f-51f6-f055-fab409685f20&t=ba73fe70-97c4-5e2d-5cc4-47c0f87130c8).

* Restoring from cache: 10s
    * Inconsistent. One time it took 10s, the next time 18s.

Total: 10s (29s faster)

## Cache speed inconsistency

The speed of restoring or creating a cache varies a bit. This just seems to be an issue with Azure Pipelines. For example, [here](https://dev.azure.com/python-discord/Python%20Discord/_build/results?buildId=6396&view=logs&j=5264e576-3c6f-51f6-f055-fab409685f20&t=419a0abe-6ae2-5290-e72a-c67ad02dc29f) it took 24s and [here](https://dev.azure.com/python-discord/Python%20Discord/_build/results?buildId=6397&view=logs&j=5264e576-3c6f-51f6-f055-fab409685f20&t=419a0abe-6ae2-5290-e72a-c67ad02dc29f) 27s to realise there's a cache miss when it normally takes 3-5s. [Here](https://dev.azure.com/python-discord/Python%20Discord/_build/results?buildId=6402&view=logs&j=5264e576-3c6f-51f6-f055-fab409685f20&t=419a0abe-6ae2-5290-e72a-c67ad02dc29f) it took 21s to upload the cache when it normally takes 13-15s. These slowdowns happen more often than I'd like, but I believe the changes are still going to result in a net positive for time.