### PR TITLE
Link #how-to-get-help in !free tag

### DIFF
--- a/bot/resources/tags/free.md
+++ b/bot/resources/tags/free.md
@@ -1,5 +1,5 @@
 **We have a new help channel system!**
 
-We recently moved to a new help channel system. You can now use any channel in the **<#691405807388196926>** category to ask your question.
+Please see <#704250143020417084> for further information.
 
-For more information, check out [our website](https://pythondiscord.com/pages/resources/guides/help-channels/).
+A more detailed guide can be found on [our website](https://pythondiscord.com/pages/resources/guides/help-channels/).


### PR DESCRIPTION
Previously, the tag was referencing the `Available` category. We now have a dedicated read-only channel with instructions, and it makes more sense to link the channel directly.

There is a considerable benefit in the fact that this link is now clickable.

![image](https://user-images.githubusercontent.com/44734341/83337286-590f1980-a2ba-11ea-9c88-2f99dfc59b0e.png)

I considered leaving an extra sentence also referencing the category as before, but I felt like it only led to unnecessary noise. The website link sentence was updated to avoid repetition and to flow better.

Close #960