### PR TITLE
Answered help session statistics

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -62,7 +62,8 @@ through our guide for [asking a good question]({ASKING_GUIDE_URL}).
 """
 
 AVAILABLE_EMOJI = "✅"
-IN_USE_EMOJI = "⌛"
+IN_USE_ANSWERED_EMOJI = "⌛"
+IN_USE_UNANSWERED_EMOJI = "⏳"
 NAME_SEPARATOR = "｜"
 
 
@@ -528,7 +529,7 @@ class HelpChannels(Scheduler, commands.Cog):
         log.info(f"Moving #{channel} ({channel.id}) to the In Use category.")
 
         await channel.edit(
-            name=f"{IN_USE_EMOJI}{NAME_SEPARATOR}{self.get_clean_channel_name(channel)}",
+            name=f"{IN_USE_UNANSWERED_EMOJI}{NAME_SEPARATOR}{self.get_clean_channel_name(channel)}",
             category=self.in_use_category,
             sync_permissions=True,
             topic=IN_USE_TOPIC,
@@ -600,6 +601,10 @@ class HelpChannels(Scheduler, commands.Cog):
 
                 if claimant_id != message.author.id:
                     self.unanswered[channel.id] = False
+
+                    await channel.edit(
+                        name=f"{IN_USE_ANSWERED_EMOJI}{NAME_SEPARATOR}{self.get_clean_channel_name(channel)}"
+                    )
 
         if not self.is_in_category(channel, constants.Categories.help_available):
             return  # Ignore messages outside the Available category.

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -597,6 +597,7 @@ class HelpChannels(Scheduler, commands.Cog):
     async def check_for_answer(self, message: discord.Message) -> None:
         """Checks for whether new content in a help channel comes from non-claimants."""
         channel = message.channel
+        log.trace(f"Checking if #{channel} ({channel.id}) has been answered.")
 
         # Confirm the channel is an in use help channel
         if self.is_in_category(channel, constants.Categories.help_in_use):
@@ -610,9 +611,9 @@ class HelpChannels(Scheduler, commands.Cog):
                     self.unanswered[channel.id] = False
 
                     # Change the emoji in the channel name to signify activity
-                    await channel.edit(
-                        name=f"{IN_USE_ANSWERED_EMOJI}{NAME_SEPARATOR}{self.get_clean_channel_name(channel)}"
-                    )
+                    log.trace(f"#{channel} ({channel.id}) has been answered; changing its emoji")
+                    name = self.get_clean_channel_name(channel)
+                    await channel.edit(name=f"{IN_USE_ANSWERED_EMOJI}{NAME_SEPARATOR}{name}")
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -594,7 +594,7 @@ class HelpChannels(Scheduler, commands.Cog):
             return  # Ignore messages sent by bots.
 
         channel = message.channel
-        if not self.is_in_category(channel, constants.Categories.help_in_use):
+        if self.is_in_category(channel, constants.Categories.help_in_use):
             if channel.id in self.unanswered:
                 claimant_id = self.help_channel_claimants[channel].id
 


### PR DESCRIPTION
Create a dictionary to gather whether help sessions were closed with no input from anyone but the original claimant.

This should help build an understanding of how many channels are unanswered.

Also introduces two emoji for the in use help channels signifying channels with input from users other than the claimant.