### PR TITLE
Fix snekbox's message parsing to extract code for re-evaluation

### DIFF
--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -232,7 +232,7 @@ class Snekbox(Cog):
                     timeout=10
                 )
 
-                code = new_message.content.split(' ', maxsplit=1)[1]
+                code = await self.get_code(new_message)
                 await ctx.message.clear_reactions()
                 with contextlib.suppress(HTTPException):
                     await response.delete()
@@ -242,6 +242,26 @@ class Snekbox(Cog):
                 return None
 
             return code
+
+    async def get_code(self, message: Message) -> Optional[str]:
+        """
+        Return the code from `message` to be evaluated.
+
+        If the message is an invocation of the eval command, return the first argument or None if it
+        doesn't exist. Otherwise, return the full content of the message.
+        """
+        log.trace(f"Getting context for message {message.id}.")
+        new_ctx = await self.bot.get_context(message)
+
+        if new_ctx.command is self.eval_command:
+            log.trace(f"Message {message.id} invokes eval command.")
+            split = message.content.split(maxsplit=1)
+            code = split[1] if len(split) > 1 else None
+        else:
+            log.trace(f"Message {message.id} does not invoke eval command.")
+            code = message.content
+
+        return code
 
     @command(name="eval", aliases=("e",))
     @guild_only()


### PR DESCRIPTION
Fixes #831.

If the edited message is still a valid eval invocation, it will split by space to get the first arg (will be `None` if the arg doesn't exist). Otherwise (yes, even if it's a different valid command), it will consider the entire content of the message to be the code.