### PR TITLE
Add cooldown channel to config-default.yml

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 ASKING_GUIDE_URL = "https://pythondiscord.com/pages/asking-good-questions/"
 MAX_CHANNELS_PER_CATEGORY = 50
-EXCLUDED_CHANNELS = (constants.Channels.how_to_get_help,)
+EXCLUDED_CHANNELS = (constants.Channels.how_to_get_help, constants.Channels.cooldown)
 
 HELP_CHANNEL_TOPIC = """
 This is a Python help channel. You can claim your own help channel in the Python Help: Available category.

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -389,6 +389,7 @@ class Channels(metaclass=YAMLGetter):
     attachment_log: int
     big_brother_logs: int
     bot_commands: int
+    cooldown: int
     defcon: int
     dev_contrib: int
     dev_core: int

--- a/config-default.yml
+++ b/config-default.yml
@@ -142,6 +142,7 @@ guild:
 
         # Python Help: Available
         how_to_get_help:    704250143020417084
+        cooldown:           720603994149486673
 
         # Logs
         attachment_log:     &ATTACH_LOG     649243850006855680


### PR DESCRIPTION
This PR adds the constants for the cooldown channel so that when users are on help cooldown instead of just having write permissions revoked in the help available category they will not see help channels and will instead see a cooldown channel:
<img width="213" alt="Screenshot 2020-06-11 at 12 44 58" src="https://user-images.githubusercontent.com/20439493/84381730-5d540480-abe1-11ea-8152-c05f76193e15.png">
