### PR TITLE
Check infraction reason isn't None before shortening it

### DIFF
--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -75,9 +75,7 @@ class Infractions(InfractionScheduler, commands.Cog):
     # region: Temporary infractions
 
     @command(aliases=["mute"])
-    async def tempmute(
-            self, ctx: Context, user: Member, duration: Expiry, *, reason: t.Optional[str] = None
-    ) -> None:
+    async def tempmute(self, ctx: Context, user: Member, duration: Expiry, *, reason: t.Optional[str] = None) -> None:
         """
         Temporarily mute a user for the given reason and duration.
 
@@ -97,7 +95,12 @@ class Infractions(InfractionScheduler, commands.Cog):
 
     @command()
     async def tempban(
-            self, ctx: Context, user: FetchedMember, duration: Expiry, *, reason: t.Optional[str] = None
+        self,
+        ctx: Context,
+        user: FetchedMember,
+        duration: Expiry,
+        *,
+        reason: t.Optional[str] = None
     ) -> None:
         """
         Temporarily ban a user for the given reason and duration.
@@ -134,9 +137,7 @@ class Infractions(InfractionScheduler, commands.Cog):
         await self.apply_kick(ctx, user, reason, hidden=True, active=False)
 
     @command(hidden=True, aliases=['shadowban', 'sban'])
-    async def shadow_ban(
-            self, ctx: Context, user: FetchedMember, *, reason: t.Optional[str] = None
-    ) -> None:
+    async def shadow_ban(self, ctx: Context, user: FetchedMember, *, reason: t.Optional[str] = None) -> None:
         """Permanently ban a user for the given reason without notifying the user."""
         await self.apply_ban(ctx, user, reason, hidden=True)
 
@@ -145,12 +146,11 @@ class Infractions(InfractionScheduler, commands.Cog):
 
     @command(hidden=True, aliases=["shadowtempmute, stempmute", "shadowmute", "smute"])
     async def shadow_tempmute(
-            self,
-            ctx: Context,
-            user: Member,
-            duration: Expiry,
-            *,
-            reason: t.Optional[str] = None
+        self, ctx: Context,
+        user: Member,
+        duration: Expiry,
+        *,
+        reason: t.Optional[str] = None
     ) -> None:
         """
         Temporarily mute a user for the given reason and duration without notifying the user.
@@ -171,12 +171,12 @@ class Infractions(InfractionScheduler, commands.Cog):
 
     @command(hidden=True, aliases=["shadowtempban, stempban"])
     async def shadow_tempban(
-            self,
-            ctx: Context,
-            user: FetchedMember,
-            duration: Expiry,
-            *,
-            reason: t.Optional[str] = None
+        self,
+        ctx: Context,
+        user: FetchedMember,
+        duration: Expiry,
+        *,
+        reason: t.Optional[str] = None
     ) -> None:
         """
         Temporarily ban a user for the given reason and duration without notifying the user.

--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -53,7 +53,7 @@ class Infractions(InfractionScheduler, commands.Cog):
     # region: Permanent infractions
 
     @command()
-    async def warn(self, ctx: Context, user: Member, *, reason: str = None) -> None:
+    async def warn(self, ctx: Context, user: Member, *, reason: t.Optional[str] = None) -> None:
         """Warn a user for the given reason."""
         infraction = await utils.post_infraction(ctx, user, "warning", reason, active=False)
         if infraction is None:
@@ -62,12 +62,12 @@ class Infractions(InfractionScheduler, commands.Cog):
         await self.apply_infraction(ctx, infraction, user)
 
     @command()
-    async def kick(self, ctx: Context, user: Member, *, reason: str = None) -> None:
+    async def kick(self, ctx: Context, user: Member, *, reason: t.Optional[str] = None) -> None:
         """Kick a user for the given reason."""
         await self.apply_kick(ctx, user, reason, active=False)
 
     @command()
-    async def ban(self, ctx: Context, user: FetchedMember, *, reason: str = None) -> None:
+    async def ban(self, ctx: Context, user: FetchedMember, *, reason: t.Optional[str] = None) -> None:
         """Permanently ban a user for the given reason and stop watching them with Big Brother."""
         await self.apply_ban(ctx, user, reason)
 
@@ -75,7 +75,9 @@ class Infractions(InfractionScheduler, commands.Cog):
     # region: Temporary infractions
 
     @command(aliases=["mute"])
