### PR TITLE
Help channels close permission fix

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -221,11 +221,11 @@ class HelpChannels(Scheduler, commands.Cog):
         log.trace("dormant command invoked; checking if the channel is in-use.")
         if ctx.channel.category == self.in_use_category:
             if await self.dormant_check(ctx):
-                with suppress(KeyError):
-                    del self.help_channel_claimants[ctx.channel]
-
                 with suppress(discord.errors.HTTPException, discord.errors.NotFound):
                     await self.reset_claimant_send_permission(ctx.channel)
+
+                with suppress(KeyError):
+                    del self.help_channel_claimants[ctx.channel]
 
                 await self.move_to_dormant(ctx.channel, "command")
                 self.cancel_task(ctx.channel.id)


### PR DESCRIPTION
The dormant command contains an error in the form of clearing the cache before resetting user permission, where the method for resetting the permissions relies on the cache being populated.

This PR fixes that, and adds logging for exceptions around the permissions reset to help differentiate between different errors instead of silencing them.