### PR TITLE
Use `send_help` to ensure that our help command is correctly invoked

### DIFF
--- a/bot/cogs/bot.py
+++ b/bot/cogs/bot.py
@@ -41,7 +41,7 @@ class BotCog(Cog, name="Bot"):
     @with_role(Roles.verified)
     async def botinfo_group(self, ctx: Context) -> None:
         """Bot informational commands."""
-        await ctx.invoke(self.bot.get_command("help"), "bot")
+        await ctx.send_help("bot")
 
     @botinfo_group.command(name='about', aliases=('info',), hidden=True)
     @with_role(Roles.verified)

--- a/bot/cogs/bot.py
+++ b/bot/cogs/bot.py
@@ -41,7 +41,7 @@ class BotCog(Cog, name="Bot"):
     @with_role(Roles.verified)
     async def botinfo_group(self, ctx: Context) -> None:
         """Bot informational commands."""
-        await ctx.send_help("bot")
+        await ctx.send_help(ctx.command)
 
     @botinfo_group.command(name='about', aliases=('info',), hidden=True)
     @with_role(Roles.verified)

--- a/bot/cogs/clean.py
+++ b/bot/cogs/clean.py
@@ -180,7 +180,7 @@ class Clean(Cog):
     @with_role(*MODERATION_ROLES)
     async def clean_group(self, ctx: Context) -> None:
         """Commands for cleaning messages in channels."""
-        await ctx.invoke(self.bot.get_command("help"), "clean")
+        await ctx.send_help("clean")
 
     @clean_group.command(name="user", aliases=["users"])
     @with_role(*MODERATION_ROLES)

--- a/bot/cogs/clean.py
+++ b/bot/cogs/clean.py
@@ -180,7 +180,7 @@ class Clean(Cog):
     @with_role(*MODERATION_ROLES)
     async def clean_group(self, ctx: Context) -> None:
         """Commands for cleaning messages in channels."""
-        await ctx.send_help("clean")
+        await ctx.send_help(ctx.command)
 
     @clean_group.command(name="user", aliases=["users"])
     @with_role(*MODERATION_ROLES)

--- a/bot/cogs/defcon.py
+++ b/bot/cogs/defcon.py
@@ -122,7 +122,7 @@ class Defcon(Cog):
     @with_role(Roles.admins, Roles.owners)
     async def defcon_group(self, ctx: Context) -> None:
         """Check the DEFCON status or run a subcommand."""
-        await ctx.send_help("defcon")
+        await ctx.send_help(ctx.command)
 
     async def _defcon_action(self, ctx: Context, days: int, action: Action) -> None:
         """Providing a structured way to do an defcon action."""

--- a/bot/cogs/defcon.py
+++ b/bot/cogs/defcon.py
@@ -122,7 +122,7 @@ class Defcon(Cog):
     @with_role(Roles.admins, Roles.owners)
     async def defcon_group(self, ctx: Context) -> None:
         """Check the DEFCON status or run a subcommand."""
-        await ctx.invoke(self.bot.get_command("help"), "defcon")
+        await ctx.send_help("defcon")
 
     async def _defcon_action(self, ctx: Context, days: int, action: Action) -> None:
         """Providing a structured way to do an defcon action."""

--- a/bot/cogs/error_handler.py
+++ b/bot/cogs/error_handler.py
@@ -83,7 +83,7 @@ class ErrorHandler(Cog):
     def get_help_command(ctx: Context) -> t.Coroutine:
         """Return a prepared `help` command invocation coroutine."""
         if ctx.command:
-            return ctx.send_help(ctx.command.qualified_name)
+            return ctx.send_help(ctx.command)
 
         return ctx.send_help()
 

--- a/bot/cogs/eval.py
+++ b/bot/cogs/eval.py
@@ -178,7 +178,7 @@ async def func():  # (None,) -> Any
     async def internal_group(self, ctx: Context) -> None:
         """Internal commands. Top secret!"""
         if not ctx.invoked_subcommand:
