### PR TITLE
Display animated avatars in the user info command

### DIFF
--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -206,7 +206,7 @@ class Information(Cog):
             description="\n\n".join(description)
         )
 
-        embed.set_thumbnail(url=user.avatar_url_as(format="png"))
+        embed.set_thumbnail(url=user.avatar_url_as(static_format="png"))
         embed.colour = user.top_role.colour if roles else Colour.blurple()
 
         return embed

--- a/tests/bot/cogs/test_information.py
+++ b/tests/bot/cogs/test_information.py
@@ -485,7 +485,7 @@ class UserEmbedTests(unittest.TestCase):
         user.avatar_url_as.return_value = "avatar url"
         embed = asyncio.run(self.cog.create_user_embed(ctx, user))
 
-        user.avatar_url_as.assert_called_once_with(format="png")
+        user.avatar_url_as.assert_called_once_with(static_format="png")
         self.assertEqual(embed.thumbnail.url, "avatar url")
 
 


### PR DESCRIPTION
Fixes #914

A simple argument change makes discord.py preserve the avatar's format if it's `gif` and only convert everything else to `png`.
