### PR TITLE
Ignore DMs in token and webhook removers

### DIFF
--- a/bot/cogs/token_remover.py
+++ b/bot/cogs/token_remover.py
@@ -63,8 +63,9 @@ class TokenRemover(Cog):
 
         See: https://discordapp.com/developers/docs/reference#snowflakes
         """
-        if not msg.guild:
-            return  # Ignore DMs; can't delete messages in there anyway.
+        # Ignore DMs; can't delete messages in there anyway.
+        if not msg.guild or msg.author.bot:
+            return
 
         found_token = self.find_token_in_message(msg)
         if found_token:
@@ -115,9 +116,6 @@ class TokenRemover(Cog):
     @classmethod
     def find_token_in_message(cls, msg: Message) -> t.Optional[Token]:
         """Return a seemingly valid token found in `msg` or `None` if no token is found."""
-        if msg.author.bot:
-            return
-
         # Use finditer rather than search to guard against method calls prematurely returning the
         # token check (e.g. `message.channel.send` also matches our token pattern)
         for match in TOKEN_RE.finditer(msg.content):

--- a/bot/cogs/token_remover.py
+++ b/bot/cogs/token_remover.py
@@ -4,7 +4,7 @@ import logging
 import re
 import typing as t
 
-from discord import Colour, Message
+from discord import Colour, Message, NotFound
 from discord.ext.commands import Cog
 
 from bot import utils
@@ -83,7 +83,13 @@ class TokenRemover(Cog):
     async def take_action(self, msg: Message, found_token: Token) -> None:
         """Remove the `msg` containing the `found_token` and send a mod log message."""
         self.mod_log.ignore(Event.message_delete, msg.id)
-        await msg.delete()
+
+        try:
+            await msg.delete()
+        except NotFound:
+            log.debug(f"Failed to remove token in message {msg.id}: message already deleted.")
+            return
+
         await msg.channel.send(DELETION_MESSAGE_TEMPLATE.format(mention=msg.author.mention))
 
         log_message = self.format_log_message(msg, found_token)

--- a/bot/cogs/token_remover.py
+++ b/bot/cogs/token_remover.py
@@ -63,6 +63,9 @@ class TokenRemover(Cog):
 
         See: https://discordapp.com/developers/docs/reference#snowflakes
         """
+        if not msg.guild:
+            return  # Ignore DMs; can't delete messages in there anyway.
+
         found_token = self.find_token_in_message(msg)
         if found_token:
             await self.take_action(msg, found_token)

--- a/bot/cogs/webhook_remover.py
+++ b/bot/cogs/webhook_remover.py
@@ -59,6 +59,10 @@ class WebhookRemover(Cog):
     @Cog.listener()
     async def on_message(self, msg: Message) -> None:
         """Check if a Discord webhook URL is in `message`."""
+        # Ignore DMs; can't delete messages in there anyway.
+        if not msg.guild or msg.author.bot:
+            return
+
         matches = WEBHOOK_URL_RE.search(msg.content)
         if matches:
             await self.delete_and_respond(msg, matches[1] + "xxx")

--- a/bot/cogs/webhook_remover.py
+++ b/bot/cogs/webhook_remover.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from discord import Colour, Message
+from discord import Colour, Message, NotFound
 from discord.ext.commands import Cog
 
 from bot.bot import Bot
@@ -35,7 +35,13 @@ class WebhookRemover(Cog):
         """Delete `msg` and send a warning that it contained the Discord webhook `redacted_url`."""
         # Don't log this, due internal delete, not by user. Will make different entry.
         self.mod_log.ignore(Event.message_delete, msg.id)
-        await msg.delete()
+
+        try:
+            await msg.delete()
+        except NotFound:
+            log.debug(f"Failed to remove webhook in message {msg.id}: message already deleted.")
+            return
+
         await msg.channel.send(ALERT_MESSAGE_TEMPLATE.format(user=msg.author.mention))
 
         message = (

--- a/tests/bot/cogs/test_token_remover.py
+++ b/tests/bot/cogs/test_token_remover.py
@@ -121,6 +121,16 @@ class TokenRemoverTests(unittest.IsolatedAsyncioTestCase):
         find_token_in_message.assert_called_once_with(self.msg)
         take_action.assert_not_awaited()
 
+    @autospec(TokenRemover, "find_token_in_message")
+    async def test_on_message_ignores_dms(self, find_token_in_message):
+        """Shouldn't parse a message if it is a DM."""
+        cog = TokenRemover(self.bot)
+        self.msg.guild = None
+
+        await cog.on_message(self.msg)
+
+        find_token_in_message.assert_not_called()
+
     @autospec("bot.cogs.token_remover", "TOKEN_RE")
     def test_find_token_ignores_bot_messages(self, token_re):
         """The token finder should ignore messages authored by bots."""


### PR DESCRIPTION
Sentry Issue: [BOT-58](https://sentry.io/organizations/python-discord/issues/1687879860/?referrer=github_integration)

DMs cannot be deleted, so don't bother trying. I also made a change to catch `NotFound` exceptions when deleting the message, in case someone managed to delete it manually before the bot could get to it.