### PR TITLE
Add status emojis to help channels and improve bottom sorting

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -223,13 +223,14 @@ class HelpChannels(Scheduler, commands.Cog):
     @staticmethod
     def get_clean_channel_name(channel: discord.TextChannel) -> str:
         """Return a clean channel name without status emojis prefix."""
+        prefix = constants.HelpChannels.name_prefix
         try:
-            # Try to remove the status prefix using the index of "help-"
-            name = channel.name[channel.name.index("help-"):]
+            # Try to remove the status prefix using the index of the channel prefix
+            name = channel.name[channel.name.index(prefix):]
             log.trace(f"The clean name for `{channel}` is `{name}`")
         except ValueError:
             # If, for some reason, the channel name does not contain "help-" fall back gracefully
-            log.info(f"Can't get clean name as `{channel}` does not follow the `help-` naming convention.")
+            log.info(f"Can't get clean name as `{channel}` does not follow the `{prefix}` naming convention.")
             name = channel.name
 
         return name

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -273,7 +273,7 @@ class HelpChannels(Scheduler, commands.Cog):
         names = set()
         for cat in (self.available_category, self.in_use_category, self.dormant_category):
             for channel in self.get_category_channels(cat):
-                names.add(channel.name)
+                names.add(self.get_clean_channel_name(channel))
 
         if len(names) > MAX_CHANNELS_PER_CATEGORY:
             log.warning(

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -221,25 +221,6 @@ class HelpChannels(Scheduler, commands.Cog):
         return channel
 
     @staticmethod
-    def get_position(channel: discord.TextChannel, destination: discord.CategoryChannel) -> int:
-        """Return the position to sort the `channel` at the bottom if moved to `destination`."""
-        log.trace(f"Getting bottom position for #{channel} ({channel.id}).")
-
-        if not destination.channels:
-            # If the destination category is empty, use the first position
-            position = 1
-        else:
-            # Else use the maximum position int + 1
-            position = max(c.position for c in destination.channels) + 1
-
-        log.trace(
-            f"Position of #{channel} ({channel.id}) in {destination.name} will be {position} "
-            f"(was {channel.position})."
-        )
-
-        return position
-
-    @staticmethod
     def get_clean_channel_name(channel: discord.TextChannel) -> str:
         """Return a clean channel name without status emojis prefix."""
         try:
@@ -454,7 +435,7 @@ class HelpChannels(Scheduler, commands.Cog):
             category=self.dormant_category,
             sync_permissions=True,
             topic=DORMANT_TOPIC,
-            position=self.get_position(channel, self.dormant_category),
+            position=10000,
         )
 
         log.trace(f"Position of #{channel} ({channel.id}) is actually {channel.position}.")
@@ -475,7 +456,7 @@ class HelpChannels(Scheduler, commands.Cog):
             category=self.in_use_category,
             sync_permissions=True,
             topic=IN_USE_TOPIC,
-            position=self.get_position(channel, self.in_use_category),
+            position=10000,
         )
 
         timeout = constants.HelpChannels.idle_minutes * 60

--- a/config-default.yml
+++ b/config-default.yml
@@ -112,7 +112,7 @@ guild:
 
     categories:
         help_available:                     691405807388196926
-        help_in_use:                        356013061213126657
+        help_in_use:                        696958401460043776
         help_dormant:                       691405908919451718
 
     channels:


### PR DESCRIPTION
This PR aims to make two changes to our help channel system:

**1. Add status emojis to help channel names**

The new help channel system appears to be intuitive to most of our members. One comment that has been made a few times is that it would be clearer if the channel names would indicate the status of the channels as well. It still happens that people don't notice the existence of two different categories and add their question to an already claimed channel.

By adding emojis to the channel name, I hope that it's more apparent to the end-user that there's a difference between channels in the "In Use" and in the "Available" category.

The following design was chosen after a conversation in the feedback channel:
![channel_status_emojis](https://user-images.githubusercontent.com/33516116/78577243-14bd4b00-782e-11ea-8b46-38b75f34f71b.png)

**2. Change the bottom sorting strategy to large ints.**

We currently attempt to position channels at the bottom of their new category ("In Use" and "Dormant" only) when we move them by getting the maximum position in their new category and adding 1 to it. However, this doesn't always seem to work as intended and channels may end up somewhere in the bottom third of the list.

Another strategy, setting a really large position integer, does seem to give more reliable results. Discord will automatically "truncate" the position integers by resizing them to the maximum current position + 1 and positioning seems to be predictable.

I'm not 100% sure it will actually work as expected in production, but it does work reliably in the testing environment. I am fairly confident that it will be no worse than our current strategy, so I think we should just try it.