### PR TITLE
Use a role overwrite to keep track of help channel cooldowns

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -230,7 +230,7 @@ class HelpChannels(Scheduler, commands.Cog):
                     del self.help_channel_claimants[ctx.channel]
 
                 with suppress(discord.errors.HTTPException, discord.errors.NotFound):
-                    await self.reset_claimant_send_permission(ctx.channel)
+                    await self.reset_claimant_send_permission(ctx.author)
 
                 await self.move_to_dormant(ctx.channel, "command")
                 self.cancel_task(ctx.channel.id)
@@ -640,18 +640,8 @@ class HelpChannels(Scheduler, commands.Cog):
                 log.trace(f"Resetting send permissions for {member} ({member.id}).")
                 await member.remove_roles(COOLDOWN_ROLE)
 
-    async def reset_claimant_send_permission(self, channel: discord.TextChannel) -> None:
-        """Reset send permissions in the Available category for the help `channel` claimant."""
-        log.trace(f"Attempting to find claimant for #{channel.name} ({channel.id}).")
-        try:
-            member = self.help_channel_claimants[channel]
-        except KeyError:
-            log.trace(
-                f"Channel #{channel.name} ({channel.id}) not in claimant cache, "
-                f"permissions unchanged."
-            )
-            return
-
+    async def reset_claimant_send_permission(self, member: discord.Member) -> None:
+        """Reset send permissions in the Available category for `member`."""
         log.trace(f"Resetting send permissions for {member} ({member.id}).")
         await member.remove_roles(COOLDOWN_ROLE)
 

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -215,8 +215,8 @@ class HelpChannels(Scheduler, commands.Cog):
 
         return role_check
 
-    @commands.command(name="dormant", aliases=["close"], enabled=False)
-    async def dormant_command(self, ctx: commands.Context) -> None:
+    @commands.command(name="close", aliases=["dormant"], enabled=False)
+    async def close_command(self, ctx: commands.Context) -> None:
         """
         Make the current in-use help channel dormant.
 
@@ -224,7 +224,7 @@ class HelpChannels(Scheduler, commands.Cog):
         delete the message that invoked this,
         and reset the send permissions cooldown for the user who started the session.
         """
-        log.trace("dormant command invoked; checking if the channel is in-use.")
+        log.trace("close command invoked; checking if the channel is in-use.")
         if ctx.channel.category == self.in_use_category:
             if await self.dormant_check(ctx):
                 with suppress(KeyError):
@@ -400,7 +400,7 @@ class HelpChannels(Scheduler, commands.Cog):
         # The ready event wasn't used because channels could change categories between the time
         # the command is invoked and the cog is ready (e.g. if move_idle_channel wasn't called yet).
         # This may confuse users. So would potentially long delays for the cog to become ready.
-        self.dormant_command.enabled = True
+        self.close_command.enabled = True
 
         await self.init_available()
 

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -412,6 +412,11 @@ class HelpChannels(Scheduler, commands.Cog):
         self.bot.stats.gauge("help.total.available", total_available)
         self.bot.stats.gauge("help.total.dormant", total_dormant)
 
+    @staticmethod
+    def is_claimant(member: discord.Member) -> bool:
+        """Return True if `member` has the 'Help Cooldown' role."""
+        return any(constants.Roles.help_cooldown == role.id for role in member.roles)
+
     def is_dormant_message(self, message: t.Optional[discord.Message]) -> bool:
         """Return True if the contents of the `message` match `DORMANT_MSG`."""
         if not message or not message.embeds:

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -632,18 +632,16 @@ class HelpChannels(Scheduler, commands.Cog):
         await category.set_permissions(member, **permissions)
 
     async def reset_send_permissions(self) -> None:
-        """Reset send permissions for members with it set to False in the Available category."""
+        """Reset send permissions in the Available category for claimants."""
         log.trace("Resetting send permissions in the Available category.")
+        guild = self.bot.get_guild(constants.Guild.id)
 
-        for member, overwrite in self.available_category.overwrites.items():
-            if isinstance(member, discord.Member) and overwrite.send_messages is False:
+        # TODO: replace with a persistent cache cause checking every member is quite slow
+        for member in guild.members:
+            if self.is_claimant(member):
                 log.trace(f"Resetting send permissions for {member} ({member.id}).")
-
-                # We don't use the permissions helper function here as we may have to reset multiple overwrites
-                # and we don't want to enforce the permissions synchronization in each iteration.
-                await self.available_category.set_permissions(member, overwrite=None)
-
-        log.trace(f"Ensuring channels in `Help: Available` are synchronized after permissions reset.")
+                role = discord.Object(constants.Roles.help_cooldown)
+                await member.remove_roles(role)
 
     async def reset_claimant_send_permission(self, channel: discord.TextChannel) -> None:
         """Reset send permissions in the Available category for the help `channel` claimant."""

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -67,6 +67,8 @@ AVAILABLE_EMOJI = "✅"
 IN_USE_EMOJI = "⌛"
 NAME_SEPARATOR = "｜"
 
+CoroutineFunc = t.Callable[..., t.Coroutine]
+
 
 class TaskData(t.NamedTuple):
     """Data for a scheduled task."""
