### PR TITLE
Allow commands in #seasonalbot-commands

### DIFF
--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -331,7 +331,10 @@ class Information(Cog):
 
     @cooldown_with_role_bypass(2, 60 * 3, BucketType.member, bypass_roles=constants.STAFF_ROLES)
     @group(invoke_without_command=True)
-    @in_whitelist(channels=(constants.Channels.bot_commands,), roles=constants.STAFF_ROLES)
+    @in_whitelist(
+        channels=(constants.Channels.bot_commands, constants.Channels.seasonalbot_commands),
+        roles=constants.STAFF_ROLES
+    )
     async def raw(self, ctx: Context, *, message: Message, json: bool = False) -> None:
         """Shows information about the raw API response."""
         # I *guess* it could be deleted right as the command is invoked but I felt like it wasn't worth handling

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -40,7 +40,7 @@ RAW_CODE_REGEX = re.compile(
 MAX_PASTE_LEN = 1000
 
 # `!eval` command whitelists
-EVAL_CHANNELS = (Channels.bot_commands, Channels.esoteric)
+EVAL_CHANNELS = (Channels.bot_commands, Channels.seasonalbot_commands, Channels.esoteric)
 EVAL_CATEGORIES = (Categories.help_available, Categories.help_in_use)
 EVAL_ROLES = (Roles.helpers, Roles.moderators, Roles.admins, Roles.owners, Roles.python_community, Roles.partners)
 

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -115,7 +115,7 @@ class Utils(Cog):
         await ctx.message.channel.send(embed=pep_embed)
 
     @command()
-    @in_whitelist(channels=(Channels.bot_commands,), roles=STAFF_ROLES)
+    @in_whitelist(channels=(Channels.bot_commands, Channels.seasonalbot_commands), roles=STAFF_ROLES)
     async def charinfo(self, ctx: Context, *, characters: str) -> None:
         """Shows you information on up to 25 unicode characters."""
         match = re.match(r"<(a?):(\w+):(\d+)>", characters)

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -396,6 +396,7 @@ class Channels(metaclass=YAMLGetter):
     organisation: int
     python_discussion: int
     reddit: int
+    seasonalbot_commands: int
     talent_pool: int
     user_event_announcements: int
     user_log: int

--- a/config-default.yml
+++ b/config-default.yml
@@ -149,10 +149,11 @@ guild:
         off_topic_2:    463035268514185226
 
         # Special
-        bot_commands:       &BOT_CMD        267659945086812160
-        esoteric:                           470884583684964352
-        reddit:                             458224812528238616
-        verification:                       352442727016693763
+        bot_commands:         &BOT_CMD        267659945086812160
+        seasonalbot_commands: &SBOT_CMD       607247579608121354
+        esoteric:                             470884583684964352
+        reddit:                               458224812528238616
+        verification:                         352442727016693763
 
         # Staff
         admins:             &ADMINS         365960823622991872
@@ -200,6 +201,7 @@ guild:
 
     reminder_whitelist:
         - *BOT_CMD
+        - *SBOT_CMD
         - *DEV_CONTRIB
 
     roles:


### PR DESCRIPTION
While chatting in #seasonalbot-commands yesterday, I tried to set a reminder to open an issue about the bot, but this channel is marked as allowed in the bot code. This PR allows commands to be executed everywhere #bot-commands was already allowed. 