### PR TITLE
Subcommand `search` and `search any` to search inside tags' contents and not names.

### DIFF
--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 from discord import Colour, Embed
 from discord.ext.commands import Cog, Context, group
@@ -86,7 +86,7 @@ class Tags(Cog):
             return self._get_suggestions(tag_name)
         return found
 
-    async def _get_tags_via_content(self, check: callable, keywords: str) -> Optional[Embed]:
+    async def _get_tags_via_content(self, check: Callable[[Iterable], bool], keywords: str) -> Optional[Embed]:
         """
         Search for tags via contents.
 
@@ -124,9 +124,8 @@ class Tags(Cog):
         Only search for tags that has ALL the keywords.
         """
         result = await self._get_tags_via_content(all, keywords)
-        if not result:
-            return
-        await ctx.send(embed=result)
+        if result:
+            await ctx.send(embed=result)
 
     @search_tag_content.command(name='any')
     async def search_tag_content_any_keyword(self, ctx: Context, *, keywords: Optional[str] = None) -> None:
@@ -136,9 +135,8 @@ class Tags(Cog):
         Search for tags that has ANY of the keywords.
         """
         result = await self._get_tags_via_content(any, keywords or 'any')
-        if not result:
-            return
-        await ctx.send(embed=result)
+        if result:
+            await ctx.send(embed=result)
 
     @tags_group.command(name='get', aliases=('show', 'g'))
     async def get_command(self, ctx: Context, *, tag_name: TagNameConverter = None) -> None:

--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -94,7 +94,8 @@ class Tags(Cog):
         """
         await self._get_tags()
 
-        keywords_processed: Tuple[str] = tuple(query.strip().casefold() for query in keywords.split(','))
+        keywords_processed: Tuple[str] = tuple(query.strip().casefold() for query in keywords.split(',') if query)
+        keywords_processed = keywords_processed or (keywords,)
         founds: list = [
             tag
             for tag in self._cache.values()
@@ -106,10 +107,13 @@ class Tags(Cog):
         elif len(founds) == 1:
             return Embed().from_dict(founds[0]['embed'])
         else:
-            return Embed(
-                title='Did you mean ...',
+            is_plural: bool = len(keywords_processed) > 1 or any(kw.count(' ') for kw in keywords_processed)
+            embed = Embed(
+                title=f"Here are the tags containing the given keyword{'s' * is_plural}:",
                 description='\n'.join(tag['title'] for tag in founds[:10])
             )
+            embed.set_footer(text=f"Keyword{'s' * is_plural} used: {keywords}"[:1024])
+            return embed
 
     @group(name='tags', aliases=('tag', 't'), invoke_without_command=True)
     async def tags_group(self, ctx: Context, *, tag_name: TagNameConverter = None) -> None:

--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import time
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from discord import Colour, Embed
 from discord.ext.commands import Cog, Context, group
@@ -86,10 +86,59 @@ class Tags(Cog):
             return self._get_suggestions(tag_name)
         return found
 
+    async def _get_tags_via_content(self, check: callable, keywords: str) -> Optional[Embed]:
+        """
+        Search for tags via contents.
+
+        `predicate` will be either any or all, or a custom callable to search. Must return a bool.
+        """
+        await self._get_tags()
+
+        keywords_processed: Tuple[str] = tuple(query.strip().casefold() for query in keywords.split(','))
+        founds: list = [
+            tag
+            for tag in self._cache.values()
+            if check(query in tag['embed']['description'] for query in keywords_processed)
+        ]
+
+        if not founds:
+            return None
+        elif len(founds) == 1:
+            return Embed().from_dict(founds[0]['embed'])
+        else:
+            return Embed(
+                title='Did you mean ...',
+                description='\n'.join(tag['title'] for tag in founds[:10])
+            )
+
     @group(name='tags', aliases=('tag', 't'), invoke_without_command=True)
     async def tags_group(self, ctx: Context, *, tag_name: TagNameConverter = None) -> None:
         """Show all known tags, a single tag, or run a subcommand."""
         await ctx.invoke(self.get_command, tag_name=tag_name)
+
+    @tags_group.group(name='search', invoke_without_command=True)
+    async def search_tag_content(self, ctx: Context, *, keywords: str) -> None:
+        """
+        Search inside tags' contents for tags. Allow searching for multiple keywords separated by comma.
+
+        Only search for tags that has ALL the keywords.
+        """
+        result = await self._get_tags_via_content(all, keywords)
+        if not result:
+            return
+        await ctx.send(embed=result)
+
+    @search_tag_content.command(name='any')
+    async def search_tag_content_any_keyword(self, ctx: Context, *, keywords: Optional[str] = None) -> None:
+        """
+        Search inside tags' contents for tags. Allow searching for multiple keywords separated by comma.
+
+        Search for tags that has ANY of the keywords.
+        """
+        result = await self._get_tags_via_content(any, keywords or 'any')
+        if not result:
+            return
+        await ctx.send(embed=result)
 
     @tags_group.command(name='get', aliases=('show', 'g'))
     async def get_command(self, ctx: Context, *, tag_name: TagNameConverter = None) -> None:

--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -117,7 +117,7 @@ class Tags(Cog):
         elif len(matching_tags) == 1:
             return Embed().from_dict(matching_tags[0]['embed'])
         else:
-            is_plural = len(keywords_processed) > 1 or keywords.strip().count(' ') > 1
+            is_plural = len(keywords_processed) > 1 or keywords.strip().count(' ') > 0
             embed = Embed(
                 title=f"Here are the tags containing the given keyword{'s' * is_plural}:",
                 description='\n'.join(tag['title'] for tag in matching_tags[:10])


### PR DESCRIPTION
#### Closes #804 

This PR introduces two new subcommands to `!tag` that will allow searching for tags via contents instead of names:

- `!tag search` will search for multiple keywords, separated by comma, and return tags that has ALL of these keywords.
- `!tag search any` is the same as `!tag search` but it return tags that has ANY of the keyword instead.

### Examples:
![image](https://user-images.githubusercontent.com/19921765/76156798-1661f900-6132-11ea-948d-24b3be683a79.png)
