### PR TITLE
Add staff counts to !server

### DIFF
--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -104,8 +104,27 @@ class Information(Cog):
         member_count = ctx.guild.member_count
 
         # How many of each type of channel?
-        channels = Counter(c.type for c in ctx.guild.channels)
-        channel_counts = "".join(sorted(f"{str(ch).title()} channels: {channels[ch]}\n" for ch in channels)).strip()
+        channel_counter = Counter(c.type for c in ctx.guild.channels)
+        channel_type_list = []
+        for channel in channel_counter:
+            channel_type = str(channel).title()
+            channel_type_list.append(f"{channel_type} channels: {channel_counter[channel]}")
+
+        channel_type_list = sorted(channel_type_list)
+        channel_counts = "\n".join(channel_type_list).strip()
+
+        # How many channels are for staff only?
+        everyone_role = ctx.guild.roles[0]
+        hidden_channels = 0
+
+        for channel in ctx.guild.channels:
+            overwrites = channel.overwrites_for(everyone_role)
+            if overwrites.is_empty():
+                continue
+
+            for perm, value in overwrites:
+                if perm == 'read_messages' and value is False:
+                    hidden_channels += 1
 
         # How many of each user status?
         statuses = Counter(member.status for member in ctx.guild.members)
@@ -126,6 +145,7 @@ class Information(Cog):
                 Members: {member_count:,}
                 Roles: {roles}
                 $channel_counts
+                Staff channels: {hidden_channels}
 
                 **Members**
                 {constants.Emojis.status_online} {statuses[Status.online]:,}

--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -130,6 +130,9 @@ class Information(Cog):
         statuses = Counter(member.status for member in ctx.guild.members)
         embed = Embed(colour=Colour.blurple())
 
+        # How many staff members?
+        staff_members = len(ctx.guild.get_role(constants.Roles.helpers).members)
+
         # Because channel_counts lacks leading whitespace, it breaks the dedent if it's inserted directly by the
         # f-string. While this is correctly formated by Discord, it makes unit testing difficult. To keep the formatting
         # without joining a tuple of strings we can use a Template string to insert the already-formatted channel_counts
@@ -141,13 +144,16 @@ class Information(Cog):
                 Voice region: {region}
                 Features: {features}
 
-                **Counts**
-                Members: {member_count:,}
-                Roles: {roles}
+                **Channel counts**
                 $channel_counts
                 Staff channels: {hidden_channels}
 
-                **Members**
+                **Member counts**
+                Members: {member_count:,}
+                Staff members: {staff_members}
+                Roles: {roles}
+
+                **Member statuses**
                 {constants.Emojis.status_online} {statuses[Status.online]:,}
                 {constants.Emojis.status_idle} {statuses[Status.idle]:,}
                 {constants.Emojis.status_dnd} {statuses[Status.dnd]:,}

--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -60,6 +60,18 @@ class Information(Cog):
 
         return len(channel_ids)
 
+    @staticmethod
+    def get_channel_type_counts(guild: Guild) -> str:
+        """Return the total amounts of the various types of channels in `guild`."""
+        channel_counter = Counter(c.type for c in guild.channels)
+        channel_type_list = []
+        for channel in channel_counter:
+            channel_type = str(channel).title()
+            channel_type_list.append(f"{channel_type} channels: {channel_counter[channel]}")
+
+        channel_type_list = sorted(channel_type_list)
+        return "\n".join(channel_type_list).strip()
+
     @with_role(*constants.MODERATION_ROLES)
     @command(name="roles")
     async def roles_info(self, ctx: Context) -> None:
@@ -136,16 +148,7 @@ class Information(Cog):
 
         roles = len(ctx.guild.roles)
         member_count = ctx.guild.member_count