@@ -640,23 +642,23 @@ class HelpChannels(Scheduler, commands.Cog):
     async def add_cooldown_role(cls, member: discord.Member) -> None:
         """Add the help cooldown role to `member`."""
         log.trace(f"Adding cooldown role for {member} ({member.id}).")
-        await cls._change_cooldown_role(member, member.add_roles(COOLDOWN_ROLE))
+        await cls._change_cooldown_role(member, member.add_roles)
 
     @classmethod
     async def remove_cooldown_role(cls, member: discord.Member) -> None:
         """Remove the help cooldown role from `member`."""
         log.trace(f"Removing cooldown role for {member} ({member.id}).")
-        await cls._change_cooldown_role(member, member.remove_roles(COOLDOWN_ROLE))
+        await cls._change_cooldown_role(member, member.remove_roles)
 
     @staticmethod
-    async def _change_cooldown_role(member: discord.Member, coro: t.Awaitable) -> None:
+    async def _change_cooldown_role(member: discord.Member, coro_func: CoroutineFunc) -> None:
         """
-        Change `member`'s cooldown role via awaiting `coro` and handle errors.
+        Change `member`'s cooldown role via awaiting `coro_func` and handle errors.
 
-        `coro` is intended to be `discord.Member.add_roles` or `discord.Member.remove_roles`.
+        `coro_func` is intended to be `discord.Member.add_roles` or `discord.Member.remove_roles`.
         """
         try:
-            await coro
+            await coro_func(COOLDOWN_ROLE)
         except discord.NotFound:
             log.debug(f"Failed to change role for {member} ({member.id}): member not found")
         except discord.Forbidden:

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -269,7 +269,7 @@ class HelpChannels(Scheduler, commands.Cog):
             log.trace(f"The clean name for `{channel}` is `{name}`")
         except ValueError:
             # If, for some reason, the channel name does not contain "help-" fall back gracefully
-            log.info(f"Can't get clean name as `{channel}` does not follow the `{prefix}` naming convention.")
+            log.info(f"Can't get clean name because `{channel}` isn't prefixed by `{prefix}`.")
             name = channel.name
 
         return name
@@ -488,10 +488,6 @@ class HelpChannels(Scheduler, commands.Cog):
             topic=AVAILABLE_TOPIC,
         )
 
-        log.trace(
-            f"Ensuring that all channels in `{self.available_category}` have "
-            f"synchronized permissions after moving `{channel}` into it."
-        )
         self.report_stats()
 
     async def move_to_dormant(self, channel: discord.TextChannel, caller: str) -> None:

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -40,8 +40,9 @@ channels in the Help: Available category.
 AVAILABLE_MSG = f"""
 This help channel is now **available**, which means that you can claim it by simply typing your \
 question into it. Once claimed, the channel will move into the **Python Help: Occupied** category, \
-and will be yours until it has been inactive for {constants.HelpChannels.idle_minutes} minutes. When \
-that happens, it will be set to **dormant** and moved into the **Help: Dormant** category.
+and will be yours until it has been inactive for {constants.HelpChannels.idle_minutes} minutes or \
+is closed manually with `!close`. When that happens, it will be set to **dormant** and moved into \
+the **Help: Dormant** category.
 
 You may claim a new channel once every {constants.HelpChannels.claim_minutes} minutes. If you \
 currently cannot send a message in this channel, it means you are on cooldown and need to wait.

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -89,12 +89,15 @@ class HelpChannels(Scheduler, commands.Cog):
         * If there are no more dormant channels, the bot will automatically create a new one
         * If there are no dormant channels to move, helpers will be notified (see `notify()`)
     * When a channel becomes available, the dormant embed will be edited to show `AVAILABLE_MSG`
+    * User can only claim a channel at an interval `constants.HelpChannels.claim_minutes`
+        * To keep track of cooldowns, user which claimed a channel will have a temporary role
 
     In Use Category
 
     * Contains all channels which are occupied by someone needing help
     * Channel moves to dormant category after `constants.HelpChannels.idle_minutes` of being idle
     * Command can prematurely mark a channel as dormant
+        * Channel claimant is allowed to use the command
         * Allowed roles for the command are configurable with `constants.HelpChannels.cmd_whitelist`
     * When a channel becomes dormant, an embed with `DORMANT_MSG` will be sent
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -421,6 +421,7 @@ class Roles(metaclass=YAMLGetter):
     announcements: int
     contributors: int
     core_developers: int
+    help_cooldown: int
     helpers: int
     jammers: int
     moderators: int

--- a/config-default.yml
+++ b/config-default.yml
@@ -201,6 +201,7 @@ guild:
     roles:
         announcements:                          463658397560995840
         contributors:                           295488872404484098
+        help_cooldown:                          699189276025421825
         muted:              &MUTED_ROLE         277914926603829249
         partners:                               323426753857191936
         python_community:   &PY_COMMUNITY_ROLE  458226413825294336


### PR DESCRIPTION
Resolves #839

Using user overwrites on the category turned out to be flawed due to syncing issues. Channels would get out of sync with the category which would lead to users being able to claim multiple channels. Using a role should hopefully avoid sync issues since the bot will no longer be constantly adding/removing channel overwrites. Instead, it will be adding/removing roles from users.

For now, the roles aren't persisted. Once we have some better infrastructure for that (or we decided to stick to pgsql), persistence can be revisited.
