### PR TITLE
Stats: Implement rules stats

### DIFF
--- a/bot/cogs/site.py
+++ b/bot/cogs/site.py
@@ -133,6 +133,9 @@ class Site(Cog):
             await ctx.send(f":x: Invalid rule indices: {indices}")
             return
 
+        for rule in rules:
+            self.bot.stats.incr(f"rule_uses.{rule}")
+
         final_rules = tuple(f"**{pick}.** {full_rules[pick - 1]}" for pick in rules)
 
         await LinePaginator.paginate(final_rules, ctx, rules_embed, max_lines=3)


### PR DESCRIPTION
Approved in #meta following [this conversation](https://canary.discordapp.com/channels/267624335836053506/429409067623251969/718449772737855559)

Adds a new statistic measuring the number of times a rule is fetched using the `!rules|site rules <rules...>` command.