-
-        # How many of each type of channel?
-        channel_counter = Counter(c.type for c in ctx.guild.channels)
-        channel_type_list = []
-        for channel in channel_counter:
-            channel_type = str(channel).title()
-            channel_type_list.append(f"{channel_type} channels: {channel_counter[channel]}")
-
-        channel_type_list = sorted(channel_type_list)
-        channel_counts = "\n".join(channel_type_list).strip()
+        channel_counts = self.get_channel_type_counts(ctx.guild)
 
         # How many of each user status?
         statuses = Counter(member.status for member in ctx.guild.members)

--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -80,7 +80,7 @@ class Information(Cog):
         ])
 
         # Now we need to check which channels are both denied for @everyone and permitted for staff
-        staff_channels = set(cid for cid in everyone_denied if cid in staff_allowed)
+        staff_channels = set(cid for cid in staff_allowed if cid in everyone_denied)
         return len(staff_channels)
 
     @with_role(*constants.MODERATION_ROLES)
@@ -176,7 +176,7 @@ class Information(Cog):
 
         # How many staff members and staff channels do we have?
         staff_member_count = len(ctx.guild.get_role(constants.Roles.helpers).members)
-        staff_channel_count = self._get_staff_channel_count()
+        staff_channel_count = self._get_staff_channel_count(ctx)
 
         # Because channel_counts lacks leading whitespace, it breaks the dedent if it's inserted directly by the
         # f-string. While this is correctly formated by Discord, it makes unit testing difficult. To keep the formatting

--- a/bot/cogs/information.py
+++ b/bot/cogs/information.py
@@ -48,15 +48,13 @@ class Information(Cog):
             if channel.type is ChannelType.category:
                 continue
 
-            if channel in channel_ids:
-                continue  # Only one of the roles has to have read permissions, not all
-
             everyone_can_read = self.role_can_read(channel, guild.default_role)
 
             for role in constants.STAFF_ROLES:
                 role_can_read = self.role_can_read(channel, guild.get_role(role))
-                if role_can_read and everyone_can_read is False:
+                if role_can_read and not everyone_can_read:
                     channel_ids.add(channel.id)
+                    break
 
         return len(channel_ids)
 
@@ -65,12 +63,12 @@ class Information(Cog):
         """Return the total amounts of the various types of channels in `guild`."""
         channel_counter = Counter(c.type for c in guild.channels)
         channel_type_list = []
-        for channel in channel_counter:
+        for channel, count in channel_counter.items():
             channel_type = str(channel).title()
-            channel_type_list.append(f"{channel_type} channels: {channel_counter[channel]}")
+            channel_type_list.append(f"{channel_type} channels: {count}")
 
         channel_type_list = sorted(channel_type_list)
-        return "\n".join(channel_type_list).strip()
+        return "\n".join(channel_type_list)
 
     @with_role(*constants.MODERATION_ROLES)
     @command(name="roles")

--- a/tests/bot/cogs/test_information.py
+++ b/tests/bot/cogs/test_information.py
@@ -148,14 +148,18 @@ class InformationCogTests(unittest.TestCase):
                 Voice region: {self.ctx.guild.region}
                 Features: {', '.join(self.ctx.guild.features)}
 
-                **Counts**
-                Members: {self.ctx.guild.member_count:,}
-                Roles: {len(self.ctx.guild.roles)}
+                **Channel counts**
                 Category channels: 1
                 Text channels: 1
                 Voice channels: 1
+                Staff channels: 0
 
-                **Members**
+                **Member counts**
+                Members: {self.ctx.guild.member_count:,}
+                Staff members: 0
+                Roles: {len(self.ctx.guild.roles)}
+
+                **Member statuses**
                 {constants.Emojis.status_online} 2
                 {constants.Emojis.status_idle} 1
                 {constants.Emojis.status_dnd} 4


### PR DESCRIPTION
A small change to add number of staff channels and number of staff members to !server. These are nice numbers to track, and may be interesting for everyone.

![image](https://user-images.githubusercontent.com/2098517/83309221-ff024b80-a208-11ea-9a15-49d3446582b2.png)

Closes #969