-    async def tempmute(self, ctx: Context, user: Member, duration: Expiry, *, reason: str = None) -> None:
+    async def tempmute(
+            self, ctx: Context, user: Member, duration: Expiry, *, reason: t.Optional[str] = None
+    ) -> None:
         """
         Temporarily mute a user for the given reason and duration.
 
@@ -94,7 +96,9 @@ class Infractions(InfractionScheduler, commands.Cog):
         await self.apply_mute(ctx, user, reason, expires_at=duration)
 
     @command()
-    async def tempban(self, ctx: Context, user: FetchedMember, duration: Expiry, *, reason: str = None) -> None:
+    async def tempban(
+            self, ctx: Context, user: FetchedMember, duration: Expiry, *, reason: t.Optional[str] = None
+    ) -> None:
         """
         Temporarily ban a user for the given reason and duration.
 
@@ -116,7 +120,7 @@ class Infractions(InfractionScheduler, commands.Cog):
     # region: Permanent shadow infractions
 
     @command(hidden=True)
-    async def note(self, ctx: Context, user: FetchedMember, *, reason: str = None) -> None:
+    async def note(self, ctx: Context, user: FetchedMember, *, reason: t.Optional[str] = None) -> None:
         """Create a private note for a user with the given reason without notifying the user."""
         infraction = await utils.post_infraction(ctx, user, "note", reason, hidden=True, active=False)
         if infraction is None:
@@ -125,12 +129,14 @@ class Infractions(InfractionScheduler, commands.Cog):
         await self.apply_infraction(ctx, infraction, user)
 
     @command(hidden=True, aliases=['shadowkick', 'skick'])
-    async def shadow_kick(self, ctx: Context, user: Member, *, reason: str = None) -> None:
+    async def shadow_kick(self, ctx: Context, user: Member, *, reason: t.Optional[str] = None) -> None:
         """Kick a user for the given reason without notifying the user."""
         await self.apply_kick(ctx, user, reason, hidden=True, active=False)
 
     @command(hidden=True, aliases=['shadowban', 'sban'])
-    async def shadow_ban(self, ctx: Context, user: FetchedMember, *, reason: str = None) -> None:
+    async def shadow_ban(
+            self, ctx: Context, user: FetchedMember, *, reason: t.Optional[str] = None
+    ) -> None:
         """Permanently ban a user for the given reason without notifying the user."""
         await self.apply_ban(ctx, user, reason, hidden=True)
 
@@ -138,7 +144,14 @@ class Infractions(InfractionScheduler, commands.Cog):
     # region: Temporary shadow infractions
 
     @command(hidden=True, aliases=["shadowtempmute, stempmute", "shadowmute", "smute"])
-    async def shadow_tempmute(self, ctx: Context, user: Member, duration: Expiry, *, reason: str = None) -> None:
+    async def shadow_tempmute(
+            self,
+            ctx: Context,
+            user: Member,
+            duration: Expiry,
+            *,
+            reason: t.Optional[str] = None
+    ) -> None:
         """
         Temporarily mute a user for the given reason and duration without notifying the user.
 
@@ -158,12 +171,12 @@ class Infractions(InfractionScheduler, commands.Cog):
 
     @command(hidden=True, aliases=["shadowtempban, stempban"])
     async def shadow_tempban(
-        self,
-        ctx: Context,
-        user: FetchedMember,
-        duration: Expiry,
-        *,
-        reason: str = None
+            self,
+            ctx: Context,
+            user: FetchedMember,
+            duration: Expiry,
+            *,
+            reason: t.Optional[str] = None
     ) -> None:
         """
         Temporarily ban a user for the given reason and duration without notifying the user.
@@ -198,7 +211,7 @@ class Infractions(InfractionScheduler, commands.Cog):
     # endregion
     # region: Base apply functions
 
-    async def apply_mute(self, ctx: Context, user: Member, reason: str, **kwargs) -> None:
+    async def apply_mute(self, ctx: Context, user: Member, reason: t.Optional[str], **kwargs) -> None:
         """Apply a mute infraction with kwargs passed to `post_infraction`."""
         if await utils.get_active_infraction(ctx, user, "mute"):
             return
@@ -218,7 +231,7 @@ class Infractions(InfractionScheduler, commands.Cog):
         await self.apply_infraction(ctx, infraction, user, action())
 
     @respect_role_hierarchy()
-    async def apply_kick(self, ctx: Context, user: Member, reason: str, **kwargs) -> None:
+    async def apply_kick(self, ctx: Context, user: Member, reason: t.Optional[str], **kwargs) -> None:
         """Apply a kick infraction with kwargs passed to `post_infraction`."""
         infraction = await utils.post_infraction(ctx, user, "kick", reason, active=False, **kwargs)
         if infraction is None:
