### PR TITLE
Test for command name and alias shadowing

### DIFF
--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -46,7 +46,7 @@ class CommandNameTests(unittest.TestCase):
     @staticmethod
     def get_qualified_names(command: commands.Command) -> t.List[str]:
         """Return a list of all qualified names, including aliases, for the `command`."""
-        names = [f"{command.full_parent_name} {alias}" for alias in command.aliases]
+        names = [f"{command.full_parent_name} {alias}".strip() for alias in command.aliases]
         names.append(command.qualified_name)
 
         return names

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -1,9 +1,14 @@
 """Test suite for general tests which apply to all cogs."""
 
+import importlib
+import pkgutil
 import typing as t
 import unittest
+from types import ModuleType
 
 from discord.ext import commands
+
+from bot import cogs
 
 
 class CommandNameTests(unittest.TestCase):
@@ -17,3 +22,9 @@ class CommandNameTests(unittest.TestCase):
                 yield command
                 if isinstance(command, commands.GroupMixin):
                     yield from command.walk_commands()
+
+    @staticmethod
+    def walk_extensions() -> t.Iterator[ModuleType]:
+        """Yield imported extensions (modules) from the bot.cogs subpackage."""
+        for module in pkgutil.iter_modules(cogs.__path__, "bot.cogs."):
+            yield importlib.import_module(module.name)

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -6,6 +6,7 @@ import typing as t
 import unittest
 from collections import defaultdict
 from types import ModuleType
+from unittest import mock
 
 from discord.ext import commands
 
@@ -31,9 +32,10 @@ class CommandNameTests(unittest.TestCase):
         def on_error(name: str) -> t.NoReturn:
             raise ImportError(name=name)
 
-        for module in pkgutil.walk_packages(cogs.__path__, "bot.cogs.", onerror=on_error):
-            if not module.ispkg:
-                yield importlib.import_module(module.name)
+        with mock.patch("discord.ext.tasks.loop"):
+            for module in pkgutil.walk_packages(cogs.__path__, "bot.cogs.", onerror=on_error):
+                if not module.ispkg:
+                    yield importlib.import_module(module.name)
 
     @staticmethod
     def walk_cogs(module: ModuleType) -> t.Iterator[commands.Cog]:

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -21,7 +21,8 @@ class CommandNameTests(unittest.TestCase):
             if command.parent is None:
                 yield command
                 if isinstance(command, commands.GroupMixin):
-                    yield from command.walk_commands()
+                    # Annoyingly it returns duplicates for each alias so use a set to fix that
+                    yield from set(command.walk_commands())
 
     @staticmethod
     def walk_modules() -> t.Iterator[ModuleType]:

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -33,7 +33,8 @@ class CommandNameTests(unittest.TestCase):
     def walk_cogs(extension: ModuleType) -> t.Iterator[commands.Cog]:
         """Yield all cogs defined in an extension."""
         for obj in extension.__dict__.values():
-            if isinstance(obj, type) and issubclass(obj, commands.Cog):
+            is_cog = isinstance(obj, type) and issubclass(obj, commands.Cog)
+            if is_cog and obj.__module__ == extension.__name__:
                 yield obj
 
     @staticmethod

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -32,9 +32,9 @@ class CommandNameTests(unittest.TestCase):
     @staticmethod
     def walk_cogs(extension: ModuleType) -> t.Iterator[commands.Cog]:
         """Yield all cogs defined in an extension."""
-        for name, cls in extension.__dict__.items():
-            if isinstance(cls, commands.Cog):
-                yield getattr(extension, name)
+        for obj in extension.__dict__.values():
+            if isinstance(obj, type) and issubclass(obj, commands.Cog):
+                yield obj
 
     @staticmethod
     def get_qualified_names(command: commands.Command) -> t.List[str]:

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -1,7 +1,19 @@
 """Test suite for general tests which apply to all cogs."""
 
+import typing as t
 import unittest
+
+from discord.ext import commands
 
 
 class CommandNameTests(unittest.TestCase):
     """Tests for shadowing command names and aliases."""
