### PR TITLE
Sort help channels and add support for `how-to-get-help` channel

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -694,6 +694,7 @@ class HelpChannels(Scheduler, commands.Cog):
                 )
                 return
 
+            log.info(f"Channel #{channel} was claimed by `{message.author.id}`.")
             await self.move_to_in_use(channel)
             await self.revoke_send_permissions(message.author)
             # Add user with channel for dormant check.

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -383,6 +383,7 @@ class Channels(metaclass=YAMLGetter):
     dev_log: int
     esoteric: int
     helpers: int
+    how_to_get_help: int
     message_log: int
     meta: int
     mod_alerts: int

--- a/config-default.yml
+++ b/config-default.yml
@@ -132,6 +132,9 @@ guild:
         meta:               429409067623251969
         python_discussion:  267624335836053506
 
+        # Python Help: Available
+        how_to_get_help:    704250143020417084
+
         # Logs
         attachment_log:     &ATTACH_LOG     649243850006855680
         message_log:        &MESSAGE_LOG    467752170159079424


### PR DESCRIPTION
This PR reintroduces the bottom-sorting behavior that we tried before, but with a different strategy that is reliable in the way it sorts the channels and minimizes the number of glitches visible in the channel list. The strategy utilizes the same "bulk channels update" endpoint as `discord.py` uses to move channels, but builds the payload in a different way that minimizes the number of required position integer changes. It does use the `discord.py` http methods to send the payload to ensure `discord.py`'s rate limit manager can do its job.

For more details, read b0c07a9 

In addition, this PR also:

- Adds support for the `#how-to-get-help` channel we want to add to the `Available` category
- Adds a logging statement that keeps track of the ID of help channel claimants.