### PR TITLE
Allowing `!eval` in help channels

### DIFF
--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -9,7 +9,7 @@ from bot.api import ResponseCodeError
 from bot.bot import Bot
 from bot.constants import Channels
 from bot.converters import TagNameConverter
-from bot.decorators import InChannelCheckFailure
+from bot.decorators import InWhitelistedContextCheckFailure
 
 log = logging.getLogger(__name__)
 
@@ -202,7 +202,7 @@ class ErrorHandler(Cog):
         * BotMissingRole
         * BotMissingAnyRole
         * NoPrivateMessage
-        * InChannelCheckFailure
+        * InWhitelistedContextCheckFailure
         """
         bot_missing_errors = (
             errors.BotMissingPermissions,
@@ -215,7 +215,7 @@ class ErrorHandler(Cog):
             await ctx.send(
                 f"Sorry, it looks like I don't have the permissions or roles I need to do that."
             )
-        elif isinstance(e, (InChannelCheckFailure, errors.NoPrivateMessage)):
+        elif isinstance(e, (InWhitelistedContextCheckFailure, errors.NoPrivateMessage)):
             ctx.bot.stats.incr("errors.wrong_channel_or_dm_error")
             await ctx.send(e)
 

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -9,7 +9,7 @@ from bot.api import ResponseCodeError
 from bot.bot import Bot
 from bot.constants import Channels
 from bot.converters import TagNameConverter
-from bot.decorators import InWhitelistedContextCheckFailure
+from bot.decorators import InWhitelistCheckFailure
 
 log = logging.getLogger(__name__)
 
@@ -202,7 +202,7 @@ class ErrorHandler(Cog):
         * BotMissingRole
         * BotMissingAnyRole
         * NoPrivateMessage
-        * InWhitelistedContextCheckFailure
+        * InWhitelistCheckFailure
         """
         bot_missing_errors = (
             errors.BotMissingPermissions,
@@ -215,7 +215,7 @@ class ErrorHandler(Cog):
             await ctx.send(
                 f"Sorry, it looks like I don't have the permissions or roles I need to do that."
             )
-        elif isinstance(e, (InWhitelistedContextCheckFailure, errors.NoPrivateMessage)):
+        elif isinstance(e, (InWhitelistCheckFailure, errors.NoPrivateMessage)):
             ctx.bot.stats.incr("errors.wrong_channel_or_dm_error")
             await ctx.send(e)
 

--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -12,7 +12,7 @@ from discord.utils import escape_markdown
 
 from bot import constants
 from bot.bot import Bot
-from bot.decorators import InChannelCheckFailure, in_channel, with_role
+from bot.decorators import InWhitelistedContextCheckFailure, in_whitelisted_context, with_role
 from bot.pagination import LinePaginator
 from bot.utils.checks import cooldown_with_role_bypass, with_role_check
 from bot.utils.time import time_since
@@ -152,7 +152,7 @@ class Information(Cog):
         # Non-staff may only do this in #bot-commands
         if not with_role_check(ctx, *constants.STAFF_ROLES):
             if not ctx.channel.id == constants.Channels.bot_commands:
-                raise InChannelCheckFailure(constants.Channels.bot_commands)
+                raise InWhitelistedContextCheckFailure(constants.Channels.bot_commands)
 
         embed = await self.create_user_embed(ctx, user)
 
@@ -331,7 +331,11 @@ class Information(Cog):
 
     @cooldown_with_role_bypass(2, 60 * 3, BucketType.member, bypass_roles=constants.STAFF_ROLES)
     @group(invoke_without_command=True)
-    @in_channel(constants.Channels.bot_commands, bypass_roles=constants.STAFF_ROLES)
+    @in_whitelisted_context(
+        whitelisted_channels=(constants.Channels.bot_commands,),
+        whitelisted_roles=constants.STAFF_ROLES,
+        redirect_channel=constants.Channels.bot_commands,
+    )
     async def raw(self, ctx: Context, *, message: Message, json: bool = False) -> None:
         """Shows information about the raw API response."""
         # I *guess* it could be deleted right as the command is invoked but I felt like it wasn't worth handling

--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -12,7 +12,7 @@ from discord.utils import escape_markdown
 
 from bot import constants
 from bot.bot import Bot
-from bot.decorators import InWhitelistedContextCheckFailure, in_whitelisted_context, with_role
+from bot.decorators import InWhitelistCheckFailure, in_whitelist, with_role
 from bot.pagination import LinePaginator
 from bot.utils.checks import cooldown_with_role_bypass, with_role_check
 from bot.utils.time import time_since
@@ -152,7 +152,7 @@ class Information(Cog):
         # Non-staff may only do this in #bot-commands
         if not with_role_check(ctx, *constants.STAFF_ROLES):
             if not ctx.channel.id == constants.Channels.bot_commands:
-                raise InWhitelistedContextCheckFailure(constants.Channels.bot_commands)
+                raise InWhitelistCheckFailure(constants.Channels.bot_commands)
 
         embed = await self.create_user_embed(ctx, user)
 
@@ -331,11 +331,7 @@ class Information(Cog):
 
     @cooldown_with_role_bypass(2, 60 * 3, BucketType.member, bypass_roles=constants.STAFF_ROLES)
     @group(invoke_without_command=True)
-    @in_whitelisted_context(
-        whitelisted_channels=(constants.Channels.bot_commands,),
-        whitelisted_roles=constants.STAFF_ROLES,
-        redirect_channel=constants.Channels.bot_commands,
-    )
+    @in_whitelist(channels=(constants.Channels.bot_commands,), roles=constants.STAFF_ROLES)
     async def raw(self, ctx: Context, *, message: Message, json: bool = False) -> None:
         """Shows information about the raw API response."""
         # I *guess* it could be deleted right as the command is invoked but I felt like it wasn't worth handling

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -13,7 +13,7 @@ from discord.ext.commands import Cog, Context, command, guild_only
 
 from bot.bot import Bot
 from bot.constants import Categories, Channels, Roles, URLs
-from bot.decorators import in_whitelisted_context
+from bot.decorators import in_whitelist
 from bot.utils.messages import wait_for_deletion
 
 log = logging.getLogger(__name__)
@@ -269,12 +269,7 @@ class Snekbox(Cog):
 
     @command(name="eval", aliases=("e",))
     @guild_only()
-    @in_whitelisted_context(
-        whitelisted_channels=EVAL_CHANNELS,
-        whitelisted_categories=EVAL_CATEGORIES,
-        whitelisted_roles=EVAL_ROLES,
-        redirect_channel=Channels.bot_commands,
-    )
+    @in_whitelist(channels=EVAL_CHANNELS, categories=EVAL_CATEGORIES, roles=EVAL_ROLES)
     async def eval_command(self, ctx: Context, *, code: str = None) -> None:
         """
         Run Python code and get the results.

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -13,7 +13,7 @@ from discord.ext.commands import Cog, Context, command, guild_only
 
 from bot.bot import Bot
 from bot.constants import Channels, Roles, URLs
-from bot.decorators import in_channel
+from bot.decorators import in_whitelisted_context
 from bot.utils.messages import wait_for_deletion
 
 log = logging.getLogger(__name__)
@@ -38,6 +38,9 @@ RAW_CODE_REGEX = re.compile(
 )
 
 MAX_PASTE_LEN = 1000
+
+# `!eval` command whitelists
+EVAL_CHANNELS = (Channels.bot_commands, Channels.esoteric)
 EVAL_ROLES = (Roles.helpers, Roles.moderators, Roles.admins, Roles.owners, Roles.python_community, Roles.partners)
 
 SIGKILL = 9
@@ -265,7 +268,11 @@ class Snekbox(Cog):
 
     @command(name="eval", aliases=("e",))
     @guild_only()
-    @in_channel(Channels.bot_commands, hidden_channels=(Channels.esoteric,), bypass_roles=EVAL_ROLES)
+    @in_whitelisted_context(
+        whitelisted_channels=EVAL_CHANNELS,
+        whitelisted_roles=EVAL_ROLES,
+        redirect_channel=Channels.bot_commands,
+    )
     async def eval_command(self, ctx: Context, *, code: str = None) -> None:
         """
         Run Python code and get the results.

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -12,7 +12,7 @@ from discord import HTTPException, Message, NotFound, Reaction, User
 from discord.ext.commands import Cog, Context, command, guild_only
 
 from bot.bot import Bot
-from bot.constants import Channels, Roles, URLs
+from bot.constants import Categories, Channels, Roles, URLs
 from bot.decorators import in_whitelisted_context
 from bot.utils.messages import wait_for_deletion
 
@@ -41,6 +41,7 @@ MAX_PASTE_LEN = 1000
 
 # `!eval` command whitelists
 EVAL_CHANNELS = (Channels.bot_commands, Channels.esoteric)
+EVAL_CATEGORIES = (Categories.help_available, Categories.help_in_use)
 EVAL_ROLES = (Roles.helpers, Roles.moderators, Roles.admins, Roles.owners, Roles.python_community, Roles.partners)
 
 SIGKILL = 9
@@ -270,6 +271,7 @@ class Snekbox(Cog):
     @guild_only()
     @in_whitelisted_context(
         whitelisted_channels=EVAL_CHANNELS,
+        whitelisted_categories=EVAL_CATEGORIES,
         whitelisted_roles=EVAL_ROLES,
         redirect_channel=Channels.bot_commands,
     )

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -13,7 +13,7 @@ from discord.ext.commands import BadArgument, Cog, Context, command
 
 from bot.bot import Bot
 from bot.constants import Channels, MODERATION_ROLES, Mention, STAFF_ROLES
-from bot.decorators import in_whitelisted_context, with_role
+from bot.decorators import in_whitelist, with_role
 from bot.utils.time import humanize_delta
 
 log = logging.getLogger(__name__)
@@ -118,11 +118,7 @@ class Utils(Cog):
         await ctx.message.channel.send(embed=pep_embed)
 
     @command()
-    @in_whitelisted_context(
-        whitelisted_channels=(Channels.bot_commands,),
-        whitelisted_roles=STAFF_ROLES,
-        redirect_channel=Channels.bot_commands,
-    )
+    @in_whitelist(channels=(Channels.bot_commands,), roles=STAFF_ROLES)
     async def charinfo(self, ctx: Context, *, characters: str) -> None:
         """Shows you information on up to 25 unicode characters."""
         match = re.match(r"<(a?):(\w+):(\d+)>", characters)

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -13,7 +13,7 @@ from discord.ext.commands import BadArgument, Cog, Context, command
 
 from bot.bot import Bot
 from bot.constants import Channels, MODERATION_ROLES, Mention, STAFF_ROLES
-from bot.decorators import in_channel, with_role
+from bot.decorators import in_whitelisted_context, with_role
 from bot.utils.time import humanize_delta
 
 log = logging.getLogger(__name__)
@@ -118,7 +118,11 @@ class Utils(Cog):
         await ctx.message.channel.send(embed=pep_embed)
 
     @command()
-    @in_channel(Channels.bot_commands, bypass_roles=STAFF_ROLES)
+    @in_whitelisted_context(
+        whitelisted_channels=(Channels.bot_commands,),
+        whitelisted_roles=STAFF_ROLES,
+        redirect_channel=Channels.bot_commands,
+    )
     async def charinfo(self, ctx: Context, *, characters: str) -> None:
         """Shows you information on up to 25 unicode characters."""
         match = re.match(r"<(a?):(\w+):(\d+)>", characters)

--- a/bot/cogs/verification.py
+++ b/bot/cogs/verification.py
@@ -9,7 +9,7 @@ from discord.ext.commands import Cog, Context, command
 from bot import constants
 from bot.bot import Bot
 from bot.cogs.moderation import ModLog
-from bot.decorators import InWhitelistedContextCheckFailure, in_whitelisted_context, without_role
+from bot.decorators import InWhitelistCheckFailure, in_whitelist, without_role
 from bot.utils.checks import without_role_check
 
 log = logging.getLogger(__name__)
@@ -122,7 +122,7 @@ class Verification(Cog):
 
     @command(name='accept', aliases=('verify', 'verified', 'accepted'), hidden=True)
     @without_role(constants.Roles.verified)
-    @in_whitelisted_context(whitelisted_channels=(constants.Channels.verification,))
+    @in_whitelist(channels=(constants.Channels.verification,))
     async def accept_command(self, ctx: Context, *_) -> None:  # We don't actually care about the args
         """Accept our rules and gain access to the rest of the server."""
         log.debug(f"{ctx.author} called !accept. Assigning the 'Developer' role.")
@@ -138,10 +138,7 @@ class Verification(Cog):
                 await ctx.message.delete()
 
     @command(name='subscribe')
-    @in_whitelisted_context(
-        whitelisted_channels=(constants.Channels.bot_commands,),
-        redirect_channel=constants.Channels.bot_commands,
-    )
+    @in_whitelist(channels=(constants.Channels.bot_commands,))
     async def subscribe_command(self, ctx: Context, *_) -> None:  # We don't actually care about the args
         """Subscribe to announcement notifications by assigning yourself the role."""
         has_role = False
@@ -165,10 +162,7 @@ class Verification(Cog):
         )
 
     @command(name='unsubscribe')
