### PR TITLE
Implement vote command.

### DIFF
--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -266,6 +266,8 @@ class Utils(Cog):
         A maximum of 20 options can be provided, as Discord supports a max of 20
         reactions on a single message.
         """
+        if len(options) < 2:
+            raise BadArgument("Please provide at least 2 options.")
         if len(options) > 20:
             raise BadArgument("I can only handle 20 options!")
 

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -257,6 +257,24 @@ class Utils(Cog):
         embed.description = best_match
         await ctx.send(embed=embed)
 
+    @command(aliases=("poll",))
+    @with_role(*MODERATION_ROLES)
+    async def vote(self, ctx: Context, title: str, *options: str) -> None:
+        """
+        Build a quick voting poll with matching reactions with the provided options.
+
+        A maximum of 20 options can be provided, as Discord supports a max of 20
+        reactions on a single message.
+        """
+        if len(options) > 20:
+            raise BadArgument("I can only handle 20 options!")
+
+        options = {chr(i): f"{chr(i)} - {v}" for i, v in enumerate(options, start=127462)}
+        embed = Embed(title=title, description="\n".join(options.values()))
+        message = await ctx.send(embed=embed)
+        for reaction in options:
+            await message.add_reaction(reaction)
+
 
 def setup(bot: Bot) -> None:
     """Load the Utils cog."""

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -271,7 +271,8 @@ class Utils(Cog):
         if len(options) > 20:
             raise BadArgument("I can only handle 20 options!")
 
-        options = {chr(i): f"{chr(i)} - {v}" for i, v in enumerate(options, start=127462)}
+        codepoint_start = 127462  # represents "regional_indicator_a" unicode value
+        options = {chr(i): f"{chr(i)} - {v}" for i, v in enumerate(options, start=codepoint_start)}
         embed = Embed(title=title, description="\n".join(options.values()))
         message = await ctx.send(embed=embed)
         for reaction in options:


### PR DESCRIPTION
## Description

The vote command takes a given list of options and generates a simple message and corresponding reactions for each so members can quickly take a vote on a subject during in-server discussions and meetings.

The title and options require double quotes to be used for multiple-word entries. It would be impossible to distinguish where titles and options start and stop otherwise without adding some custom separator and parsing, which is just unnecessary for such a simple command and when it works fine with quotes.

## Usage
![image](https://user-images.githubusercontent.com/29337040/76189187-cbc1a900-6225-11ea-9f29-e2908c2b9270.png)

## Limitations
Messages can only accept 20 individual reactions, so this has been hard limited to a max of 20 options and will return an error if more is given.
![image](https://user-images.githubusercontent.com/29337040/76188780-bac46800-6224-11ea-8cb8-ed73d7c41883.png)

Large numbers of reactions may cause an internal rate limit bucket to be invoked despite the lib meant to have been preventing this from happening. This usually happens if more than 15 reactions are provided, and typically only shows up once. This may potentially raise a warning in sentry, but it's best to see if it occurs in production. There's little to nothing we can do about this though aside from ignore it, as it's being handled in the discord.py library internals.

Due to the easy method of being able to get the bot to spam emojis all at once and possibly may cause the above warning mentioned, I've limited the command to mods+ for now.