### PR TITLE
Increase snekbox re eval timeout to 30 seconds

### DIFF
--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -227,7 +227,7 @@ class Snekbox(Cog):
                 _, new_message = await self.bot.wait_for(
                     'message_edit',
                     check=_predicate_eval_message_edit,
-                    timeout=10
+                    timeout=30
                 )
                 await ctx.message.add_reaction(REEVAL_EMOJI)
                 await self.bot.wait_for(

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -47,6 +47,7 @@ EVAL_ROLES = (Roles.helpers, Roles.moderators, Roles.admins, Roles.owners, Roles
 SIGKILL = 9
 
 REEVAL_EMOJI = '\U0001f501'  # :repeat:
+REEVAL_TIMEOUT = 30
 
 
 class Snekbox(Cog):
@@ -227,7 +228,7 @@ class Snekbox(Cog):
                 _, new_message = await self.bot.wait_for(
                     'message_edit',
                     check=_predicate_eval_message_edit,
-                    timeout=30
+                    timeout=REEVAL_TIMEOUT
                 )
                 await ctx.message.add_reaction(REEVAL_EMOJI)
                 await self.bot.wait_for(

--- a/tests/bot/cogs/test_snekbox.py
+++ b/tests/bot/cogs/test_snekbox.py
@@ -291,7 +291,11 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(actual, expected)
         self.bot.wait_for.assert_has_awaits(
             (
-                call('message_edit', check=partial_mock(snekbox.predicate_eval_message_edit, ctx), timeout=10),
+                call(
+                    'message_edit',
+                    check=partial_mock(snekbox.predicate_eval_message_edit, ctx),
+                    timeout=snekbox.REEVAL_TIMEOUT,
+                ),
                 call('reaction_add', check=partial_mock(snekbox.predicate_eval_emoji_reaction, ctx), timeout=10)
             )
         )


### PR DESCRIPTION
Increases the re eval message edit timeout to 30 seconds as discussed in #920 