-    @in_whitelisted_context(
-        whitelisted_channels=(constants.Channels.bot_commands,),
-        redirect_channel=constants.Channels.bot_commands,
-    )
+    @in_whitelist(channels=(constants.Channels.bot_commands,))
     async def unsubscribe_command(self, ctx: Context, *_) -> None:  # We don't actually care about the args
         """Unsubscribe from announcement notifications by removing the role from yourself."""
         has_role = False
@@ -193,8 +187,8 @@ class Verification(Cog):
 
     # This cannot be static (must have a __func__ attribute).
     async def cog_command_error(self, ctx: Context, error: Exception) -> None:
-        """Check for & ignore any InWhitelistedContextCheckFailure."""
-        if isinstance(error, InWhitelistedContextCheckFailure):
+        """Check for & ignore any InWhitelistCheckFailure."""
+        if isinstance(error, InWhitelistCheckFailure):
             error.handled = True
 
     @staticmethod

--- a/bot/cogs/verification.py
+++ b/bot/cogs/verification.py
@@ -9,7 +9,7 @@ from discord.ext.commands import Cog, Context, command
 from bot import constants
 from bot.bot import Bot
 from bot.cogs.moderation import ModLog
-from bot.decorators import InChannelCheckFailure, in_channel, without_role
+from bot.decorators import InWhitelistedContextCheckFailure, in_whitelisted_context, without_role
 from bot.utils.checks import without_role_check
 
 log = logging.getLogger(__name__)
