### PR TITLE
Use Scheduler instead of asyncio.sleep on silence cog

### DIFF
--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -5,16 +5,16 @@ from collections import namedtuple
 from contextlib import suppress
 from typing import Optional
 
+from discord import TextChannel
+from discord.ext import commands, tasks
+from discord.ext.commands import Context
+
 from bot.bot import Bot
 from bot.constants import Channels, Emojis, Guild, MODERATION_ROLES, Roles
 from bot.converters import HushDurationConverter
 from bot.utils import time
 from bot.utils.checks import with_role_check
 from bot.utils.scheduling import Scheduler
-
-from discord import TextChannel
-from discord.ext import commands, tasks
-from discord.ext.commands import Context
 
 log = logging.getLogger(__name__)
 

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -161,8 +161,8 @@ class Silence(Scheduler, commands.Cog):
         if current_overwrite.send_messages is False:
             await channel.set_permissions(self._verified_role, **dict(current_overwrite, send_messages=None))
             log.info(f"Unsilenced channel #{channel} ({channel.id}).")
-            self.notifier.remove_channel(channel)
             self.cancel_task(channel.id)
+            self.notifier.remove_channel(channel)
             self.muted_channels.discard(channel)
             return True
         log.info(f"Tried to unsilence channel #{channel} ({channel.id}) but the channel was not silenced.")

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -6,11 +6,12 @@ from contextlib import suppress
 from typing import Optional
 
 from bot.bot import Bot
-from bot.constants import MODERATION_ROLES, Channels, Emojis, Guild, Roles
+from bot.constants import Channels, Emojis, Guild, MODERATION_ROLES, Roles
 from bot.converters import HushDurationConverter
 from bot.utils import time
 from bot.utils.checks import with_role_check
 from bot.utils.scheduling import Scheduler
+
 from discord import TextChannel
 from discord.ext import commands, tasks
 from discord.ext.commands import Context
@@ -23,7 +24,7 @@ SilencedChannel = namedtuple(
 
 
 class UnsilenceScheduler(Scheduler):
-    """Scheduler for unsilencing channels"""
+    """Scheduler for unsilencing channels."""
 
     def __init__(self, bot: Bot):
         super().__init__()
@@ -31,17 +32,13 @@ class UnsilenceScheduler(Scheduler):
         self.bot = bot
 
     async def schedule_unsilence(self, channel: SilencedChannel) -> None:
-        """Schedule expiration for silenced channels"""
+        """Schedule expiration for silenced channels."""
         await self.bot.wait_until_guild_available()
         log.debug("Scheduling unsilencer")
         self.schedule_task(channel.id, channel)
 
     async def _scheduled_task(self, channel: SilencedChannel) -> None:
-        """
-        Removes expired silenced channel from `silence.muted_channels`
-        and calls `silence.unsilence` to unsilence the channel
-        after the silence expires
-        """
+        """Calls `silence.unsilence` on expired silenced channel to unsilence it."""
         await time.wait_until(channel.stop)
         log.info("Unsilencing channel after set delay.")
 

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -111,7 +111,7 @@ class Silence(Scheduler, commands.Cog):
             delay=duration*60,
         )
 
-        await self.schedule_task(ctx.channel.id, channel)
+        self.schedule_task(ctx.channel.id, channel)
 
     @commands.command(aliases=("unhush",))
     async def unsilence(self, ctx: Context) -> None:

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from contextlib import suppress
-from typing import Optional, NamedTuple
+from typing import NamedTuple, Optional
 
 from discord import TextChannel
 from discord.ext import commands, tasks

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -68,12 +68,6 @@ class Silence(Scheduler, commands.Cog):
         self._get_instance_vars_task = self.bot.loop.create_task(self._get_instance_vars())
         self._get_instance_vars_event = asyncio.Event()
 
-    async def schedule_unsilence(self, channel: SilencedChannel) -> None:
-        """Schedule expiration for silenced channels."""
-        await self.bot.wait_until_guild_available()
-        log.debug("Scheduling unsilencer")
-        self.schedule_task(channel.id, channel)
-
     async def _scheduled_task(self, channel: SilencedChannel) -> None:
         """Calls `self.unsilence` on expired silenced channel to unsilence it."""
         await asyncio.sleep(channel.delay)
@@ -114,7 +108,7 @@ class Silence(Scheduler, commands.Cog):
 
         channel = SilencedChannel(
             ctx=ctx,
-            stop=duration*60,
+            delay=duration*60,
         )
 
         await self.schedule_task(ctx.channel.id, channel)

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -123,7 +123,7 @@ class Silence(Scheduler, commands.Cog):
         await self._get_instance_vars_event.wait()
         log.debug(f"Unsilencing channel #{ctx.channel} from {ctx.author}'s command.")
         if not await self._unsilence(ctx.channel):
-            await ctx.send(f"{Emojis.cross_mark} current channel is not silenced.")
+            await ctx.send(f"{Emojis.cross_mark} current channel was not silenced.")
         else:
             await ctx.send(f"{Emojis.check_mark} unsilenced current channel.")
 

--- a/tests/bot/cogs/moderation/test_silence.py
+++ b/tests/bot/cogs/moderation/test_silence.py
@@ -127,10 +127,20 @@ class SilenceTests(unittest.IsolatedAsyncioTestCase):
             self.ctx.reset_mock()
 
     async def test_unsilence_sent_correct_discord_message(self):
-        """Proper reply after a successful unsilence."""
-        with mock.patch.object(self.cog, "_unsilence", return_value=True):
-            await self.cog.unsilence.callback(self.cog, self.ctx)
-            self.ctx.send.assert_called_once_with(f"{Emojis.check_mark} unsilenced current channel.")
+        """Check if proper message was sent when unsilencing channel."""
+        test_cases = (
+            (True, f"{Emojis.check_mark} unsilenced current channel."),
+            (False, f"{Emojis.cross_mark} current channel was not silenced.")
+        )
+        for _unsilence_patch_return, result_message in test_cases:
+            with self.subTest(
+                starting_silenced_state=_unsilence_patch_return,
+                result_message=result_message
+            ):
+                with mock.patch.object(self.cog, "_unsilence", return_value=_unsilence_patch_return):
+                    await self.cog.unsilence.callback(self.cog, self.ctx)
+                    self.ctx.send.assert_called_once_with(result_message)
+            self.ctx.reset_mock()
 
     async def test_silence_private_for_false(self):
         """Permissions are not set and `False` is returned in an already silenced channel."""


### PR DESCRIPTION
Closes #977 

As described in #977 using `asyncio.sleep` isn't a good way to check if the silence duration has passed, since in some cases, it can cause channels to get prematurely unsilenced.

This solves that issue by using `Scheduler` from `bot.utils.scheduling` which has the ability to cancel on-going scheduled tasks. This also means that there can be a message on `!unsilence` saying that the channel is currently not silenced, which provides much better feedback than not sending anything.