### PR TITLE
add "solved" as a alias for "closed"

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -225,7 +225,7 @@ class HelpChannels(Scheduler, commands.Cog):
 
         return role_check
 
-    @commands.command(name="close", aliases=["dormant"], enabled=False)
+    @commands.command(name="close", aliases=["dormant", "solved"], enabled=False)
     async def close_command(self, ctx: commands.Context) -> None:
         """
         Make the current in-use help channel dormant.


### PR DESCRIPTION
I have seen many users try `!solved`

So, why not add it as a command alias to make it easier for them :smile: 