@@ -122,7 +122,7 @@ class Verification(Cog):
 
     @command(name='accept', aliases=('verify', 'verified', 'accepted'), hidden=True)
     @without_role(constants.Roles.verified)
-    @in_channel(constants.Channels.verification)
+    @in_whitelisted_context(whitelisted_channels=(constants.Channels.verification,))
     async def accept_command(self, ctx: Context, *_) -> None:  # We don't actually care about the args
         """Accept our rules and gain access to the rest of the server."""
         log.debug(f"{ctx.author} called !accept. Assigning the 'Developer' role.")
@@ -138,7 +138,10 @@ class Verification(Cog):
                 await ctx.message.delete()
 
     @command(name='subscribe')
-    @in_channel(constants.Channels.bot_commands)
+    @in_whitelisted_context(
+        whitelisted_channels=(constants.Channels.bot_commands,),
+        redirect_channel=constants.Channels.bot_commands,
+    )
     async def subscribe_command(self, ctx: Context, *_) -> None:  # We don't actually care about the args
         """Subscribe to announcement notifications by assigning yourself the role."""
         has_role = False
@@ -162,7 +165,10 @@ class Verification(Cog):
         )
 
     @command(name='unsubscribe')
-    @in_channel(constants.Channels.bot_commands)
+    @in_whitelisted_context(
+        whitelisted_channels=(constants.Channels.bot_commands,),
+        redirect_channel=constants.Channels.bot_commands,
+    )
     async def unsubscribe_command(self, ctx: Context, *_) -> None:  # We don't actually care about the args
         """Unsubscribe from announcement notifications by removing the role from yourself."""
         has_role = False
