### PR TITLE
ModLog: fix posting null attachments for deleted message logs

### DIFF
--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -67,7 +67,7 @@ class ModLog(Cog, name="ModLog"):
                         'embeds': [embed.to_dict() for embed in message.embeds],
                         'attachments': attachment,
                     }
-                    for message, attachment in zip_longest(messages, attachments)
+                    for message, attachment in zip_longest(messages, attachments, fillvalue=[])
                 ]
             }
         )


### PR DESCRIPTION
If attachments are not given to `upload_log`, an empty list is used. By default, `zip_longest` uses `None` as the fill value, so each message was getting paired with a `None` (AKA null) attachment. The filed in the DB is non-nullable so an empty list must be used instead.

Fixes #792

Note that the clean command still won't send attachments. This PR just fixes the error so at least the clean command can post messages to the API.