### PR TITLE
ModLog Channel Update formatting fix.

### DIFF
--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -215,7 +215,7 @@ class ModLog(Cog, name="ModLog"):
                 new = value["new_value"]
                 old = value["old_value"]
 
-                changes.append(f"**{key.title()}:** `{old}` **→** `{new}`")
+                changes.append(f"**{key.title()}:** `{old or 'None'}` **→** `{new or 'None'}`")
 
             done.append(key)
 

--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -215,6 +215,8 @@ class ModLog(Cog, name="ModLog"):
                 new = value["new_value"]
                 old = value["old_value"]
 
+                # `or` is required here on `old` and `new` due otherwise, when one of them is empty,
+                # formatting in Discord will break.
                 changes.append(f"**{key.title()}:** `{old or 'None'}` **→** `{new or 'None'}`")
 
             done.append(key)

--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -215,8 +215,9 @@ class ModLog(Cog, name="ModLog"):
                 new = value["new_value"]
                 old = value["old_value"]
 
-                # `or` is required here on `old` and `new` due otherwise, when one of them is empty,
-                # formatting in Discord will break.
+                # Discord does not treat consecutive backticks ("``") as an empty inline code block, so the markdown
+                # formatting is broken when `new` and/or `old` are empty values. "None" is used for these cases so
+                # formatting is preserved.
                 changes.append(f"**{key.title()}:** `{old or 'None'}` **→** `{new or 'None'}`")
 
             done.append(key)


### PR DESCRIPTION
I added `None` string possibility to modlog channel update event to avoid bad MD formatting when one of values is empty. Closes #793 