@@ -187,8 +193,8 @@ class Verification(Cog):
 
     # This cannot be static (must have a __func__ attribute).
     async def cog_command_error(self, ctx: Context, error: Exception) -> None:
-        """Check for & ignore any InChannelCheckFailure."""
-        if isinstance(error, InChannelCheckFailure):
+        """Check for & ignore any InWhitelistedContextCheckFailure."""
+        if isinstance(error, InWhitelistedContextCheckFailure):
             error.handled = True
 
     @staticmethod

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -31,7 +31,7 @@ class CommandNameTests(unittest.TestCase):
     def walk_modules() -> t.Iterator[ModuleType]:
         """Yield imported modules from the bot.cogs subpackage."""
         def on_error(name: str) -> t.NoReturn:
-            raise ImportError(name=name)
+            raise ImportError(name=name)  # pragma: no cover
 
         # The mock prevents asyncio.get_event_loop() from being called.
         with mock.patch("discord.ext.tasks.loop"):
@@ -71,7 +71,7 @@ class CommandNameTests(unittest.TestCase):
 
             for name in self.get_qualified_names(cmd):
                 with self.subTest(cmd=func_name, name=name):
-                    if name in all_names:
+                    if name in all_names:  # pragma: no cover
                         conflicts = ", ".join(all_names.get(name, ""))
                         self.fail(
                             f"Name '{name}' of the command {func_name} conflicts with {conflicts}."

--- a/tests/bot/cogs/test_information.py
+++ b/tests/bot/cogs/test_information.py
@@ -7,7 +7,7 @@ import discord
 
 from bot import constants
 from bot.cogs import information
-from bot.decorators import InWhitelistedContextCheckFailure
+from bot.decorators import InWhitelistCheckFailure
 from tests import helpers
 
 
@@ -525,7 +525,7 @@ class UserCommandTests(unittest.TestCase):
         ctx = helpers.MockContext(author=self.author, channel=helpers.MockTextChannel(id=100))
 
         msg = "Sorry, but you may only use this command within <#50>."
-        with self.assertRaises(InWhitelistedContextCheckFailure, msg=msg):
+        with self.assertRaises(InWhitelistCheckFailure, msg=msg):
             asyncio.run(self.cog.user_info.callback(self.cog, ctx))
 
     @unittest.mock.patch("bot.cogs.information.Information.create_user_embed", new_callable=unittest.mock.AsyncMock)

--- a/tests/bot/cogs/test_information.py
+++ b/tests/bot/cogs/test_information.py
@@ -7,7 +7,7 @@ import discord
 
 from bot import constants
 from bot.cogs import information
-from bot.decorators import InChannelCheckFailure
+from bot.decorators import InWhitelistedContextCheckFailure
 from tests import helpers
 
 
@@ -525,7 +525,7 @@ class UserCommandTests(unittest.TestCase):
         ctx = helpers.MockContext(author=self.author, channel=helpers.MockTextChannel(id=100))
 
         msg = "Sorry, but you may only use this command within <#50>."
-        with self.assertRaises(InChannelCheckFailure, msg=msg):
+        with self.assertRaises(InWhitelistedContextCheckFailure, msg=msg):
             asyncio.run(self.cog.user_info.callback(self.cog, ctx))
 
     @unittest.mock.patch("bot.cogs.information.Information.create_user_embed", new_callable=unittest.mock.AsyncMock)

--- a/tests/bot/test_decorators.py
+++ b/tests/bot/test_decorators.py
@@ -2,15 +2,15 @@ import collections
 import unittest
 import unittest.mock
 
-from bot.decorators import InWhitelistedContextCheckFailure, in_whitelisted_context
+from bot.decorators import InWhitelistCheckFailure, in_whitelist
 from tests import helpers
 
 
 WhitelistedContextTestCase = collections.namedtuple("WhitelistedContextTestCase", ("kwargs", "ctx"))
 
 
-class InWhitelistedContextTests(unittest.TestCase):
-    """Tests for the `in_whitelisted_context` check."""
+class InWhitelistTests(unittest.TestCase):
+    """Tests for the `in_whitelist` check."""
 
     @classmethod
     def setUpClass(cls):
@@ -23,43 +23,43 @@ class InWhitelistedContextTests(unittest.TestCase):
         cls.staff_role = helpers.MockRole(id=121212)
         cls.staff_member = helpers.MockMember(roles=(cls.staff_role,))
 
-        cls.whitelisted_channels = (cls.bot_commands.id,)
-        cls.whitelisted_categories = (cls.help_channel.category_id,)
-        cls.whitelisted_roles = (cls.staff_role.id,)
+        cls.channels = (cls.bot_commands.id,)
+        cls.categories = (cls.help_channel.category_id,)
+        cls.roles = (cls.staff_role.id,)
 
     def test_predicate_returns_true_for_whitelisted_context(self):
         """The predicate should return `True` if a whitelisted context was passed to it."""
         test_cases = (
             # Commands issued in whitelisted channels by members without whitelisted roles
             WhitelistedContextTestCase(
-                kwargs={"whitelisted_channels": self.whitelisted_channels},
+                kwargs={"channels": self.channels},
                 ctx=helpers.MockContext(channel=self.bot_commands, author=self.non_staff_member)
             ),
-            # `redirect_channel` should be added implicitly to the `whitelisted_channels`
+            # `redirect` should be added implicitly to the `channels`
             WhitelistedContextTestCase(
-                kwargs={"redirect_channel": self.bot_commands.id},
+                kwargs={"redirect": self.bot_commands.id},
                 ctx=helpers.MockContext(channel=self.bot_commands, author=self.non_staff_member)
             ),
 
             # Commands issued in a whitelisted category by members without whitelisted roles
             WhitelistedContextTestCase(
-                kwargs={"whitelisted_categories": self.whitelisted_categories},
+                kwargs={"categories": self.categories},
                 ctx=helpers.MockContext(channel=self.help_channel, author=self.non_staff_member)
             ),
 
             # Command issued by a staff member in a non-whitelisted channel/category
             WhitelistedContextTestCase(
-                kwargs={"whitelisted_roles": self.whitelisted_roles},
+                kwargs={"roles": self.roles},
                 ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.staff_member)
             ),
 
             # With all kwargs provided
             WhitelistedContextTestCase(
                 kwargs={
-                    "whitelisted_channels": self.whitelisted_channels,
-                    "whitelisted_categories": self.whitelisted_categories,
-                    "whitelisted_roles": self.whitelisted_roles,
-                    "redirect_channel": self.bot_commands,
+                    "channels": self.channels,
+                    "categories": self.categories,
+                    "roles": self.roles,
+                    "redirect": self.bot_commands,
                 },
                 ctx=helpers.MockContext(channel=self.help_channel, author=self.staff_member)
             ),
@@ -69,31 +69,31 @@ class InWhitelistedContextTests(unittest.TestCase):
             # patch `commands.check` with a no-op lambda that just returns the predicate passed to it
             # so we can test the predicate that was generated from the specified kwargs.
             with unittest.mock.patch("bot.decorators.commands.check", new=lambda predicate: predicate):
-                predicate = in_whitelisted_context(**test_case.kwargs)
+                predicate = in_whitelist(**test_case.kwargs)
 
             with self.subTest(test_case=test_case):
                 self.assertTrue(predicate(test_case.ctx))
 
     def test_predicate_raises_exception_for_non_whitelisted_context(self):
-        """The predicate should raise `InWhitelistedContextCheckFailure` for a non-whitelisted context."""
+        """The predicate should raise `InWhitelistCheckFailure` for a non-whitelisted context."""
         test_cases = (
-            # Failing check with `redirect_channel`
+            # Failing check with `redirect`
             WhitelistedContextTestCase(
                 kwargs={
-                    "whitelisted_categories": self.whitelisted_categories,
-                    "whitelisted_channels": self.whitelisted_channels,
-                    "whitelisted_roles": self.whitelisted_roles,
-                    "redirect_channel": self.bot_commands.id,
+                    "categories": self.categories,
+                    "channels": self.channels,
+                    "roles": self.roles,
+                    "redirect": self.bot_commands.id,
                 },
                 ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.non_staff_member)
             ),
 
-            # Failing check without `redirect_channel`
+            # Failing check without `redirect`
             WhitelistedContextTestCase(
                 kwargs={
-                    "whitelisted_categories": self.whitelisted_categories,
-                    "whitelisted_channels": self.whitelisted_channels,
-                    "whitelisted_roles": self.whitelisted_roles,
+                    "categories": self.categories,
+                    "channels": self.channels,
+                    "roles": self.roles,
                 },
                 ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.non_staff_member)
             ),
