### PR TITLE
Remove status emojis from help channels to prevent us from hitting rate limits

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -660,10 +660,13 @@ class HelpChannels(Scheduler, commands.Cog):
 
             # Check if there is an entry in unanswered (does not persist across restarts)
             if channel.id in self.unanswered:
-                claimant_id = self.help_channel_claimants[channel].id
+                claimant = self.help_channel_claimants.get(channel)
+                if not claimant:
+                    # The mapping for this channel was lost, we can't do anything.
+                    return
 
                 # Check the message did not come from the claimant
-                if claimant_id != message.author.id:
+                if claimant.id != message.author.id:
                     # Mark the channel as answered
                     self.unanswered[channel.id] = False
 


### PR DESCRIPTION
Discord has introduced new, strict rate limits for editing the names and topics of individual channels: You may only change the topic/name twice per 10 minutes per channel. 

Unfortunately, our help channel system frequently goes over that rate limit as it edits the name and topic of a channel on all three "move" actions we have: to available, to occupied, and to dormant. In addition, our "unanswered" feature adds another channel name change on top of the move-related edits.

That's why I've removed the topic/emoji changing features from the help channel system. This means we now have a generic topic that fits all three categories and no status emojis in the channel names.

**Note:** The `get_clean_channel_name` method has been left in place, but can be removed once we've ensures that all the help channels have "clean" names without emojis. We can't really do this beforehand, as the bot keeps adding them until this change is merged.