### PR TITLE
Help System: Move dormant faster if help channel is empty

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -468,7 +468,7 @@ class HelpChannels(Scheduler, commands.Cog):
         """
         log.trace(f"Handling in-use channel #{channel} ({channel.id}).")
 
-        if not self.is_empty(channel):
+        if not await self.is_empty(channel):
             idle_seconds = constants.HelpChannels.idle_minutes * 60
         else:
             idle_seconds = constants.HelpChannels.deleted_idle_minutes * 60
@@ -731,7 +731,10 @@ class HelpChannels(Scheduler, commands.Cog):
 
         The new time for the dormant task is configured with `HelpChannels.deleted_idle_minutes`.
         """
-        if not self.is_in_category(msg.channel, constants.Categories.help_in_use) or not self.is_empty(msg.channel):
+        if not self.is_in_category(msg.channel, constants.Categories.help_in_use):
+            return
+
+        if not await self.is_empty(msg.channel):
             return
 
         log.info(f"Claimant of #{msg.channel} ({msg.author}) deleted message, channel is empty now. Rescheduling task.")

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -440,14 +440,11 @@ class HelpChannels(Scheduler, commands.Cog):
 
     def is_dormant_message(self, message: t.Optional[discord.Message]) -> bool:
         """Return True if the contents of the `message` match `DORMANT_MSG`."""
-        if not message:
-            return False
-
         return self.match_bot_embed(message, DORMANT_MSG)
 
-    def match_bot_embed(self, message: discord.Message, description: str) -> bool:
+    def match_bot_embed(self, message: t.Optional[discord.Message], description: str) -> bool:
         """Return `True` if the bot's `message`'s embed description matches `description`."""
-        if not message.embeds:
+        if not message or not message.embeds:
             return False
 
         embed = message.embeds[0]
@@ -748,9 +745,6 @@ class HelpChannels(Scheduler, commands.Cog):
     async def is_empty(self, channel: discord.TextChannel) -> bool:
         """Return True if the most recent message in `channel` is the bot's `AVAILABLE_MSG`."""
         msg = await self.get_last_message(channel)
-        if not msg:
-            return False
-
         return self.match_bot_embed(msg, AVAILABLE_MSG)
 
     async def reset_send_permissions(self) -> None:

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -438,10 +438,6 @@ class HelpChannels(Scheduler, commands.Cog):
         """Return True if `member` has the 'Help Cooldown' role."""
         return any(constants.Roles.help_cooldown == role.id for role in member.roles)
 
-    def is_dormant_message(self, message: t.Optional[discord.Message]) -> bool:
-        """Return True if the contents of the `message` match `DORMANT_MSG`."""
-        return self.match_bot_embed(message, DORMANT_MSG)
-
     def match_bot_embed(self, message: t.Optional[discord.Message], description: str) -> bool:
         """Return `True` if the bot's `message`'s embed description matches `description`."""
         if not message or not message.embeds:
@@ -822,7 +818,7 @@ class HelpChannels(Scheduler, commands.Cog):
         embed = discord.Embed(description=AVAILABLE_MSG)
 
         msg = await self.get_last_message(channel)
-        if self.is_dormant_message(msg):
+        if self.match_bot_embed(msg, DORMANT_MSG):
             log.trace(f"Found dormant message {msg.id} in {channel_info}; editing it.")
             await msg.edit(embed=embed)
         else:

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -440,11 +440,18 @@ class HelpChannels(Scheduler, commands.Cog):
 
     def is_dormant_message(self, message: t.Optional[discord.Message]) -> bool:
         """Return True if the contents of the `message` match `DORMANT_MSG`."""
-        if not message or not message.embeds:
+        if not message:
+            return False
+
+        return self.embed_description_match(message, DORMANT_MSG)
+
+    def embed_description_match(self, message: discord.Message, text: str) -> bool:
+        """Return `True` if `message` embed description match with `text`."""
+        if not message.embeds:
             return False
 
         embed = message.embeds[0]
-        return message.author == self.bot.user and embed.description.strip() == DORMANT_MSG.strip()
+        return message.author == self.bot.user and embed.description.strip() == text.strip()
 
     @staticmethod
     def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:
