### PR TITLE
Remove the mention command

### DIFF
--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -2,19 +2,16 @@ import difflib
 import logging
 import re
 import unicodedata
-from asyncio import TimeoutError, sleep
 from email.parser import HeaderParser
 from io import StringIO
 from typing import Tuple, Union
 
-from dateutil import relativedelta
-from discord import Colour, Embed, Message, Role
+from discord import Colour, Embed
 from discord.ext.commands import BadArgument, Cog, Context, command
 
 from bot.bot import Bot
-from bot.constants import Channels, MODERATION_ROLES, Mention, STAFF_ROLES
+from bot.constants import Channels, MODERATION_ROLES, STAFF_ROLES
 from bot.decorators import in_whitelist, with_role
-from bot.utils.time import humanize_delta
 
 log = logging.getLogger(__name__)
 
@@ -160,47 +157,6 @@ class Utils(Cog):
             embed.add_field(name='Raw', value=f"`{''.join(rawlist)}`", inline=False)
 
         await ctx.send(embed=embed)
-
-    @command()
-    @with_role(*MODERATION_ROLES)
-    async def mention(self, ctx: Context, *, role: Role) -> None:
-        """Set a role to be mentionable for a limited time."""
-        if role.mentionable:
-            await ctx.send(f"{role} is already mentionable!")
-            return
-
-        await role.edit(reason=f"Role unlocked by {ctx.author}", mentionable=True)
-
-        human_time = humanize_delta(relativedelta.relativedelta(seconds=Mention.message_timeout))
-        await ctx.send(
-            f"{role} has been made mentionable. I will reset it in {human_time}, or when someone mentions this role."
-        )
-
-        def check(m: Message) -> bool:
-            """Checks that the message contains the role mention."""
-            return role in m.role_mentions
-
-        try:
-            msg = await self.bot.wait_for("message", check=check, timeout=Mention.message_timeout)
-        except TimeoutError:
-            await role.edit(mentionable=False, reason="Automatic role lock - timeout.")
-            await ctx.send(f"{ctx.author.mention}, you took too long. I have reset {role} to be unmentionable.")
-            return
-
-        if any(r.id in MODERATION_ROLES for r in msg.author.roles):
-            await sleep(Mention.reset_delay)
-            await role.edit(mentionable=False, reason=f"Automatic role lock by {msg.author}")
-            await ctx.send(
-                f"{ctx.author.mention}, I have reset {role} to be unmentionable as "
-                f"{msg.author if msg.author != ctx.author else 'you'} sent a message mentioning it."
-            )
-            return
-
-        await role.edit(mentionable=False, reason=f"Automatic role lock - unauthorised use by {msg.author}")
-        await ctx.send(
-            f"{ctx.author.mention}, I have reset {role} to be unmentionable "
-            f"as I detected unauthorised use by {msg.author} (ID: {msg.author.id})."
-        )
 
     @command()
     async def zen(self, ctx: Context, *, search_value: Union[int, str, None] = None) -> None:

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -550,13 +550,6 @@ class HelpChannels(metaclass=YAMLGetter):
     notify_roles: List[int]
 
 
-class Mention(metaclass=YAMLGetter):
-    section = 'mention'
-
-    message_timeout: int
-    reset_delay: int
-
-
 class RedirectOutput(metaclass=YAMLGetter):
     section = 'redirect_output'
 

--- a/config-default.yml
+++ b/config-default.yml
@@ -507,9 +507,6 @@ free:
     cooldown_rate: 1
     cooldown_per: 60.0
 
-mention:
-    message_timeout: 300
-    reset_delay: 5
 
 help_channels:
     enable: true


### PR DESCRIPTION
It was made obsolete by a new Discord feature. Users can be granted a permission to mention a role despite the role being set as non-mentionable.