@@ -102,14 +102,14 @@ class InWhitelistedContextTests(unittest.TestCase):
         for test_case in test_cases:
             # Create expected exception message based on whether or not a redirect channel was provided
             expected_message = "Sorry, but you are not allowed to use that command here."
-            if test_case.kwargs.get("redirect_channel"):
-                expected_message += f" Please use the <#{test_case.kwargs['redirect_channel']}> channel instead."
+            if test_case.kwargs.get("redirect"):
+                expected_message += f" Please use the <#{test_case.kwargs['redirect']}> channel instead."
 
             # patch `commands.check` with a no-op lambda that just returns the predicate passed to it
             # so we can test the predicate that was generated from the specified kwargs.
             with unittest.mock.patch("bot.decorators.commands.check", new=lambda predicate: predicate):
-                predicate = in_whitelisted_context(**test_case.kwargs)
+                predicate = in_whitelist(**test_case.kwargs)
 
             with self.subTest(test_case=test_case):
-                with self.assertRaises(InWhitelistedContextCheckFailure, msg=expected_message):
+                with self.assertRaises(InWhitelistCheckFailure, msg=expected_message):
                     predicate(test_case.ctx)

--- a/tests/bot/test_decorators.py
+++ b/tests/bot/test_decorators.py
@@ -2,11 +2,12 @@ import collections
 import unittest
 import unittest.mock
 
+from bot import constants
 from bot.decorators import InWhitelistCheckFailure, in_whitelist
 from tests import helpers
 
 