-            await ctx.send_help("internal")
+            await ctx.send_help(ctx.command)
 
     @internal_group.command(name='eval', aliases=('e',))
     @with_role(Roles.admins, Roles.owners)

--- a/bot/cogs/eval.py
+++ b/bot/cogs/eval.py
@@ -178,7 +178,7 @@ async def func():  # (None,) -> Any
     async def internal_group(self, ctx: Context) -> None:
         """Internal commands. Top secret!"""
         if not ctx.invoked_subcommand:
-            await ctx.invoke(self.bot.get_command("help"), "internal")
+            await ctx.send_help("internal")
 
     @internal_group.command(name='eval', aliases=('e',))
     @with_role(Roles.admins, Roles.owners)

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -65,7 +65,7 @@ class Extensions(commands.Cog):
     @group(name="extensions", aliases=("ext", "exts", "c", "cogs"), invoke_without_command=True)
     async def extensions_group(self, ctx: Context) -> None:
         """Load, unload, reload, and list loaded extensions."""
-        await ctx.invoke(self.bot.get_command("help"), "extensions")
+        await ctx.send_help("extensions")
 
     @extensions_group.command(name="load", aliases=("l",))
     async def load_command(self, ctx: Context, *extensions: Extension) -> None:
@@ -75,7 +75,7 @@ class Extensions(commands.Cog):
         If '\*' or '\*\*' is given as the name, all unloaded extensions will be loaded.
         """  # noqa: W605
         if not extensions:
-            await ctx.invoke(self.bot.get_command("help"), "extensions load")
+            await ctx.send_help("extensions load")
             return
 
         if "*" in extensions or "**" in extensions:
@@ -92,7 +92,7 @@ class Extensions(commands.Cog):
         If '\*' or '\*\*' is given as the name, all loaded extensions will be unloaded.
         """  # noqa: W605
         if not extensions:
-            await ctx.invoke(self.bot.get_command("help"), "extensions unload")
+            await ctx.send_help("extensions unload")
             return
 
         blacklisted = "\n".join(UNLOAD_BLACKLIST & set(extensions))
@@ -118,7 +118,7 @@ class Extensions(commands.Cog):
         If '\*\*' is given as the name, all extensions, including unloaded ones, will be reloaded.
         """  # noqa: W605
         if not extensions:
-            await ctx.invoke(self.bot.get_command("help"), "extensions reload")
+            await ctx.send_help("extensions reload")
             return
 
         if "**" in extensions:

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -65,7 +65,7 @@ class Extensions(commands.Cog):
     @group(name="extensions", aliases=("ext", "exts", "c", "cogs"), invoke_without_command=True)
     async def extensions_group(self, ctx: Context) -> None:
         """Load, unload, reload, and list loaded extensions."""
-        await ctx.send_help("extensions")
+        await ctx.send_help(ctx.command)
 
     @extensions_group.command(name="load", aliases=("l",))
     async def load_command(self, ctx: Context, *extensions: Extension) -> None:
@@ -75,7 +75,7 @@ class Extensions(commands.Cog):
         If '\*' or '\*\*' is given as the name, all unloaded extensions will be loaded.
         """  # noqa: W605
         if not extensions:
-            await ctx.send_help("extensions load")
+            await ctx.send_help(ctx.command)
             return
 
         if "*" in extensions or "**" in extensions:
@@ -92,7 +92,7 @@ class Extensions(commands.Cog):
         If '\*' or '\*\*' is given as the name, all loaded extensions will be unloaded.
         """  # noqa: W605
         if not extensions:
-            await ctx.send_help("extensions unload")
+            await ctx.send_help(ctx.command)
             return
 
         blacklisted = "\n".join(UNLOAD_BLACKLIST & set(extensions))
@@ -118,7 +118,7 @@ class Extensions(commands.Cog):
         If '\*\*' is given as the name, all extensions, including unloaded ones, will be reloaded.
         """  # noqa: W605
         if not extensions:
-            await ctx.send_help("extensions reload")
+            await ctx.send_help(ctx.command)
             return
 
         if "**" in extensions:

