### PR TITLE
Fix category cache issue

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -276,13 +276,12 @@ class HelpChannels(Scheduler, commands.Cog):
 
         return name
 
-    @staticmethod
-    def get_category_channels(category: discord.CategoryChannel) -> t.Iterable[discord.TextChannel]:
+    def get_category_channels(self, category: discord.CategoryChannel) -> t.Iterable[discord.TextChannel]:
         """Yield the text channels of the `category` in an unsorted manner."""
         log.trace(f"Getting text channels in the category '{category}' ({category.id}).")
 
         # This is faster than using category.channels because the latter sorts them.
-        for channel in category.guild.channels:
+        for channel in self.bot.get_guild(constants.Guild.id).channels:
             if channel.category_id == category.id and isinstance(channel, discord.TextChannel):
                 yield channel
 


### PR DESCRIPTION
After experiencing a reconnect from Discord, the channel cache we were using in the help cog began to fall apart and claimed there were 29 channels in the available category and no channels elsewhere.

(Blue line marks disconnect)

![image](https://user-images.githubusercontent.com/20439493/79870216-8d014000-83da-11ea-862e-f7c95bf366ee.png)

This PR forces retrieval of the channels in the guild from the bot cache in the `get_category_channels` method through the usage of `bot.get_guild` instead of `category.guild.channels`, since the latter fell apart after a reconnect.