-WhitelistedContextTestCase = collections.namedtuple("WhitelistedContextTestCase", ("kwargs", "ctx"))
+InWhitelistTestCase = collections.namedtuple("WhitelistedContextTestCase", ("kwargs", "ctx", "description"))
 
 
 class InWhitelistTests(unittest.TestCase):
@@ -18,6 +19,7 @@ class InWhitelistTests(unittest.TestCase):
         cls.bot_commands = helpers.MockTextChannel(id=123456789, category_id=123456)
         cls.help_channel = helpers.MockTextChannel(id=987654321, category_id=987654)
         cls.non_whitelisted_channel = helpers.MockTextChannel(id=666666)
+        cls.dm_channel = helpers.MockDMChannel()
 
         cls.non_staff_member = helpers.MockMember()
         cls.staff_role = helpers.MockRole(id=121212)
@@ -30,38 +32,35 @@ class InWhitelistTests(unittest.TestCase):
     def test_predicate_returns_true_for_whitelisted_context(self):
         """The predicate should return `True` if a whitelisted context was passed to it."""
         test_cases = (
-            # Commands issued in whitelisted channels by members without whitelisted roles
-            WhitelistedContextTestCase(
+            InWhitelistTestCase(
                 kwargs={"channels": self.channels},
-                ctx=helpers.MockContext(channel=self.bot_commands, author=self.non_staff_member)
+                ctx=helpers.MockContext(channel=self.bot_commands, author=self.non_staff_member),
+                description="In whitelisted channels by members without whitelisted roles",
             ),
-            # `redirect` should be added implicitly to the `channels`
-            WhitelistedContextTestCase(
+            InWhitelistTestCase(
                 kwargs={"redirect": self.bot_commands.id},
-                ctx=helpers.MockContext(channel=self.bot_commands, author=self.non_staff_member)
+                ctx=helpers.MockContext(channel=self.bot_commands, author=self.non_staff_member),
+                description="`redirect` should be implicitly added to `channels`",
             ),
-
-            # Commands issued in a whitelisted category by members without whitelisted roles
-            WhitelistedContextTestCase(
+            InWhitelistTestCase(
                 kwargs={"categories": self.categories},
-                ctx=helpers.MockContext(channel=self.help_channel, author=self.non_staff_member)
+                ctx=helpers.MockContext(channel=self.help_channel, author=self.non_staff_member),
+                description="Whitelisted category without whitelisted role",
             ),
-
-            # Command issued by a staff member in a non-whitelisted channel/category
-            WhitelistedContextTestCase(
+            InWhitelistTestCase(
                 kwargs={"roles": self.roles},
-                ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.staff_member)
+                ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.staff_member),
+                description="Whitelisted role outside of whitelisted channel/category"
             ),
-
-            # With all kwargs provided
-            WhitelistedContextTestCase(
+            InWhitelistTestCase(
                 kwargs={
                     "channels": self.channels,
                     "categories": self.categories,
                     "roles": self.roles,
                     "redirect": self.bot_commands,
                 },
-                ctx=helpers.MockContext(channel=self.help_channel, author=self.staff_member)
+                ctx=helpers.MockContext(channel=self.help_channel, author=self.staff_member),
+                description="Case with all whitelist kwargs used",
             ),
         )
 
@@ -71,45 +70,78 @@ class InWhitelistTests(unittest.TestCase):
             with unittest.mock.patch("bot.decorators.commands.check", new=lambda predicate: predicate):
                 predicate = in_whitelist(**test_case.kwargs)
 
-            with self.subTest(test_case=test_case):
+            with self.subTest(test_description=test_case.description):
                 self.assertTrue(predicate(test_case.ctx))
 
     def test_predicate_raises_exception_for_non_whitelisted_context(self):
         """The predicate should raise `InWhitelistCheckFailure` for a non-whitelisted context."""
         test_cases = (
-            # Failing check with `redirect`
-            WhitelistedContextTestCase(
+            # Failing check with explicit `redirect`
+            InWhitelistTestCase(
                 kwargs={
                     "categories": self.categories,
                     "channels": self.channels,
                     "roles": self.roles,
                     "redirect": self.bot_commands.id,
                 },
-                ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.non_staff_member)
+                ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.non_staff_member),
+                description="Failing check with an explicit redirect channel",
             ),
 
-            # Failing check without `redirect`
-            WhitelistedContextTestCase(
+            # Failing check with implicit `redirect`
+            InWhitelistTestCase(
                 kwargs={
                     "categories": self.categories,
                     "channels": self.channels,
                     "roles": self.roles,
                 },
-                ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.non_staff_member)
+                ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.non_staff_member),
+                description="Failing check with an implicit redirect channel",
+            ),
+
+            # Failing check without `redirect`
+            InWhitelistTestCase(
+                kwargs={
+                    "categories": self.categories,
+                    "channels": self.channels,
+                    "roles": self.roles,
+                    "redirect": None,
+                },
+                ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.non_staff_member),
+                description="Failing check without a redirect channel",
+            ),
+
+            # Command issued in DM channel
+            InWhitelistTestCase(
+                kwargs={
+                    "categories": self.categories,
+                    "channels": self.channels,
+                    "roles": self.roles,
+                    "redirect": None,
+                },
+                ctx=helpers.MockContext(channel=self.dm_channel, author=self.dm_channel.me),
+                description="Commands issued in DM channel should be rejected",
             ),
         )
 
         for test_case in test_cases:
