### PR TITLE
Reverse deletion of `!dormant` invocation messages

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -224,10 +224,6 @@ class HelpChannels(Scheduler, commands.Cog):
                 with suppress(KeyError):
                     del self.help_channel_claimants[ctx.channel]
 
-                with suppress(discord.errors.NotFound):
-                    log.trace("Deleting dormant invokation message.")
-                    await ctx.message.delete()
-
                 with suppress(discord.errors.HTTPException, discord.errors.NotFound):
                     await self.reset_claimant_send_permission(ctx.channel)
 


### PR DESCRIPTION
Pull request #868 introduced the automatic deletion of the message in which the `!dormant` command was issued to close an occupied help channel. While this arguably removes some clutter from the channels, it also hides the reason for why a channel suddenly went dormant; other users have had to been actively watching the channel to have spotted the invocation. As the command can be issued at any time, this could lead to the user experience of thinking that a channel that still had an active, ongoing conversation was suddenly auto-magically made dormant. 

This PR aims to improve that user experience by removing the removal feature.

This PR closes #880 