### PR TITLE
Update to Antimalware Filter (.txt uploads)

### DIFF
--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -44,7 +44,7 @@ class AntiMalware(Cog):
             embed.description = (
                 "**Uh-oh!** It looks like your message got zapped by our spam filter. "
                 "We currently don't allow `.txt` attachments, so here are some tips to help you travel safely: \n\n"
-                "**1.** You tried to send a message longer than 2000 characters (Discord uploads these as files) \n"
+                "**1.** You tried to send a message longer than 2000 characters \n"
                 "• Try shortening your message to fit within the character limit or use a pasting service (see below) "
                 "\n\n**2.** You tried to show someone your code (no worries, we'd love to see it!)\n"
                 f"• Try using codeblocks (run `!code-blocks` in {cmd_channel.mention}) or use a pasting service \n\n"

--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -38,6 +38,18 @@ class AntiMalware(Cog):
                 "It looks like you tried to attach a Python file - "
                 f"please use a code-pasting service such as {URLs.site_schema}{URLs.site_paste}"
             )
+        elif ".txt" in extensions_blocked:
+            # Work around Discord AutoConversion of messages longer than 2000 chars to .txt
+            cmd_channel = self.bot.get_channel(Channels.bot_commands)
+            embed.description = (
+                "**Uh-oh!** It looks like your message got zapped by our spam filter. "
+                "We currently don't allow `.txt` attachments, so here are some tips to help you travel safely: \n\n"
+                "**1.** You tried to send a message longer than 2000 characters (Discord uploads these as files) \n"
+                "• Try shortening your message to fit within the character limit or use a pasting service (see below) "
+                "\n\n**2.** You tried to show someone your code (no worries, we'd love to see it!)\n"
+                f"• Try using codeblocks (run `!code-blocks` in {cmd_channel.mention}) or use a pasting service \n\n"
+                f"If you would like, here is a pasting service we like to use: {URLs.site_schema}{URLs.site_paste}"
+            )
         elif extensions_blocked:
             whitelisted_types = ', '.join(AntiMalwareConfig.whitelist)
             meta_channel = self.bot.get_channel(Channels.meta)

--- a/bot/cogs/antimalware.py
+++ b/bot/cogs/antimalware.py
@@ -44,11 +44,11 @@ class AntiMalware(Cog):
             embed.description = (
                 "**Uh-oh!** It looks like your message got zapped by our spam filter. "
                 "We currently don't allow `.txt` attachments, so here are some tips to help you travel safely: \n\n"
-                "**1.** You tried to send a message longer than 2000 characters \n"
-                "• Try shortening your message to fit within the character limit or use a pasting service (see below) "
-                "\n\n**2.** You tried to show someone your code (no worries, we'd love to see it!)\n"
-                f"• Try using codeblocks (run `!code-blocks` in {cmd_channel.mention}) or use a pasting service \n\n"
-                f"If you would like, here is a pasting service we like to use: {URLs.site_schema}{URLs.site_paste}"
+                "• If you attempted to send a message longer than 2000 characters, try shortening your message "
+                "to fit within the character limit or use a pasting service (see below) \n\n"
+                "• If you tried to show someone your code, you can use codeblocks \n(run `!code-blocks` in "
+                f"{cmd_channel.mention} for more information) or use a pasting service like: "
+                f"\n\n{URLs.site_schema}{URLs.site_paste}"
             )
         elif extensions_blocked:
             whitelisted_types = ', '.join(AntiMalwareConfig.whitelist)


### PR DESCRIPTION
This was a debate not only on the issue page: (see https://github.com/python-discord/bot/issues/889) but also in #meta a few times, and the consensus seemed to be that the primary focus should be the .txt file extension as there was no reason to unblock .csv, .json, or like file types.

Also, as for the message to display, I wanted to cover both case scenarios (someone who uploaded code, and someone whose message was too long) and writing a longer embed was the least expensive way to do so in my opinion. Here is a attachment of the output (don't mind the hyperlink, that's obviously just my config :smile:) Please let me know if any changes should be made :)
![InvalidExtensionEmbed](https://user-images.githubusercontent.com/64629111/81021708-c5bd0280-8e39-11ea-813c-c9c56360d4e0.png)