-            # Create expected exception message based on whether or not a redirect channel was provided
-            expected_message = "Sorry, but you are not allowed to use that command here."
-            if test_case.kwargs.get("redirect"):
-                expected_message += f" Please use the <#{test_case.kwargs['redirect']}> channel instead."
+            if "redirect" not in test_case.kwargs or test_case.kwargs["redirect"] is not None:
+                # There are two cases in which we have a redirect channel:
+                #   1. No redirect channel was passed; the default value of `bot_commands` is used
+                #   2. An explicit `redirect` is set that is "not None"
+                redirect_channel = test_case.kwargs.get("redirect", constants.Channels.bot_commands)
+                redirect_message = f" here. Please use the <#{redirect_channel}> channel instead"
+            else:
+                # If an explicit `None` was passed for `redirect`, there is no redirect channel
+                redirect_message = ""
+
+            exception_message = f"You are not allowed to use that command{redirect_message}."
 
             # patch `commands.check` with a no-op lambda that just returns the predicate passed to it
             # so we can test the predicate that was generated from the specified kwargs.
             with unittest.mock.patch("bot.decorators.commands.check", new=lambda predicate: predicate):
                 predicate = in_whitelist(**test_case.kwargs)
 
-            with self.subTest(test_case=test_case):
-                with self.assertRaises(InWhitelistCheckFailure, msg=expected_message):
+            with self.subTest(test_description=test_case.description):
+                with self.assertRaisesRegex(InWhitelistCheckFailure, exception_message):
                     predicate(test_case.ctx)

