### PR TITLE
Use selector event loop on Windows

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import sys
@@ -59,3 +60,8 @@ coloredlogs.install(logger=root_log, stream=sys.stdout)
 logging.getLogger("discord").setLevel(logging.WARNING)
 logging.getLogger("websockets").setLevel(logging.WARNING)
 logging.getLogger(__name__)
+
+
+# On Windows, the selector event loop is required for aiodns.
+if os.name == "nt":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -75,7 +75,7 @@ class Bot(commands.Bot):
             await self._resolver.close()
 
         if self.stats._transport:
-            await self.stats._transport.close()
+            self.stats._transport.close()
 
     async def login(self, *args, **kwargs) -> None:
         """Re-create the connector and set up sessions before logging into Discord."""


### PR DESCRIPTION
Fixes #894

aiodns requires the selector event loop for asyncio. In Python 3.8, the default event loop for Windows was changed to proactor. To fix this, the event loop is explicitly set to selector.