@@ -722,7 +729,7 @@ class HelpChannels(Scheduler, commands.Cog):
         """
         Reschedule an in-use channel to become dormant sooner if the channel is empty.
 
-        The new time for the dormant task is configured with `HelpChannels.deleted_idle_minutes`. 
+        The new time for the dormant task is configured with `HelpChannels.deleted_idle_minutes`.
         """
         if not self.is_in_category(msg.channel, constants.Categories.help_in_use) or not self.is_empty(msg.channel):
             return
@@ -738,14 +745,10 @@ class HelpChannels(Scheduler, commands.Cog):
     async def is_empty(self, channel: discord.TextChannel) -> bool:
         """Return True if the most recent message in `channel` is the bot's `AVAILABLE_MSG`."""
         msg = await self.get_last_message(channel)
-        if not msg or not msg.author.bot or not msg.embeds:
+        if not msg:
             return False
 
-        embed = msg.embeds[0]
-        if embed.description == AVAILABLE_MSG:
-            return True
-        else:
-            return False
+        return self.embed_description_match(msg, AVAILABLE_MSG)
 
     async def reset_send_permissions(self) -> None:
         """Reset send permissions in the Available category for claimants."""

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -719,7 +719,11 @@ class HelpChannels(Scheduler, commands.Cog):
 
     @commands.Cog.listener()
     async def on_message_delete(self, msg: discord.Message) -> None:
-        """Reschedule dormant when help channel is empty."""
+        """
+        Reschedule an in-use channel to become dormant sooner if the channel is empty.
+
+        The new time for the dormant task is configured with `HelpChannels.deleted_idle_minutes`. 
+        """
         if not self.is_in_category(msg.channel, constants.Categories.help_in_use) or not self.is_empty(msg.channel):
             return
 
@@ -732,7 +736,7 @@ class HelpChannels(Scheduler, commands.Cog):
         self.schedule_task(msg.channel.id, task)
 
     async def is_empty(self, channel: discord.TextChannel) -> bool:
-        """Check is last message bot sent available message."""
+        """Return True if the most recent message in `channel` is the bot's `AVAILABLE_MSG`."""
         msg = await self.get_last_message(channel)
         if not msg or not msg.author.bot or not msg.embeds:
             return False

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -443,15 +443,15 @@ class HelpChannels(Scheduler, commands.Cog):
         if not message:
             return False
 
-        return self.embed_description_match(message, DORMANT_MSG)
+        return self.match_bot_embed(message, DORMANT_MSG)
 
-    def embed_description_match(self, message: discord.Message, text: str) -> bool:
-        """Return `True` if `message` embed description match with `text`."""
+    def match_bot_embed(self, message: discord.Message, description: str) -> bool:
+        """Return `True` if the bot's `message`'s embed description matches `description`."""
         if not message.embeds:
             return False
 
         embed = message.embeds[0]
-        return message.author == self.bot.user and embed.description.strip() == text.strip()
+        return message.author == self.bot.user and embed.description.strip() == description.strip()
 
     @staticmethod
     def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:
@@ -751,7 +751,7 @@ class HelpChannels(Scheduler, commands.Cog):
         if not msg:
             return False
 
-        return self.embed_description_match(msg, AVAILABLE_MSG)
+        return self.match_bot_embed(msg, AVAILABLE_MSG)
 
     async def reset_send_permissions(self) -> None:
         """Reset send permissions in the Available category for claimants."""

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -541,6 +541,7 @@ class HelpChannels(metaclass=YAMLGetter):
     claim_minutes: int
     cmd_whitelist: List[int]
     idle_minutes: int
+    deleted_idle_minutes: int
     max_available: int
     max_total_channels: int
     name_prefix: str

--- a/config-default.yml
+++ b/config-default.yml
@@ -529,6 +529,10 @@ help_channels:
     # Allowed duration of inactivity before making a channel dormant
     idle_minutes: 30
 
+    # Allowed duration of inactivity when question message deleted
+    # and no one other sent before message making channel dormant.
+    deleted_idle_minutes: 5
+
     # Maximum number of channels to put in the available category
     max_available: 2
 


### PR DESCRIPTION
Closes #939 

- Implemented `on_message_delete`, that reschedule a task, when `is_empty` return `True` and channel is inside `help in-use` category. 
- `move_idle_channel` check, is channel empty and when it is, this uses correct (shorter) `idle_seconds`.
- `is_empty` request last message and then check, is this bot available message.