### PR TITLE
Fix filtered extension string out of scope for antismalware log message

### DIFF
--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -29,8 +29,9 @@ class AntiMalware(Cog):
             return
 
         embed = Embed()
-        file_extensions = {splitext(message.filename.lower())[1] for message in message.attachments}
+        file_extensions = {splitext(attachment.filename.lower())[1] for attachment in message.attachments}
         extensions_blocked = file_extensions - set(AntiMalwareConfig.whitelist)
+        blocked_extensions_str = ', '.join(extensions_blocked)
         if ".py" in extensions_blocked:
             # Short-circuit on *.py files to provide a pastebin link
             embed.description = (
@@ -38,7 +39,6 @@ class AntiMalware(Cog):
                 f"please use a code-pasting service such as {URLs.site_schema}{URLs.site_paste}"
             )
         elif extensions_blocked:
-            blocked_extensions_str = ', '.join(extensions_blocked)
             whitelisted_types = ', '.join(AntiMalwareConfig.whitelist)
             meta_channel = self.bot.get_channel(Channels.meta)
             embed.description = (


### PR DESCRIPTION
A bug was introduced by #814 where the event listener for the antimalware cog would raise an exception for `*.py` files because the log message attempts to call the string representation of the blocked extensions, which is only in scope if something other than a `*.py` file is found. This fixes that.