+
+    @staticmethod
+    def walk_commands(cog: commands.Cog) -> t.Iterator[commands.Command]:
+        """An iterator that recursively walks through `cog`'s commands and subcommands."""
+        for command in cog.__cog_commands__:
+            if command.parent is None:
+                yield command
+                if isinstance(command, commands.GroupMixin):
+                    yield from command.walk_commands()

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -1,0 +1,7 @@
+"""Test suite for general tests which apply to all cogs."""
+
+import unittest
+
+
+class CommandNameTests(unittest.TestCase):
+    """Tests for shadowing command names and aliases."""

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -28,3 +28,10 @@ class CommandNameTests(unittest.TestCase):
         """Yield imported extensions (modules) from the bot.cogs subpackage."""
         for module in pkgutil.iter_modules(cogs.__path__, "bot.cogs."):
             yield importlib.import_module(module.name)
+
+    @staticmethod
+    def walk_cogs(extension: ModuleType) -> t.Iterator[commands.Cog]:
+        """Yield all cogs defined in an extension."""
+        for name, cls in extension.__dict__.items():
+            if isinstance(cls, commands.Cog):
+                yield getattr(extension, name)

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -19,6 +19,7 @@ class CommandNameTests(unittest.TestCase):
     @staticmethod
     def walk_commands(cog: commands.Cog) -> t.Iterator[commands.Command]:
         """An iterator that recursively walks through `cog`'s commands and subcommands."""
+        # Can't use Bot.walk_commands() or Cog.get_commands() cause those are instance methods.
         for command in cog.__cog_commands__:
             if command.parent is None:
                 yield command
@@ -32,6 +33,7 @@ class CommandNameTests(unittest.TestCase):
         def on_error(name: str) -> t.NoReturn:
             raise ImportError(name=name)
 
+        # The mock prevents asyncio.get_event_loop() from being called.
         with mock.patch("discord.ext.tasks.loop"):
             for module in pkgutil.walk_packages(cogs.__path__, "bot.cogs.", onerror=on_error):
                 if not module.ispkg:
@@ -41,6 +43,7 @@ class CommandNameTests(unittest.TestCase):
     def walk_cogs(module: ModuleType) -> t.Iterator[commands.Cog]:
         """Yield all cogs defined in an extension."""
         for obj in module.__dict__.values():
+            # Check if it's a class type cause otherwise issubclass() may raise a TypeError.
             is_cog = isinstance(obj, type) and issubclass(obj, commands.Cog)
             if is_cog and obj.__module__ == module.__name__:
                 yield obj

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -43,3 +43,10 @@ class CommandNameTests(unittest.TestCase):
         names.append(command.qualified_name)
 
         return names
+
+    def get_all_commands(self) -> t.Iterator[commands.Command]:
+        """Yield all commands for all cogs in all extensions."""
+        for extension in self.walk_extensions():
+            for cog in self.walk_cogs(extension):
+                for cmd in self.walk_commands(cog):
+                    yield cmd

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -35,3 +35,11 @@ class CommandNameTests(unittest.TestCase):
         for name, cls in extension.__dict__.items():
             if isinstance(cls, commands.Cog):
                 yield getattr(extension, name)
+
+    @staticmethod
+    def get_qualified_names(command: commands.Command) -> t.List[str]:
+        """Return a list of all qualified names, including aliases, for the `command`."""
+        names = [f"{command.full_parent_name} {alias}" for alias in command.aliases]
+        names.append(command.qualified_name)
+
+        return names


### PR DESCRIPTION
Resolves #765 

Adds a test to ensure command and alias names are unique. This allows for any names or aliases which shadow other commands to be caught in CI when tests run. The test will report all conflicts. It will _not_ stop at the first conflict encountered. For conflicts, the test will provide the following in the error message:

1. The command's fully qualified name or alias
2. The command's function's name qualified by its module's name
3. The qualified (similar to № 2) command function names of all commands with which the name or alias conflicts

The test only looks for commands which are defined a cog that is within the `bot.cogs` subpackage. Commands added dynamically via `add_command` will likely not be detected. Basically, this is only intended for commands defined with the `@commands.command()` decorator or group equivalent.