### PR TITLE
Add multichannel !purge

### DIFF
--- a/bot/cogs/clean.py
+++ b/bot/cogs/clean.py
@@ -46,7 +46,6 @@ class Clean(Cog):
         bots_only: bool = False,
         user: User = None,
         regex: Optional[str] = None,
-
     ) -> None:
         """A helper function that does the actual message cleaning."""
         def predicate_bots_only(message: Message) -> bool:

--- a/bot/cogs/clean.py
+++ b/bot/cogs/clean.py
@@ -166,10 +166,8 @@ class Clean(Cog):
             return
 
         # Build the embed and send it
-        if len(channels) > 1:
-            target_channels = ", ".join(channel.mention for channel in channels)
-        else:
-            target_channels = f"<#{channels[0].id}>"
+        target_channels = ", ".join(channel.mention for channel in channels)
+
         message = (
             f"**{len(message_ids)}** messages deleted in {target_channels} by **{ctx.author.name}**\n\n"
             f"A log of the deleted messages can be found [here]({log_url})."

--- a/bot/cogs/clean.py
+++ b/bot/cogs/clean.py
@@ -167,7 +167,7 @@ class Clean(Cog):
 
         # Build the embed and send it
         if len(channels) > 1:
-            target_channels = ", ".join([f"<#{channel.id}>" for channel in channels])
+            target_channels = ", ".join(channel.mention for channel in channels)
         else:
             target_channels = f"<#{channels[0].id}>"
         message = (

--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -3,6 +3,7 @@ import difflib
 import itertools
 import logging
 import typing as t
+from contextlib import contextmanager
 from datetime import datetime
 from itertools import zip_longest
 
@@ -40,6 +41,7 @@ class ModLog(Cog, name="ModLog"):
     def __init__(self, bot: Bot):
         self.bot = bot
         self._ignored = {event: [] for event in Event}
+        self._ignore_all = False
 
         self._cached_deletes = []
         self._cached_edits = []
@@ -80,6 +82,15 @@ class ModLog(Cog, name="ModLog"):
         for item in items:
             if item not in self._ignored[event]:
                 self._ignored[event].append(item)
+
+    @contextmanager
+    def ignore_all(self) -> None:
+        """Ignore all events while inside this context scope."""
+        self._ignore_all = True
+        try:
+            yield
+        finally:
+            self._ignore_all = False
 
     async def send_log_message(
         self,
@@ -189,6 +200,9 @@ class ModLog(Cog, name="ModLog"):
 
         if before.id in self._ignored[Event.guild_channel_update]:
             self._ignored[Event.guild_channel_update].remove(before.id)
+            return
+
+        if self._ignore_all:
             return
 
         # Two channel updates are sent for a single edit: 1 for topic and 1 for category change.
@@ -386,6 +400,9 @@ class ModLog(Cog, name="ModLog"):
             self._ignored[Event.member_ban].remove(member.id)
             return
 
+        if self._ignore_all:
+            return
+
         await self.send_log_message(
             Icons.user_ban, Colours.soft_red,
             "User banned", f"{member} (`{member.id}`)",
@@ -426,6 +443,9 @@ class ModLog(Cog, name="ModLog"):
             self._ignored[Event.member_remove].remove(member.id)
             return
 
+        if self._ignore_all:
+            return
+
         member_str = escape_markdown(str(member))
         await self.send_log_message(
             Icons.sign_out, Colours.soft_red,
@@ -444,6 +464,9 @@ class ModLog(Cog, name="ModLog"):
             self._ignored[Event.member_unban].remove(member.id)
             return
 
+        if self._ignore_all:
+            return
+
         member_str = escape_markdown(str(member))
         await self.send_log_message(
             Icons.user_unban, Colour.blurple(),
@@ -460,6 +483,9 @@ class ModLog(Cog, name="ModLog"):
 
         if before.id in self._ignored[Event.member_update]:
             self._ignored[Event.member_update].remove(before.id)
+            return
+
+        if self._ignore_all:
             return
 
         diff = DeepDiff(before, after)
@@ -564,6 +590,9 @@ class ModLog(Cog, name="ModLog"):
             self._ignored[Event.message_delete].remove(message.id)
             return
 
+        if self._ignore_all:
+            return
+
         if author.bot:
             return
 
@@ -621,6 +650,9 @@ class ModLog(Cog, name="ModLog"):
 
         if event.message_id in self._ignored[Event.message_delete]:
             self._ignored[Event.message_delete].remove(event.message_id)
+            return
+
+        if self._ignore_all:
             return
 
         channel = self.bot.get_channel(event.channel_id)
@@ -795,6 +827,9 @@ class ModLog(Cog, name="ModLog"):
 
         if member.id in self._ignored[Event.voice_state_update]:
             self._ignored[Event.voice_state_update].remove(member.id)
+            return
+
+        if self._ignore_all:
             return
 
         # Exclude all channel attributes except the name.

--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -3,7 +3,6 @@ import difflib
 import itertools
 import logging
 import typing as t
-from contextlib import contextmanager
 from datetime import datetime
 from itertools import zip_longest
 
@@ -41,7 +40,6 @@ class ModLog(Cog, name="ModLog"):
     def __init__(self, bot: Bot):
         self.bot = bot
         self._ignored = {event: [] for event in Event}
-        self._ignore_all = False
 
         self._cached_deletes = []
         self._cached_edits = []
@@ -82,15 +80,6 @@ class ModLog(Cog, name="ModLog"):
         for item in items:
             if item not in self._ignored[event]:
                 self._ignored[event].append(item)
-
-    @contextmanager
-    def ignore_all(self) -> None:
-        """Ignore all events while inside this context scope."""
-        self._ignore_all = True
-        try:
-            yield
-        finally:
-            self._ignore_all = False
 
     async def send_log_message(
         self,
@@ -200,9 +189,6 @@ class ModLog(Cog, name="ModLog"):
 
         if before.id in self._ignored[Event.guild_channel_update]:
             self._ignored[Event.guild_channel_update].remove(before.id)
-            return
-
-        if self._ignore_all:
             return
 
         # Two channel updates are sent for a single edit: 1 for topic and 1 for category change.
@@ -400,9 +386,6 @@ class ModLog(Cog, name="ModLog"):
             self._ignored[Event.member_ban].remove(member.id)
             return
 
-        if self._ignore_all:
-            return
-
         await self.send_log_message(
             Icons.user_ban, Colours.soft_red,
             "User banned", f"{member} (`{member.id}`)",
@@ -443,9 +426,6 @@ class ModLog(Cog, name="ModLog"):
             self._ignored[Event.member_remove].remove(member.id)
             return
 
-        if self._ignore_all:
-            return
-
         member_str = escape_markdown(str(member))
         await self.send_log_message(
             Icons.sign_out, Colours.soft_red,
@@ -464,9 +444,6 @@ class ModLog(Cog, name="ModLog"):
             self._ignored[Event.member_unban].remove(member.id)
             return
 
-        if self._ignore_all:
-            return
-
         member_str = escape_markdown(str(member))
         await self.send_log_message(
             Icons.user_unban, Colour.blurple(),
@@ -483,9 +460,6 @@ class ModLog(Cog, name="ModLog"):
 
         if before.id in self._ignored[Event.member_update]:
             self._ignored[Event.member_update].remove(before.id)
-            return
-
-        if self._ignore_all:
             return
 
         diff = DeepDiff(before, after)
@@ -590,9 +564,6 @@ class ModLog(Cog, name="ModLog"):
             self._ignored[Event.message_delete].remove(message.id)
             return
 
-        if self._ignore_all:
-            return
-
         if author.bot:
             return
 
@@ -650,9 +621,6 @@ class ModLog(Cog, name="ModLog"):
 
         if event.message_id in self._ignored[Event.message_delete]:
             self._ignored[Event.message_delete].remove(event.message_id)
-            return
-
-        if self._ignore_all:
             return
 
         channel = self.bot.get_channel(event.channel_id)
@@ -827,9 +795,6 @@ class ModLog(Cog, name="ModLog"):
 
         if member.id in self._ignored[Event.voice_state_update]:
             self._ignored[Event.voice_state_update].remove(member.id)
-            return
-
-        if self._ignore_all:
             return
 
         # Exclude all channel attributes except the name.


### PR DESCRIPTION
We can now pass in as many channel mentions as we want after any !purge command - for example `!purge all 5 #python-general #python-language`

Closes #968.