### PR TITLE
Add snekbox to the Docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,14 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
 
+  snekbox:
+    image: pythondiscord/snekbox:latest
+    init: true
+    ipc: none
+    ports:
+     - "127.0.0.1:8060:8060"
+    privileged: true
+
   web:
     image: pythondiscord/site:latest
     command: ["run", "--debug"]
@@ -47,6 +55,7 @@ services:
     depends_on:
       - web
       - redis
+      - snekbox
     environment:
       BOT_TOKEN: ${BOT_TOKEN}
       BOT_API_KEY: badbot13m0n8f570f942013fc818f234916ca531


### PR DESCRIPTION
A feature relies on it so I don't see why it contributors should have to set up snekbox separately. It's also currently undocumented so this will help until some docs are written.