--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -43,7 +43,7 @@ class ModManagement(commands.Cog):
     @commands.group(name='infraction', aliases=('infr', 'infractions', 'inf'), invoke_without_command=True)
     async def infraction_group(self, ctx: Context) -> None:
         """Infraction manipulation commands."""
-        await ctx.invoke(self.bot.get_command("help"), "infraction")
+        await ctx.send_help("infraction")
 
     @infraction_group.command(name='edit')
     async def infraction_edit(

--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -43,7 +43,7 @@ class ModManagement(commands.Cog):
     @commands.group(name='infraction', aliases=('infr', 'infractions', 'inf'), invoke_without_command=True)
     async def infraction_group(self, ctx: Context) -> None:
         """Infraction manipulation commands."""
-        await ctx.send_help("infraction")
+        await ctx.send_help(ctx.command)
 
     @infraction_group.command(name='edit')
     async def infraction_edit(

--- a/bot/cogs/off_topic_names.py
+++ b/bot/cogs/off_topic_names.py
@@ -97,7 +97,7 @@ class OffTopicNames(Cog):
     @with_role(*MODERATION_ROLES)
     async def otname_group(self, ctx: Context) -> None:
         """Add or list items from the off-topic channel name rotation."""
-        await ctx.send_help("otname")
+        await ctx.send_help(ctx.command)
 
     @otname_group.command(name='add', aliases=('a',))
     @with_role(*MODERATION_ROLES)

--- a/bot/cogs/off_topic_names.py
+++ b/bot/cogs/off_topic_names.py
@@ -97,7 +97,7 @@ class OffTopicNames(Cog):
     @with_role(*MODERATION_ROLES)
     async def otname_group(self, ctx: Context) -> None:
         """Add or list items from the off-topic channel name rotation."""
-        await ctx.invoke(self.bot.get_command("help"), "otname")
+        await ctx.send_help("otname")
 
     @otname_group.command(name='add', aliases=('a',))
     @with_role(*MODERATION_ROLES)

--- a/bot/cogs/reddit.py
+++ b/bot/cogs/reddit.py
@@ -245,7 +245,7 @@ class Reddit(Cog):
     @group(name="reddit", invoke_without_command=True)
     async def reddit_group(self, ctx: Context) -> None:
         """View the top posts from various subreddits."""
-        await ctx.send_help("reddit")
+        await ctx.send_help(ctx.command)
 
     @reddit_group.command(name="top")
     async def top_command(self, ctx: Context, subreddit: Subreddit = "r/Python") -> None:

--- a/bot/cogs/reddit.py
+++ b/bot/cogs/reddit.py
@@ -245,7 +245,7 @@ class Reddit(Cog):
     @group(name="reddit", invoke_without_command=True)
     async def reddit_group(self, ctx: Context) -> None:
         """View the top posts from various subreddits."""
-        await ctx.invoke(self.bot.get_command("help"), "reddit")
+        await ctx.send_help("reddit")
 
     @reddit_group.command(name="top")
     async def top_command(self, ctx: Context, subreddit: Subreddit = "r/Python") -> None:

--- a/bot/cogs/reminders.py
+++ b/bot/cogs/reminders.py
@@ -281,7 +281,7 @@ class Reminders(Scheduler, Cog):
     @remind_group.group(name="edit", aliases=("change", "modify"), invoke_without_command=True)
     async def edit_reminder_group(self, ctx: Context) -> None:
         """Commands for modifying your current reminders."""
-        await ctx.send_help("reminders edit")
+        await ctx.send_help(ctx.command)
 
     @edit_reminder_group.command(name="duration", aliases=("time",))
     async def edit_reminder_duration(self, ctx: Context, id_: int, expiration: Duration) -> None:

--- a/bot/cogs/reminders.py
+++ b/bot/cogs/reminders.py
@@ -281,7 +281,7 @@ class Reminders(Scheduler, Cog):
     @remind_group.group(name="edit", aliases=("change", "modify"), invoke_without_command=True)
     async def edit_reminder_group(self, ctx: Context) -> None:
         """Commands for modifying your current reminders."""
-        await ctx.invoke(self.bot.get_command("help"), "reminders", "edit")
+        await ctx.send_help("reminders edit")
 
     @edit_reminder_group.command(name="duration", aliases=("time",))
     async def edit_reminder_duration(self, ctx: Context, id_: int, expiration: Duration) -> None:

--- a/bot/cogs/site.py
+++ b/bot/cogs/site.py
@@ -21,7 +21,7 @@ class Site(Cog):
     @group(name="site", aliases=("s",), invoke_without_command=True)
     async def site_group(self, ctx: Context) -> None:
         """Commands for getting info about our website."""
-        await ctx.invoke(self.bot.get_command("help"), "site")
+        await ctx.send_help("site")
 
     @site_group.command(name="home", aliases=("about",))
     async def site_main(self, ctx: Context) -> None:

--- a/bot/cogs/site.py
+++ b/bot/cogs/site.py
@@ -21,7 +21,7 @@ class Site(Cog):
     @group(name="site", aliases=("s",), invoke_without_command=True)
     async def site_group(self, ctx: Context) -> None:
         """Commands for getting info about our website."""
-        await ctx.send_help("site")
+        await ctx.send_help(ctx.command)
 
     @site_group.command(name="home", aliases=("about",))
     async def site_main(self, ctx: Context) -> None:

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -289,7 +289,7 @@ class Snekbox(Cog):
             return
 
         if not code:  # None or empty string
-            await ctx.send_help("eval")
+            await ctx.send_help(ctx.command)
             return
 
         log.info(f"Received code from {ctx.author} for evaluation:\n{code}")

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -289,7 +289,7 @@ class Snekbox(Cog):
             return
 
         if not code:  # None or empty string
-            await ctx.invoke(self.bot.get_command("help"), "eval")
+            await ctx.send_help("eval")
             return
 
         log.info(f"Received code from {ctx.author} for evaluation:\n{code}")

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -55,7 +55,7 @@ class Utils(Cog):
         if pep_number.isdigit():
             pep_number = int(pep_number)
         else:
-            await ctx.invoke(self.bot.get_command("help"), "pep")
+            await ctx.send_help("pep")
             return
 
         # Handle PEP 0 directly because it's not in .rst or .txt so it can't be accessed like other PEPs.

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -55,7 +55,7 @@ class Utils(Cog):
         if pep_number.isdigit():
             pep_number = int(pep_number)
         else:
-            await ctx.send_help("pep")
+            await ctx.send_help(ctx.command)
             return
 
         # Handle PEP 0 directly because it's not in .rst or .txt so it can't be accessed like other PEPs.

--- a/bot/cogs/watchchannels/bigbrother.py
+++ b/bot/cogs/watchchannels/bigbrother.py
@@ -30,7 +30,7 @@ class BigBrother(WatchChannel, Cog, name="Big Brother"):
     @with_role(*MODERATION_ROLES)
     async def bigbrother_group(self, ctx: Context) -> None:
         """Monitors users by relaying their messages to the Big Brother watch channel."""
-        await ctx.send_help("bigbrother")
+        await ctx.send_help(ctx.command)
 
     @bigbrother_group.command(name='watched', aliases=('all', 'list'))
     @with_role(*MODERATION_ROLES)

--- a/bot/cogs/watchchannels/bigbrother.py
+++ b/bot/cogs/watchchannels/bigbrother.py
@@ -30,7 +30,7 @@ class BigBrother(WatchChannel, Cog, name="Big Brother"):
     @with_role(*MODERATION_ROLES)
     async def bigbrother_group(self, ctx: Context) -> None:
         """Monitors users by relaying their messages to the Big Brother watch channel."""
-        await ctx.invoke(self.bot.get_command("help"), "bigbrother")
+        await ctx.send_help("bigbrother")
 
     @bigbrother_group.command(name='watched', aliases=('all', 'list'))
     @with_role(*MODERATION_ROLES)

--- a/bot/cogs/watchchannels/talentpool.py
+++ b/bot/cogs/watchchannels/talentpool.py
@@ -34,7 +34,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
     @with_role(*MODERATION_ROLES)
     async def nomination_group(self, ctx: Context) -> None:
         """Highlights the activity of helper nominees by relaying their messages to the talent pool channel."""
-        await ctx.send_help("talentpool")
+        await ctx.send_help(ctx.command)
 
     @nomination_group.command(name='watched', aliases=('all', 'list'))
     @with_role(*MODERATION_ROLES)
@@ -173,7 +173,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
     @with_role(*MODERATION_ROLES)
     async def nomination_edit_group(self, ctx: Context) -> None:
         """Commands to edit nominations."""
-        await ctx.send_help("talentpool edit")
+        await ctx.send_help(ctx.command)
 
     @nomination_edit_group.command(name='reason')
     @with_role(*MODERATION_ROLES)

--- a/bot/cogs/watchchannels/talentpool.py
+++ b/bot/cogs/watchchannels/talentpool.py
@@ -34,7 +34,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
     @with_role(*MODERATION_ROLES)
     async def nomination_group(self, ctx: Context) -> None:
         """Highlights the activity of helper nominees by relaying their messages to the talent pool channel."""
-        await ctx.invoke(self.bot.get_command("help"), "talentpool")
+        await ctx.send_help("talentpool")
 
     @nomination_group.command(name='watched', aliases=('all', 'list'))
     @with_role(*MODERATION_ROLES)
@@ -173,7 +173,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
     @with_role(*MODERATION_ROLES)
     async def nomination_edit_group(self, ctx: Context) -> None:
         """Commands to edit nominations."""
-        await ctx.invoke(self.bot.get_command("help"), "talentpool", "edit")
+        await ctx.send_help("talentpool edit")
 
     @nomination_edit_group.command(name='reason')
     @with_role(*MODERATION_ROLES)

--- a/tests/bot/cogs/test_snekbox.py
+++ b/tests/bot/cogs/test_snekbox.py
@@ -209,9 +209,8 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
     async def test_eval_command_call_help(self):
         """Test if the eval command call the help command if no code is provided."""
         ctx = MockContext()
-        ctx.invoke = AsyncMock()
         await self.cog.eval_command.callback(self.cog, ctx=ctx, code='')
-        ctx.invoke.assert_called_once_with(self.bot.get_command("help"), "eval")
+        ctx.send_help.assert_called_once_with("eval")
 
     async def test_send_eval(self):
         """Test the send_eval function."""

--- a/tests/bot/cogs/test_snekbox.py
+++ b/tests/bot/cogs/test_snekbox.py
@@ -208,9 +208,9 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_eval_command_call_help(self):
         """Test if the eval command call the help command if no code is provided."""
-        ctx = MockContext()
+        ctx = MockContext(command="sentinel")
         await self.cog.eval_command.callback(self.cog, ctx=ctx, code='')
-        ctx.send_help.assert_called_once_with("eval")
+        ctx.send_help.assert_called_once_with("sentinel")
 
     async def test_send_eval(self):
         """Test the send_eval function."""


### PR DESCRIPTION
Currently, we're invoking our help command manually like this:

```py
await ctx.invoke(self.bot.get_command("help"), "bot")
```

However, unfortunately, this fails when the command callback function is decorated, leading to exceptions like:

```py
AttributeError: 'Help' object has no attribute 'channel'
  File "discord/ext/commands/core.py", line 83, in wrapped
    ret = await coro(*args, **kwargs)
  File "bot/cogs/snekbox.py", line 292, in eval_command
    await ctx.invoke(self.bot.get_command("help"), "eval")
  File "discord/ext/commands/context.py", line 132, in invoke
    ret = await command.callback(*arguments, **kwargs)
  File "bot/decorators.py", line 149, in inner
    if ctx.channel.id == destination_channel:

Error executing command invoked by <>: !e
```
See Sentry issue: [BOT-4T](https://sentry.io/organizations/python-discord/issues/1670955136/?referrer=github_integration)

The solution is to use the way of invoking the help command built built into `discord.py`: `ctx.send_help`, as the recent refactoring of the help command made our custom help command compatible with that `Context` method.