### PR TITLE
Add the !modmail tag

### DIFF
--- a/bot/resources/tags/modmail.md
+++ b/bot/resources/tags/modmail.md
@@ -1,0 +1,9 @@
+**Contacting the moderation team via ModMail**
+
+<@!683001325440860340> is a bot that will relay your messages to our moderation team, so that you can start a conversation with the moderation team. Your messages will be relayed to the entire moderator team, who will be able to respond to you via the bot.
+
+It supports attachments, codeblocks, and reactions. As communication happens over direct messages, the conversation will stay between you and the mod team.
+
+**To use it, simply send a direct message to the bot.**
+
+Should there be an urgent and immediate need for a moderator or admin to look at a channel, feel free to ping the <@&267629731250176001> or <@&267628507062992896> role instead.


### PR DESCRIPTION
Adds a `!modmail` tag, useful for when a member of the community asks how to contact staff.