### PR TITLE
Perma Bans now Overwrite Temp Bans

### DIFF
--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -199,7 +199,7 @@ class Infractions(InfractionScheduler, commands.Cog):
 
     async def apply_mute(self, ctx: Context, user: Member, reason: str, **kwargs) -> None:
         """Apply a mute infraction with kwargs passed to `post_infraction`."""
-        if await utils.get_active_infractions(ctx, user, "mute"):
+        if await utils.get_active_infraction(ctx, user, "mute"):
             return
 
         infraction = await utils.post_infraction(ctx, user, "mute", reason, active=True, **kwargs)
@@ -236,28 +236,23 @@ class Infractions(InfractionScheduler, commands.Cog):
         Will also remove the banned user from the Big Brother watch list if applicable.
         """
         # In the case of a permanent ban, we don't need get_active_infractions to tell us if one is active
-        send_msg = "expires_at" in kwargs
-        active_infraction = await utils.get_active_infractions(ctx, user, "ban", send_msg)
+        send_msg = kwargs.get("expires_at") is None
+        active_infraction = await utils.get_active_infraction(ctx, user, "ban", send_msg)
 
         if active_infraction:
             log.trace("Active infractions found.")
-            if (
-                active_infraction.get('expires_at') is not None
-                and kwargs.get('expires_at') is None
-            ):
-                log.trace("Active ban is a temporary and being called by a perma.  Removing temporary.")
-                await self.pardon_infraction(ctx, "ban", user, send_msg)
+            if kwargs.get('expires_at') is None:
+                if active_infraction.get('expires_at') is not None:
+                    log.trace("Active ban is a temporary and being called by a perma.  Removing temporary.")
+                    await self.pardon_infraction(ctx, "ban", user, send_msg)
 
-            elif (
-                active_infraction.get('expires_at') is None
-                and kwargs.get('expires_at') is None
-            ):
-                log.trace("Active ban is a perma ban and being called by a perma.  Send bounce back message.")
-                await ctx.send(
-                    f":x: According to my records, this user is already permanently banned. "
-                    f"See infraction **#{active_infraction['id']}**."
-                )
-                return
+                elif active_infraction.get('expires_at') is None:
+                    log.trace("Active ban is a perma ban and being called by a perma.  Send bounce back message.")
+                    await ctx.send(
+                        f":x: According to my records, this user is already permanently banned. "
+                        f"See infraction **#{active_infraction['id']}**."
+                    )
+                    return
             else:
                 log.trace("Active ban is a temp ban being called by a temp or a perma being called by a temp. Ignore.")
                 return

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -190,7 +190,13 @@ class InfractionScheduler(Scheduler):
 
         log.info(f"Applied {infr_type} infraction #{id_} to {user}.")
 
-    async def pardon_infraction(self, ctx: Context, infr_type: str, user: UserSnowflake) -> None:
+    async def pardon_infraction(
+            self,
+            ctx: Context,
+            infr_type: str,
+            user: UserSnowflake,
+            send_msg: bool = True
+    ) -> None:
         """Prematurely end an infraction for a user and log the action in the mod log."""
         log.trace(f"Pardoning {infr_type} infraction for {user}.")
 
@@ -277,10 +283,11 @@ class InfractionScheduler(Scheduler):
 
         # Send a confirmation message to the invoking context.
         log.trace(f"Sending infraction #{id_} pardon confirmation message.")
-        await ctx.send(
-            f"{dm_emoji}{confirm_msg} infraction **{infr_type}** for {user.mention}. "
-            f"{log_text.get('Failure', '')}"
-        )
+        if send_msg:
+            await ctx.send(
+                f"{dm_emoji}{confirm_msg} infraction **{infr_type}** for {user.mention}. "
+                f"{log_text.get('Failure', '')}"
+            )
 
         # Send a log message to the mod log.
         await self.mod_log.send_log_message(

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -197,7 +197,12 @@ class InfractionScheduler(Scheduler):
             user: UserSnowflake,
             send_msg: bool = True
     ) -> None:
-        """Prematurely end an infraction for a user and log the action in the mod log."""
+        """
+        Prematurely end an infraction for a user and log the action in the mod log.
+
+        If `send_msg` is True, then a pardoning confirmation message will be sent to
+        the context channel.  Otherwise, no such message will be sent.
+        """
         log.trace(f"Pardoning {infr_type} infraction for {user}.")
 
         # Check the current active infraction
@@ -282,8 +287,8 @@ class InfractionScheduler(Scheduler):
             log.info(f"Pardoned {infr_type} infraction #{id_} for {user}.")
 
         # Send a confirmation message to the invoking context.
-        log.trace(f"Sending infraction #{id_} pardon confirmation message.")
         if send_msg:
+            log.trace(f"Sending infraction #{id_} pardon confirmation message.")
             await ctx.send(
                 f"{dm_emoji}{confirm_msg} infraction **{infr_type}** for {user.mention}. "
                 f"{log_text.get('Failure', '')}"

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -130,7 +130,7 @@ class Superstarify(InfractionScheduler, Cog):
         An optional reason can be provided. If no reason is given, the original name will be shown
         in a generated reason.
         """
