### PR TITLE
Add more statistics

### DIFF
--- a/bot/cogs/bot.py
+++ b/bot/cogs/bot.py
@@ -326,6 +326,8 @@ class BotCog(Cog, name="Bot"):
                             log.trace("The code consists only of expressions, not sending instructions")
 
                     if howto != "":
+                        # Increase amount of codeblock correction in stats
+                        self.bot.stats.incr("codeblock_corrections")
                         howto_embed = Embed(description=howto)
                         bot_message = await msg.channel.send(f"Hey {msg.author.mention}!", embed=howto_embed)
                         self.codeblock_message_ids[msg.id] = bot_message.id

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -207,9 +207,9 @@ class Snekbox(Cog):
 
             # Collect stats of eval fails + successes
             if icon == ":x:":
-                self.bot.stats.incr("evals.fail")
+                self.bot.stats.incr("snekbox.python.fail")
             elif icon in (":warning:", ":white_check_mark:"):
-                self.bot.stats.incr("evals.success")
+                self.bot.stats.incr("snekbox.python.success")
 
             response = await ctx.send(msg)
             self.bot.loop.create_task(
@@ -299,16 +299,16 @@ class Snekbox(Cog):
             return
 
         if Roles.helpers in (role.id for role in ctx.author.roles):
-            self.bot.stats.incr("evals.roles.helpers")
+            self.bot.stats.incr("snekbox_usages.roles.helpers")
         else:
-            self.bot.stats.incr("evals.roles.developers")
+            self.bot.stats.incr("snekbox_usages.roles.developers")
 
         if ctx.channel.category_id == Categories.help_in_use:
-            self.bot.stats.incr("evals.channels.help")
+            self.bot.stats.incr("snekbox_usages.channels.help")
         elif ctx.channel.id == Channels.bot_commands:
-            self.bot.stats.incr("evals.channels.bot_commands")
+            self.bot.stats.incr("snekbox_usages.channels.bot_commands")
         else:
-            self.bot.stats.incr("evals.channels.topical")
+            self.bot.stats.incr("snekbox_usages.channels.topical")
 
         log.info(f"Received code from {ctx.author} for evaluation:\n{code}")
 

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -303,6 +303,13 @@ class Snekbox(Cog):
         else:
             self.bot.stats.incr("evals.roles.developers")
 
+        if ctx.channel.category_id == Categories.help_in_use:
+            self.bot.stats.incr("evals.channels.help")
+        elif ctx.channel.id == Channels.bot_commands:
+            self.bot.stats.incr("evals.channels.bot_commands")
+        else:
+            self.bot.stats.incr("evals.channels.topical")
+
         log.info(f"Received code from {ctx.author} for evaluation:\n{code}")
 
         while True:

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -205,6 +205,12 @@ class Snekbox(Cog):
             if paste_link:
                 msg = f"{msg}\nFull output: {paste_link}"
 
+            # Collect stats of eval fails + successes
+            if icon == ":x:":
+                self.bot.stats.incr("evals.fail")
+            elif icon in (":warning:", ":white_check_mark:"):
+                self.bot.stats.incr("evals.success")
+
             response = await ctx.send(msg)
             self.bot.loop.create_task(
                 wait_for_deletion(response, user_ids=(ctx.author.id,), client=ctx.bot)

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -208,7 +208,7 @@ class Snekbox(Cog):
             # Collect stats of eval fails + successes
             if icon == ":x:":
                 self.bot.stats.incr("snekbox.python.fail")
-            elif icon in (":warning:", ":white_check_mark:"):
+            else:
                 self.bot.stats.incr("snekbox.python.success")
 
             response = await ctx.send(msg)

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -298,6 +298,11 @@ class Snekbox(Cog):
             await ctx.invoke(self.bot.get_command("help"), "eval")
             return
 
+        if Roles.helpers in (role.id for role in ctx.author.roles):
+            self.bot.stats.incr("evals.roles.helpers")
+        else:
+            self.bot.stats.incr("evals.roles.developers")
+
         log.info(f"Received code from {ctx.author} for evaluation:\n{code}")
 
         while True:

--- a/bot/cogs/stats.py
+++ b/bot/cogs/stats.py
@@ -106,14 +106,14 @@ class Stats(Cog):
 
     @loop(hours=1)
     async def update_guild_boost(self) -> None:
-        """Update every hour guild boosts amount + level."""
+        """Post the server boost level and tier every hour."""
         await self.bot.wait_until_guild_available()
         g = self.bot.get_guild(Guild.id)
         self.bot.stats.gauge("boost.amount", g.premium_subscription_count)
         self.bot.stats.gauge("boost.tier", g.premium_tier)
 
     def cog_unload(self) -> None:
-        """Stop guild boost stat collecting task on Cog unload."""
+        """Stop the boost statistic task on unload of the Cog."""
         self.update_guild_boost.stop()
 
 

--- a/bot/cogs/stats.py
+++ b/bot/cogs/stats.py
@@ -2,8 +2,10 @@ import string
 from datetime import datetime
 
 from discord import Member, Message, Status
-from discord.ext.commands import Bot, Cog, Context
+from discord.ext.commands import Cog, Context
+from discord.ext.tasks import loop
 
+from bot.bot import Bot
 from bot.constants import Channels, Guild, Stats as StatConf
 
 
@@ -23,6 +25,7 @@ class Stats(Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
         self.last_presence_update = None
+        self.update_guild_boost.start()
 
     @Cog.listener()
     async def on_message(self, message: Message) -> None:
@@ -100,6 +103,18 @@ class Stats(Cog):
         self.bot.stats.gauge("guild.status.idle", idle)
         self.bot.stats.gauge("guild.status.do_not_disturb", dnd)
         self.bot.stats.gauge("guild.status.offline", offline)
+
+    @loop(hours=1)
+    async def update_guild_boost(self) -> None:
+        """Update every hour guild boosts amount + level."""
+        await self.bot.wait_until_guild_available()
+        g = self.bot.get_guild(Guild.id)
+        self.bot.stats.gauge("boost.amount", g.premium_subscription_count)
+        self.bot.stats.gauge("boost.tier", g.premium_tier)
+
+    def cog_unload(self) -> None:
+        """Stop guild boost stat collecting task on Cog unload."""
+        self.update_guild_boost.stop()
 
 
 def setup(bot: Bot) -> None:


### PR DESCRIPTION
Added following new statistics:
- Guild boost statistics
- Markdown code block correction
- `eval` fails and successes
- Who runs `eval`? `Helper` or `Developer`?
- Where `eval` run? Topical, help channels or bot commands

There is no public issue, but one private organization issue.