--- a/tests/bot/test_decorators.py
+++ b/tests/bot/test_decorators.py
@@ -1,0 +1,115 @@
+import collections
+import unittest
+import unittest.mock
+
+from bot.decorators import InWhitelistedContextCheckFailure, in_whitelisted_context
+from tests import helpers
+
+
+WhitelistedContextTestCase = collections.namedtuple("WhitelistedContextTestCase", ("kwargs", "ctx"))
+
+
+class InWhitelistedContextTests(unittest.TestCase):
+    """Tests for the `in_whitelisted_context` check."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up helpers that only need to be defined once."""
+        cls.bot_commands = helpers.MockTextChannel(id=123456789, category_id=123456)
+        cls.help_channel = helpers.MockTextChannel(id=987654321, category_id=987654)
+        cls.non_whitelisted_channel = helpers.MockTextChannel(id=666666)
+
+        cls.non_staff_member = helpers.MockMember()
+        cls.staff_role = helpers.MockRole(id=121212)
+        cls.staff_member = helpers.MockMember(roles=(cls.staff_role,))
+
+        cls.whitelisted_channels = (cls.bot_commands.id,)
+        cls.whitelisted_categories = (cls.help_channel.category_id,)
+        cls.whitelisted_roles = (cls.staff_role.id,)
+
+    def test_predicate_returns_true_for_whitelisted_context(self):
+        """The predicate should return `True` if a whitelisted context was passed to it."""
+        test_cases = (
+            # Commands issued in whitelisted channels by members without whitelisted roles
+            WhitelistedContextTestCase(
+                kwargs={"whitelisted_channels": self.whitelisted_channels},
+                ctx=helpers.MockContext(channel=self.bot_commands, author=self.non_staff_member)
+            ),
+            # `redirect_channel` should be added implicitly to the `whitelisted_channels`
+            WhitelistedContextTestCase(
+                kwargs={"redirect_channel": self.bot_commands.id},
+                ctx=helpers.MockContext(channel=self.bot_commands, author=self.non_staff_member)
+            ),
+
+            # Commands issued in a whitelisted category by members without whitelisted roles
+            WhitelistedContextTestCase(
+                kwargs={"whitelisted_categories": self.whitelisted_categories},
+                ctx=helpers.MockContext(channel=self.help_channel, author=self.non_staff_member)
+            ),
+
+            # Command issued by a staff member in a non-whitelisted channel/category
+            WhitelistedContextTestCase(
+                kwargs={"whitelisted_roles": self.whitelisted_roles},
+                ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.staff_member)
+            ),
+
+            # With all kwargs provided
+            WhitelistedContextTestCase(
+                kwargs={
+                    "whitelisted_channels": self.whitelisted_channels,
+                    "whitelisted_categories": self.whitelisted_categories,
+                    "whitelisted_roles": self.whitelisted_roles,
+                    "redirect_channel": self.bot_commands,
+                },
+                ctx=helpers.MockContext(channel=self.help_channel, author=self.staff_member)
+            ),
+        )
+
+        for test_case in test_cases:
+            # patch `commands.check` with a no-op lambda that just returns the predicate passed to it
+            # so we can test the predicate that was generated from the specified kwargs.
+            with unittest.mock.patch("bot.decorators.commands.check", new=lambda predicate: predicate):
+                predicate = in_whitelisted_context(**test_case.kwargs)
+
+            with self.subTest(test_case=test_case):
+                self.assertTrue(predicate(test_case.ctx))
+
+    def test_predicate_raises_exception_for_non_whitelisted_context(self):
+        """The predicate should raise `InWhitelistedContextCheckFailure` for a non-whitelisted context."""
+        test_cases = (
+            # Failing check with `redirect_channel`
+            WhitelistedContextTestCase(
+                kwargs={
+                    "whitelisted_categories": self.whitelisted_categories,
+                    "whitelisted_channels": self.whitelisted_channels,
+                    "whitelisted_roles": self.whitelisted_roles,
+                    "redirect_channel": self.bot_commands.id,
+                },
+                ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.non_staff_member)
+            ),
+
+            # Failing check without `redirect_channel`
+            WhitelistedContextTestCase(
+                kwargs={
+                    "whitelisted_categories": self.whitelisted_categories,
+                    "whitelisted_channels": self.whitelisted_channels,
+                    "whitelisted_roles": self.whitelisted_roles,
+                },
+                ctx=helpers.MockContext(channel=self.non_whitelisted_channel, author=self.non_staff_member)
+            ),
+        )
+
+        for test_case in test_cases:
+            # Create expected exception message based on whether or not a redirect channel was provided
+            expected_message = "Sorry, but you are not allowed to use that command here."
+            if test_case.kwargs.get("redirect_channel"):
+                expected_message += f" Please use the <#{test_case.kwargs['redirect_channel']}> channel instead."
+
+            # patch `commands.check` with a no-op lambda that just returns the predicate passed to it
+            # so we can test the predicate that was generated from the specified kwargs.
+            with unittest.mock.patch("bot.decorators.commands.check", new=lambda predicate: predicate):
+                predicate = in_whitelisted_context(**test_case.kwargs)
+
+            with self.subTest(test_case=test_case):
+                with self.assertRaises(InWhitelistedContextCheckFailure, msg=expected_message):
+                    predicate(test_case.ctx)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -315,7 +315,7 @@ class MockTextChannel(CustomMockMixin, unittest.mock.Mock, HashableMixin):
     """
     spec_set = channel_instance
 
-    def __init__(self, name: str = 'channel', channel_id: int = 1, **kwargs) -> None:
+    def __init__(self, **kwargs) -> None:
         default_kwargs = {'id': next(self.discord_id), 'name': 'channel', 'guild': MockGuild()}
         super().__init__(**collections.ChainMap(kwargs, default_kwargs))
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -323,6 +323,27 @@ class MockTextChannel(CustomMockMixin, unittest.mock.Mock, HashableMixin):
             self.mention = f"#{self.name}"
 
 
+# Create data for the DMChannel instance
+state = unittest.mock.MagicMock()
+me = unittest.mock.MagicMock()
+dm_channel_data = {"id": 1, "recipients": [unittest.mock.MagicMock()]}
+dm_channel_instance = discord.DMChannel(me=me, state=state, data=dm_channel_data)
+
+
+class MockDMChannel(CustomMockMixin, unittest.mock.Mock, HashableMixin):
+    """
+    A MagicMock subclass to mock TextChannel objects.
+
+    Instances of this class will follow the specifications of `discord.TextChannel` instances. For
+    more information, see the `MockGuild` docstring.
+    """
+    spec_set = dm_channel_instance
+
+    def __init__(self, **kwargs) -> None:
+        default_kwargs = {'id': next(self.discord_id), 'recipient': MockUser(), "me": MockUser()}
+        super().__init__(**collections.ChainMap(kwargs, default_kwargs))
+
+
 # Create a Message instance to get a realistic MagicMock of `discord.Message`
 message_data = {
     'id': 1,


### PR DESCRIPTION
This PR implements the policy change we've agreed upon during the staff meeting: Allowing the `!eval` command to be used by regular members in help channels. However, as our help channels are dynamically generated up to a certain number of channels, using a simple whitelist based on channel IDs won't work. That's why this PR generalizes the `in_channel` decorator to be able to whitelist more aspects of the command's context, including the channel category. This means that we can whitelist channels, including help channels, by the categories that they are in.

This PR closes #893 

## Generalizing the `in_channel` decorator

The previous decorator, `in_channel`, allowed us to whitelist commands based on the channel context they were issued in. However, unlike the name suggested, it could also be used to whitelist commands based on another aspect of the command context: The roles the author of the message containing the commands had. In fact, despite the name `in_channel`, the decorator could in principle be used to whitelist commands solely based on the author's roles using the `bypass_roles` kwarg.

This means that instead of having an `in_channel` decorator, we basically had a decorator that whitelisted commands based on two aspects of the command invocation context (i.e. the channel and the author's roles). To highlight this fact, I've generalized the decorator to a general "on_whitelisted_context` decorator that also allows for a third kind of context whitelist: the category containing the channel.

To force readability, I've made it so all the arguments should given as keyword arguments. This means that it's directly clear on which aspects of the context the decorator acts:

```py
@in_whitelisted_context(
    whitelisted_channels=EVAL_CHANNELS,
    whitelisted_categories=EVAL_CATEGORIES,
    whitelisted_roles=EVAL_ROLES,
    redirect_channel=Channels.bot_commands,
)
```

As it's now no longer obvious if and which redirect channel needs to be used to send a member to in case the check fails, the decorator now takes an optional `redirect_channel` kwarg. If such a channel is not given, the error message will not mention a "go here instead" channel; if it is given, we'll kindly suggest to the member that they should use the command there. (My guess is that this channel will usually be `#bot-commands`.)

If we ever want to add more options for context whitelisting, adding another kwarg to the decorator should be trivial.


