### PR TITLE
Add persistence to the help channel system

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -562,11 +562,10 @@ class HelpChannels(Scheduler, commands.Cog):
             self.bot.stats.timing("help.in_use_time", in_use_time)
 
         unanswered = await self.unanswered.get(channel.id)
-        if unanswered is not None:
-            if unanswered:
-                self.bot.stats.incr("help.sessions.unanswered")
-            else:
-                self.bot.stats.incr("help.sessions.answered")
+        if unanswered:
+            self.bot.stats.incr("help.sessions.unanswered")
+        elif unanswered is not None:
+            self.bot.stats.incr("help.sessions.answered")
 
         log.trace(f"Position of #{channel} ({channel.id}) is actually {channel.position}.")
         log.trace(f"Sending dormant message for #{channel} ({channel.id}).")

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -9,7 +9,6 @@ from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 
-import dateutil
 import discord
 import discord.abc
 from discord.ext import commands
@@ -550,9 +549,9 @@ class HelpChannels(Scheduler, commands.Cog):
         self.bot.stats.incr(f"help.dormant_calls.{caller}")
 
         if await self.claim_times.contains(channel.id):
-            claimed_datestring = await self.claim_times.get(channel.id)
-            claimed = dateutil.parser.parse(claimed_datestring)
-            in_use_time = datetime.now() - claimed
+            claimed_timestamp = await self.claim_times.get(channel.id)
+            claimed = datetime.fromtimestamp(claimed_timestamp)
+            in_use_time = datetime.utcnow() - claimed
             self.bot.stats.timing("help.in_use_time", in_use_time)
 
         if await self.unanswered.contains(channel.id):
@@ -688,7 +687,7 @@ class HelpChannels(Scheduler, commands.Cog):
 
             self.bot.stats.incr("help.claimed")
 
-            await self.claim_times.set(channel.id, str(datetime.now()))
+            await self.claim_times.set(channel.id, datetime.utcnow().timestamp())
             await self.unanswered.set(channel.id, True)
 
             log.trace(f"Releasing on_message lock for {message.id}.")

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -794,11 +794,14 @@ class HelpChannels(Scheduler, commands.Cog):
         # Would mean the user somehow bypassed the lack of permissions (e.g. user is guild owner).
         self.cancel_task(member.id, ignore_missing=True)
 
-        timeout = constants.HelpChannels.claim_minutes * 60
-        callback = self.remove_cooldown_role(member)
+        await self.schedule_cooldown_expiration(member, constants.HelpChannels.claim_minutes * 60)
 
-        log.trace(f"Scheduling {member}'s ({member.id}) send message permissions to be reinstated.")
-        self.schedule_task(member.id, TaskData(timeout, callback))
+    async def schedule_cooldown_expiration(self, member: discord.Member, seconds: int) -> None:
+        """Schedule the cooldown role for `member` to be removed after a duration of `seconds`."""
+        log.trace(f"Scheduling removal of {member}'s ({member.id}) cooldown.")
+
+        callback = self.remove_cooldown_role(member)
+        self.schedule_task(member.id, TaskData(seconds, callback))
 
     async def send_available_message(self, channel: discord.TextChannel) -> None:
         """Send the available message by editing a dormant message or sending a new message."""

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -5,7 +5,6 @@ import logging
 import random
 import typing as t
 from collections import deque
-from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 
@@ -224,10 +223,11 @@ class HelpChannels(Scheduler, commands.Cog):
         log.trace("close command invoked; checking if the channel is in-use.")
         if ctx.channel.category == self.in_use_category:
             if await self.dormant_check(ctx):
-                with suppress(KeyError):
-                    await self.help_channel_claimants.delete(ctx.channel.id)
 
+                # Remove the claimant and the cooldown role
+                await self.help_channel_claimants.delete(ctx.channel.id)
                 await self.remove_cooldown_role(ctx.author)
+
                 # Ignore missing task when cooldown has passed but the channel still isn't dormant.
                 self.cancel_task(ctx.author.id, ignore_missing=True)
 

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -647,7 +647,7 @@ class HelpChannels(Scheduler, commands.Cog):
         if self.is_in_category(channel, constants.Categories.help_in_use):
             log.trace(f"Checking if #{channel} ({channel.id}) has been answered.")
 
-            # Check if there is an entry in unanswered (does not persist across restarts)
+            # Check if there is an entry in unanswered
             if await self.unanswered.contains(channel.id):
                 claimant_id = await self.help_channel_claimants.get(channel.id)
                 if not claimant_id:

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -548,20 +548,20 @@ class HelpChannels(Scheduler, commands.Cog):
 
         self.bot.stats.incr(f"help.dormant_calls.{caller}")
 
-        if await self.claim_times.contains(channel.id):
-            claimed_timestamp = await self.claim_times.get(channel.id)
+        claimed_timestamp = await self.claim_times.get(channel.id)
+        if claimed_timestamp:
             claimed = datetime.fromtimestamp(claimed_timestamp)
             in_use_time = datetime.utcnow() - claimed
             self.bot.stats.timing("help.in_use_time", in_use_time)
 
-        if await self.unanswered.contains(channel.id):
-            if await self.unanswered.get(channel.id):
+        unanswered = await self.unanswered.get(channel.id)
+        if unanswered is not None:
+            if unanswered:
                 self.bot.stats.incr("help.sessions.unanswered")
             else:
                 self.bot.stats.incr("help.sessions.answered")
 
         log.trace(f"Position of #{channel} ({channel.id}) is actually {channel.position}.")
-
         log.trace(f"Sending dormant message for #{channel} ({channel.id}).")
         embed = discord.Embed(description=DORMANT_MSG)
         await channel.send(embed=embed)

--- a/bot/utils/redis_cache.py
+++ b/bot/utils/redis_cache.py
@@ -48,8 +48,8 @@ class RedisCache:
     behaves, and should be familiar to Python users. The biggest difference is that
     all the public methods in this class are coroutines, and must be awaited.
 
-    Because of limitations in Redis, this cache will only accept strings, integers and
-    floats both for keys and values.
+    Because of limitations in Redis, this cache will only accept strings and integers for keys,
+    and strings, integers, floats and booleans for values.
 
     Please note that this class MUST be created as a class attribute, and that that class
     must also contain an attribute with an instance of our Bot. See `__get__` and `__set_name__`

--- a/tests/bot/utils/test_redis_cache.py
+++ b/tests/bot/utils/test_redis_cache.py
@@ -59,7 +59,9 @@ class RedisCacheTests(unittest.IsolatedAsyncioTestCase):
         test_cases = (
             ('favorite_fruit', 'melon'),
             ('favorite_number', 86),
-            ('favorite_fraction', 86.54)
+            ('favorite_fraction', 86.54),
+            ('favorite_boolean', False),
+            ('other_boolean', True),
         )
 
         # Test that we can get and set different types.


### PR DESCRIPTION
This PR should ensure that help channel-related data is persisted across bot restarts.

To achieve this, we make two changes.

## RedisCache now supports Booleans as values
For the unanswered cache, we need to know whether or not a channel has been answered, and so it was relevant to store a boolean in the RedisCache. There was no support for this, so I added some. It seems like a feature we might want in the future for other things anyway.

## Refactoring help_channels.py
The rest is pretty straight forward - Replacing the `help_channel_claimants`, `unanswered`, and `claim_times` dicts with RedisCaches, and changing the code that accessed it to do so in a RedisCache compatible way.