-        if await utils.has_active_infraction(ctx, member, "superstar"):
+        if await utils.get_active_infractions(ctx, member, "superstar"):
             return
 
         # Post the infraction to the API

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -130,7 +130,7 @@ class Superstarify(InfractionScheduler, Cog):
         An optional reason can be provided. If no reason is given, the original name will be shown
         in a generated reason.
         """
-        if await utils.get_active_infractions(ctx, member, "superstar"):
+        if await utils.get_active_infraction(ctx, member, "superstar"):
             return
 
         # Post the infraction to the API

--- a/bot/cogs/moderation/utils.py
+++ b/bot/cogs/moderation/utils.py
@@ -97,8 +97,13 @@ async def post_infraction(
                 return
 
 
-async def has_active_infraction(ctx: Context, user: UserSnowflake, infr_type: str) -> bool:
-    """Checks if a user already has an active infraction of the given type."""
+async def get_active_infractions(
+        ctx: Context,
+        user: UserSnowflake,
+        infr_type: str,
+        send_msg: bool = True
+) -> t.Optional[dict]:
+    """Retrieves active infractions of the given type for the user."""
     log.trace(f"Checking if {user} has active infractions of type {infr_type}.")
 
     active_infractions = await ctx.bot.api_client.get(
@@ -110,15 +115,16 @@ async def has_active_infraction(ctx: Context, user: UserSnowflake, infr_type: st
         }
     )
     if active_infractions:
-        log.trace(f"{user} has active infractions of type {infr_type}.")
-        await ctx.send(
-            f":x: According to my records, this user already has a {infr_type} infraction. "
-            f"See infraction **#{active_infractions[0]['id']}**."
-        )
-        return True
+        # Checks to see if the moderator should be told there is an active infraction
+        if send_msg:
+            log.trace(f"{user} has active infractions of type {infr_type}.")
+            await ctx.send(
+                f":x: According to my records, this user already has a {infr_type} infraction. "
+                f"See infraction **#{active_infractions[0]['id']}**."
+            )
+        return active_infractions[0]
     else:
         log.trace(f"{user} does not have active infractions of type {infr_type}.")
-        return False
 
 
 async def notify_infraction(

--- a/bot/cogs/moderation/utils.py
+++ b/bot/cogs/moderation/utils.py
@@ -97,13 +97,19 @@ async def post_infraction(
                 return
 
 
-async def get_active_infractions(
+async def get_active_infraction(
         ctx: Context,
         user: UserSnowflake,
         infr_type: str,
         send_msg: bool = True
 ) -> t.Optional[dict]:
-    """Retrieves active infractions of the given type for the user."""
+    """
+    Retrieves an active infraction of the given type for the user.
+
+    If `send_msg` is True and the user has an active infraction matching the `infr_type` parameter,
+    then a message for the moderator will be sent to the context channel letting them know.
+    Otherwise, no message will be sent.
+    """
     log.trace(f"Checking if {user} has active infractions of type {infr_type}.")
 
     active_infractions = await ctx.bot.api_client.get(


### PR DESCRIPTION
In the current implementation, if a user is temporarily banned and does something that would require a permanent one, a moderator must first use the !unban command and then follow up with a !ban.  There have been plenty of times where such functionality has been a hinderance, and this PR aims to correct the behavior to make it a more streamlined process.


- Changed `has_active_infraction` to `get_active_infractions` in order to add additional logic in `apply_ban`.

- Added `send_msg` parameters to `pardon_infraction` and `get_active_infractions` so that multi-step checks and actions don't need to send additional messages unless told to do so.

Signed-off-by: Daniel Brown <browndj3@gmail.com>