### PR TITLE
Implement help system feedback.

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -33,7 +33,7 @@ log_format = logging.Formatter(format_string)
 
 log_file = Path("logs", "bot.log")
 log_file.parent.mkdir(exist_ok=True)
-file_handler = handlers.RotatingFileHandler(log_file, maxBytes=5242880, backupCount=7)
+file_handler = handlers.RotatingFileHandler(log_file, maxBytes=5242880, backupCount=7, encoding="utf8")
 file_handler.setFormatter(log_format)
 
 root_log = logging.getLogger()

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -210,6 +210,9 @@ class HelpChannels(Scheduler, commands.Cog):
         log.trace("dormant command invoked; checking if the channel is in-use.")
         if ctx.channel.category == self.in_use_category:
             if await self.dormant_check(ctx):
+                with suppress(KeyError):
+                    del self.help_channel_claimants[ctx.channel]
+
                 with suppress(discord.errors.NotFound):
                     log.trace("Deleting dormant invokation message.")
                     await ctx.message.delete()

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -196,6 +196,7 @@ class HelpChannels(Scheduler, commands.Cog):
         if ctx.channel.category == self.in_use_category:
             self.cancel_task(ctx.channel.id)
             await self.move_to_dormant(ctx.channel)
+            await ctx.message.delete()
         else:
             log.debug(f"{ctx.author} invoked command 'dormant' outside an in-use help channel")
 

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -199,7 +199,13 @@ class HelpChannels(Scheduler, commands.Cog):
 
     @commands.command(name="dormant", aliases=["close"], enabled=False)
     async def dormant_command(self, ctx: commands.Context) -> None:
-        """Make the current in-use help channel dormant."""
+        """
+        Make the current in-use help channel dormant.
+
+        Make the channel dormant if the user passes the `dormant_check`,
+        delete the message that invoked this,
+        and reset the send permissions cooldown for the user who started the session.
+        """
         log.trace("dormant command invoked; checking if the channel is in-use.")
         if ctx.channel.category == self.in_use_category:
             if await self.dormant_check(ctx):

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -5,6 +5,7 @@ import logging
 import random
 import typing as t
 from collections import deque
+from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 
@@ -211,7 +212,9 @@ class HelpChannels(Scheduler, commands.Cog):
             if await self.dormant_check(ctx):
                 self.cancel_task(ctx.channel.id)
                 await self.move_to_dormant(ctx.channel)
-                await ctx.message.delete()
+                with suppress(discord.errors.NotFound):
+                    await ctx.message.delete()
+                    log.trace("Deleting dormant invokation message.")
                 await self.reset_send_permissions_for_help_user(ctx.channel)
         else:
             log.debug(f"{ctx.author} invoked command 'dormant' outside an in-use help channel")

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -190,12 +190,12 @@ class HelpChannels(Scheduler, commands.Cog):
         return deque(available_names)
 
     async def dormant_check(self, ctx: commands.Context) -> bool:
-        """Return True if the user started the help channel session or passes the role check."""
+        """Return True if the user is the help channel claimant or passes the role check."""
         if self.help_channel_claimants.get(ctx.channel) == ctx.author:
-            log.trace(f"{ctx.author} started the help session, passing the check for dormant.")
+            log.trace(f"{ctx.author} is the help channel claimant, passing the check for dormant.")
             return True
 
-        log.trace(f"{ctx.author} did not start the help session, checking roles.")
+        log.trace(f"{ctx.author} is not the help channel claimant, checking roles.")
         return with_role_check(ctx, *constants.HelpChannels.cmd_whitelist)
 
     @commands.command(name="dormant", aliases=["close"], enabled=False)
@@ -621,12 +621,12 @@ class HelpChannels(Scheduler, commands.Cog):
         await self.ensure_permissions_synchronization(self.available_category)
 
     async def reset_claimant_send_permission(self, channel: discord.TextChannel) -> None:
-        """Reset send permissions in the Available category for member that started the help session in `channel`."""
-        log.trace(f"Attempting to find user for help session in #{channel.name} ({channel.id}).")
+        """Reset send permissions in the Available category for the help `channel` claimant."""
+        log.trace(f"Attempting to find claimant for #{channel.name} ({channel.id}).")
         try:
             member = self.help_channel_claimants[channel]
         except KeyError:
-            log.trace(f"Channel #{channel.name} ({channel.id}) not in help session cache, permissions unchanged.")
+            log.trace(f"Channel #{channel.name} ({channel.id}) not in claimant cache, permissions unchanged.")
             return
         log.trace(f"Resetting send permissions for {member} ({member.id}).")
         await self.available_category.set_permissions(member, overwrite=None)

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -217,8 +217,8 @@ class HelpChannels(Scheduler, commands.Cog):
                 with suppress(discord.errors.HTTPException, discord.errors.NotFound):
                     await self.reset_claimant_send_permission(ctx.channel)
 
-                self.cancel_task(ctx.channel.id)
                 await self.move_to_dormant(ctx.channel)
+                self.cancel_task(ctx.channel.id)
         else:
             log.debug(f"{ctx.author} invoked command 'dormant' outside an in-use help channel")
 

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -214,7 +214,8 @@ class HelpChannels(Scheduler, commands.Cog):
                     log.trace("Deleting dormant invokation message.")
                     await ctx.message.delete()
 
