### PR TITLE
Ignore response when posting python news

### DIFF
--- a/bot/cogs/python_news.py
+++ b/bot/cogs/python_news.py
@@ -153,6 +153,7 @@ class PythonNews(Cog):
 
                 if (
                         thread_information["thread_id"] in existing_news["data"][maillist]
+                        or 'Re: ' in thread_information["subject"]
                         or new_date.date() < date.today()
                 ):
                     continue


### PR DESCRIPTION
Sometimes a mailing list user doesn't press respond correctly to the email, and so a response is sent as a separate thread. To keep only new threads in the channel, we need to ignore those.