@@ -233,7 +246,7 @@ class Infractions(InfractionScheduler, commands.Cog):
         await self.apply_infraction(ctx, infraction, user, action)
 
     @respect_role_hierarchy()
-    async def apply_ban(self, ctx: Context, user: UserSnowflake, reason: str, **kwargs) -> None:
+    async def apply_ban(self, ctx: Context, user: UserSnowflake, reason: t.Optional[str], **kwargs) -> None:
         """
         Apply a ban infraction with kwargs passed to `post_infraction`.
 

--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -298,7 +298,7 @@ class Infractions(InfractionScheduler, commands.Cog):
     # endregion
     # region: Base pardon functions
 
-    async def pardon_mute(self, user_id: int, guild: discord.Guild, reason: str) -> t.Dict[str, str]:
+    async def pardon_mute(self, user_id: int, guild: discord.Guild, reason: t.Optional[str]) -> t.Dict[str, str]:
         """Remove a user's muted role, DM them a notification, and return a log dict."""
         user = guild.get_member(user_id)
         log_text = {}
@@ -324,7 +324,7 @@ class Infractions(InfractionScheduler, commands.Cog):
 
         return log_text
 
-    async def pardon_ban(self, user_id: int, guild: discord.Guild, reason: str) -> t.Dict[str, str]:
+    async def pardon_ban(self, user_id: int, guild: discord.Guild, reason: t.Optional[str]) -> t.Dict[str, str]:
         """Remove a user's ban on the Discord guild and return a log dict."""
         user = discord.Object(user_id)
         log_text = {}

--- a/bot/cogs/moderation/infractions.py
+++ b/bot/cogs/moderation/infractions.py
@@ -226,7 +226,10 @@ class Infractions(InfractionScheduler, commands.Cog):
 
         self.mod_log.ignore(Event.member_remove, user.id)
 
-        action = user.kick(reason=textwrap.shorten(reason, width=512, placeholder="..."))
+        if reason:
+            reason = textwrap.shorten(reason, width=512, placeholder="...")
+
+        action = user.kick(reason=reason)
         await self.apply_infraction(ctx, infraction, user, action)
 
     @respect_role_hierarchy()
@@ -259,9 +262,10 @@ class Infractions(InfractionScheduler, commands.Cog):
 
         self.mod_log.ignore(Event.member_remove, user.id)
 
-        truncated_reason = textwrap.shorten(reason, width=512, placeholder="...")
+        if reason:
+            reason = textwrap.shorten(reason, width=512, placeholder="...")
 
-        action = ctx.guild.ban(user, reason=truncated_reason, delete_message_days=0)
+        action = ctx.guild.ban(user, reason=reason, delete_message_days=0)
         await self.apply_infraction(ctx, infraction, user, action)
 
         if infraction.get('expires_at') is not None:

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -127,17 +127,17 @@ class InfractionScheduler(Scheduler):
                     dm_result = ":incoming_envelope: "
                     dm_log_text = "\nDM: Sent"
 
-        if reason and infraction["actor"] == self.bot.user.id:
+        end_msg = ""
+        if infraction["actor"] == self.bot.user.id:
             log.trace(
                 f"Infraction #{id_} actor is bot; including the reason in the confirmation message."
             )
-            end_msg = f" (reason: {textwrap.shorten(reason, width=1500, placeholder='...')})"
+            if reason:
+                end_msg = f" (reason: {textwrap.shorten(reason, width=1500, placeholder='...')})"
         elif ctx.channel.id not in STAFF_CHANNELS:
             log.trace(
                 f"Infraction #{id_} context is not in a staff channel; omitting infraction count."
             )
-
-            end_msg = ""
         else:
             log.trace(f"Fetching total infraction count for {user}.")
 

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -127,11 +127,10 @@ class InfractionScheduler(Scheduler):
                     dm_result = ":incoming_envelope: "
                     dm_log_text = "\nDM: Sent"
 
-        if infraction["actor"] == self.bot.user.id:
+        if reason and infraction["actor"] == self.bot.user.id:
             log.trace(
                 f"Infraction #{id_} actor is bot; including the reason in the confirmation message."
             )
-
             end_msg = f" (reason: {textwrap.shorten(reason, width=1500, placeholder='...')})"
         elif ctx.channel.id not in STAFF_CHANNELS:
             log.trace(


### PR DESCRIPTION
With the recent changes to truncate reasons, infractions will fail to apply if a reason isn't provided. The fix is to only shorten the reason if it isn't None.