-                await self.reset_claimant_send_permission(ctx.channel)
+                with suppress(discord.errors.HTTPException, discord.errors.NotFound):
+                    await self.reset_claimant_send_permission(ctx.channel)
 
                 self.cancel_task(ctx.channel.id)
                 await self.move_to_dormant(ctx.channel)

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -628,6 +628,7 @@ class HelpChannels(Scheduler, commands.Cog):
         except KeyError:
             log.trace(f"Channel #{channel.name} ({channel.id}) not in claimant cache, permissions unchanged.")
             return
+
         log.trace(f"Resetting send permissions for {member} ({member.id}).")
         await self.available_category.set_permissions(member, overwrite=None)
         # Cancel task, ignore no task existing when the claim time passed but idle time has not.

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -629,7 +629,7 @@ class HelpChannels(Scheduler, commands.Cog):
             log.trace(f"Channel #{channel.name} ({channel.id}) not in help session cache, permissions unchanged.")
             return
         log.trace(f"Resetting send permissions for {member} ({member.id}).")
-        await self.available_category.set_permissions(member, send_messages=None)
+        await self.available_category.set_permissions(member, overwrite=None)
         # Cancel task, ignore no task existing when the claim time passed but idle time has not.
         self.cancel_task(member.id, ignore_missing=True)
 

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -631,7 +631,7 @@ class HelpChannels(Scheduler, commands.Cog):
 
         log.trace(f"Resetting send permissions for {member} ({member.id}).")
         await self.available_category.set_permissions(member, overwrite=None)
-        # Cancel task, ignore no task existing when the claim time passed but idle time has not.
+        # Ignore missing task when claim cooldown has passed but the channel still isn't dormant.
         self.cancel_task(member.id, ignore_missing=True)
 
     async def revoke_send_permissions(self, member: discord.Member) -> None:

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -214,9 +214,10 @@ class HelpChannels(Scheduler, commands.Cog):
                     log.trace("Deleting dormant invokation message.")
                     await ctx.message.delete()
 
+                await self.reset_claimant_send_permission(ctx.channel)
+
                 self.cancel_task(ctx.channel.id)
                 await self.move_to_dormant(ctx.channel)
-                await self.reset_claimant_send_permission(ctx.channel)
         else:
             log.debug(f"{ctx.author} invoked command 'dormant' outside an in-use help channel")
 

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -635,7 +635,7 @@ class HelpChannels(Scheduler, commands.Cog):
             return
 
         log.trace(f"Resetting send permissions for {member} ({member.id}).")
-        await self.available_category.set_permissions(member, overwrite=None)
+        await self.update_category_permissions(self.available_category, member, overwrite=None)
         # Ignore missing task when claim cooldown has passed but the channel still isn't dormant.
         self.cancel_task(member.id, ignore_missing=True)
 

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -210,11 +210,12 @@ class HelpChannels(Scheduler, commands.Cog):
         log.trace("dormant command invoked; checking if the channel is in-use.")
         if ctx.channel.category == self.in_use_category:
             if await self.dormant_check(ctx):
+                with suppress(discord.errors.NotFound):
+                    log.trace("Deleting dormant invokation message.")
+                    await ctx.message.delete()
+
                 self.cancel_task(ctx.channel.id)
                 await self.move_to_dormant(ctx.channel)
-                with suppress(discord.errors.NotFound):
-                    await ctx.message.delete()
-                    log.trace("Deleting dormant invokation message.")
                 await self.reset_claimant_send_permission(ctx.channel)
         else:
             log.debug(f"{ctx.author} invoked command 'dormant' outside an in-use help channel")

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -632,6 +632,8 @@ class HelpChannels(Scheduler, commands.Cog):
             return
         log.trace(f"Resetting send permissions for {member} ({member.id}).")
         await self.available_category.set_permissions(member, send_messages=None)
+        # Cancel task, ignore no task existing when the claim time passed but idle time has not.
+        self.cancel_task(member.id, ignore_missing=True)
 
     async def revoke_send_permissions(self, member: discord.Member) -> None:
         """

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -109,7 +109,9 @@ class HelpChannels(Scheduler, commands.Cog):
         super().__init__()
 
         self.bot = bot
-        self.help_channel_claimants: t.Dict[discord.TextChannel, discord.User] = {}
+        self.help_channel_claimants: (
+            t.Dict[discord.TextChannel, t.Union[discord.Member, discord.User]]
+        ) = {}
 
         # Categories
         self.available_category: discord.CategoryChannel = None

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -390,14 +390,13 @@ class HelpChannels(Scheduler, commands.Cog):
         log.info("Cog is ready!")
         self.ready.set()
 
-    @staticmethod
-    def is_dormant_message(message: t.Optional[discord.Message]) -> bool:
+    def is_dormant_message(self, message: t.Optional[discord.Message]) -> bool:
         """Return True if the contents of the `message` match `DORMANT_MSG`."""
         if not message or not message.embeds:
             return False
 
         embed = message.embeds[0]
-        return embed.description.strip() == DORMANT_MSG.strip()
+        return message.author == self.bot.user and embed.description.strip() == DORMANT_MSG.strip()
 
     async def move_idle_channel(self, channel: discord.TextChannel, has_task: bool = True) -> None:
         """


### PR DESCRIPTION
closes: #867 

Implements the requested feedback from the linked issue for the dormant command, allowing claimants to close their own channel, restore their send permissions to available channels and delete the invokation message.

I'm not entirely satisfied with the check here but couldn't think of a nice way to make it a decorator, so I'm open to other ideas if there are any.

```python
await self.available_category.set_permissions(member, send_messages=None)
```
Was not sure if the `send_messages` should be reset here or the whole overwrite (and if it matters), but left it at `send_messages`