### PR TITLE
Add one second padding to format_infraction_with_duration

### DIFF
--- a/bot/utils/time.py
+++ b/bot/utils/time.py
@@ -144,7 +144,7 @@ def format_infraction_with_duration(
     if absolute:
         delta = abs(delta)
 
-    duration = humanize_delta(delta, max_units=max_units) + datetime.timedelta(seconds=1)
+    duration = humanize_delta(delta + datetime.timedelta(seconds=1), max_units=max_units)
     duration_formatted = f" ({duration})" if duration else ""
 
     return f"{date_to_formatted}{duration_formatted}"

--- a/bot/utils/time.py
+++ b/bot/utils/time.py
@@ -144,7 +144,7 @@ def format_infraction_with_duration(
     if absolute:
         delta = abs(delta)
 
-    duration = humanize_delta(delta, max_units=max_units)
+    duration = humanize_delta(delta, max_units=max_units) + datetime.timedelta(seconds=1)
     duration_formatted = f" ({duration})" if duration else ""
 
     return f"{date_to_formatted}{duration_formatted}"


### PR DESCRIPTION
It caused the message to be rounded one second down, for example `59 minutes and 59 seconds` instead of `1 hour`, because of the way `humanize_delta` works. This PR simply add a one second padding in order to make the infraction message proper. 