### PR TITLE
Specify encoding when reading tag files

### DIFF
--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -44,7 +44,7 @@ class Tags(Cog):
                 tag = {
                     "title": tag_title,
                     "embed": {
-                        "description": file.read_text(),
+                        "description": file.read_text(encoding="utf8"),
                     },
                     "restricted_to": "developers",
                 }


### PR DESCRIPTION
Re-adds the change from #875 that got overwritten by #866 when it was marged, causing the bot to crash on windows at startup.