### PR TITLE
Scheduler Redesign

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -1,5 +1,4 @@
 import asyncio
-import inspect
 import json
 import logging
 import random
@@ -57,14 +56,7 @@ through our guide for [asking a good question]({ASKING_GUIDE_URL}).
 CoroutineFunc = t.Callable[..., t.Coroutine]
 
 
-class TaskData(t.NamedTuple):
-    """Data for a scheduled task."""
-
-    wait_time: int
-    callback: t.Awaitable
-
-
-class HelpChannels(Scheduler, commands.Cog):
+class HelpChannels(commands.Cog):
     """
     Manage the help channel system of the guild.
 
@@ -114,9 +106,8 @@ class HelpChannels(Scheduler, commands.Cog):
     claim_times = RedisCache()
 
     def __init__(self, bot: Bot):
-        super().__init__()
-
         self.bot = bot
+        self.scheduler = Scheduler(self.__class__.__name__)
 
         # Categories
         self.available_category: discord.CategoryChannel = None
@@ -145,7 +136,7 @@ class HelpChannels(Scheduler, commands.Cog):
         for task in self.queue_tasks:
             task.cancel()
 
-        self.cancel_all()
+        self.scheduler.cancel_all()
 
     def create_channel_queue(self) -> asyncio.Queue:
         """
@@ -229,10 +220,11 @@ class HelpChannels(Scheduler, commands.Cog):
                 await self.remove_cooldown_role(ctx.author)
 
                 # Ignore missing task when cooldown has passed but the channel still isn't dormant.
-                self.cancel_task(ctx.author.id, ignore_missing=True)
+                if ctx.author.id in self.scheduler:
+                    self.scheduler.cancel(ctx.author.id)
 
                 await self.move_to_dormant(ctx.channel, "command")
-                self.cancel_task(ctx.channel.id)
+                self.scheduler.cancel(ctx.channel.id)
         else:
             log.debug(f"{ctx.author} invoked command 'dormant' outside an in-use help channel")
 
@@ -474,16 +466,15 @@ class HelpChannels(Scheduler, commands.Cog):
         else:
             # Cancel the existing task, if any.
             if has_task:
-                self.cancel_task(channel.id)
+                self.scheduler.cancel(channel.id)
 
-            data = TaskData(idle_seconds - time_elapsed, self.move_idle_channel(channel))
-
+            delay = idle_seconds - time_elapsed
             log.info(
                 f"#{channel} ({channel.id}) is still active; "
-                f"scheduling it to be moved after {data.wait_time} seconds."
+                f"scheduling it to be moved after {delay} seconds."
             )
 
-            self.schedule_task(channel.id, data)
+            self.scheduler.schedule_later(delay, channel.id, self.move_idle_channel(channel))
 
     async def move_to_bottom_position(self, channel: discord.TextChannel, category_id: int, **options) -> None:
         """
@@ -588,8 +579,7 @@ class HelpChannels(Scheduler, commands.Cog):
         timeout = constants.HelpChannels.idle_minutes * 60
 
         log.trace(f"Scheduling #{channel} ({channel.id}) to become dormant in {timeout} sec.")
-        data = TaskData(timeout, self.move_idle_channel(channel))
-        self.schedule_task(channel.id, data)
+        self.scheduler.schedule_later(timeout, channel.id, self.move_idle_channel(channel))
         self.report_stats()
 
     async def notify(self) -> None:
@@ -722,10 +712,10 @@ class HelpChannels(Scheduler, commands.Cog):
         log.info(f"Claimant of #{msg.channel} ({msg.author}) deleted message, channel is empty now. Rescheduling task.")
 
         # Cancel existing dormant task before scheduling new.
-        self.cancel_task(msg.channel.id)
+        self.scheduler.cancel(msg.channel.id)
 
-        task = TaskData(constants.HelpChannels.deleted_idle_minutes * 60, self.move_idle_channel(msg.channel))
-        self.schedule_task(msg.channel.id, task)
+        delay = constants.HelpChannels.deleted_idle_minutes * 60
+        self.scheduler.schedule_later(delay, msg.channel.id, self.move_idle_channel(msg.channel))
 
     async def is_empty(self, channel: discord.TextChannel) -> bool:
         """Return True if the most recent message in `channel` is the bot's `AVAILABLE_MSG`."""
@@ -752,8 +742,8 @@ class HelpChannels(Scheduler, commands.Cog):
                 await self.remove_cooldown_role(member)
             else:
                 # The member is still on a cooldown; re-schedule it for the remaining time.
-                remaining = cooldown - in_use_time.seconds
-                await self.schedule_cooldown_expiration(member, remaining)
+                delay = cooldown - in_use_time.seconds
+                self.scheduler.schedule_later(delay, member.id, self.remove_cooldown_role(member))
 
     async def add_cooldown_role(self, member: discord.Member) -> None:
         """Add the help cooldown role to `member`."""
@@ -804,16 +794,11 @@ class HelpChannels(Scheduler, commands.Cog):
 
         # Cancel the existing task, if any.
         # Would mean the user somehow bypassed the lack of permissions (e.g. user is guild owner).
-        self.cancel_task(member.id, ignore_missing=True)
+        if member.id in self.scheduler:
+            self.scheduler.cancel(member.id)
 
-        await self.schedule_cooldown_expiration(member, constants.HelpChannels.claim_minutes * 60)
-
-    async def schedule_cooldown_expiration(self, member: discord.Member, seconds: int) -> None:
-        """Schedule the cooldown role for `member` to be removed after a duration of `seconds`."""
-        log.trace(f"Scheduling removal of {member}'s ({member.id}) cooldown.")
-
-        callback = self.remove_cooldown_role(member)
-        self.schedule_task(member.id, TaskData(seconds, callback))
+        delay = constants.HelpChannels.claim_minutes * 60
+        self.scheduler.schedule_later(delay, member.id, self.remove_cooldown_role(member))
 
     async def send_available_message(self, channel: discord.TextChannel) -> None:
         """Send the available message by editing a dormant message or sending a new message."""
@@ -854,21 +839,6 @@ class HelpChannels(Scheduler, commands.Cog):
         self.queue_tasks.remove(task)
 
         return channel
-
-    async def _scheduled_task(self, data: TaskData) -> None:
-        """Await the `data.callback` coroutine after waiting for `data.wait_time` seconds."""
-        try:
-            log.trace(f"Waiting {data.wait_time} seconds before awaiting callback.")
-            await asyncio.sleep(data.wait_time)
-
-            # Use asyncio.shield to prevent callback from cancelling itself.
-            # The parent task (_scheduled_task) will still get cancelled.
-            log.trace("Done waiting; now awaiting the callback.")
-            await asyncio.shield(data.callback)
-        finally:
-            if inspect.iscoroutine(data.callback):
-                log.trace("Explicitly closing coroutine.")
-                data.callback.close()
 
 
 def validate_config() -> None:

--- a/bot/cogs/moderation/management.py
+++ b/bot/cogs/moderation/management.py
@@ -135,11 +135,11 @@ class ModManagement(commands.Cog):
         if 'expires_at' in request_data:
             # A scheduled task should only exist if the old infraction wasn't permanent
             if old_infraction['expires_at']:
-                self.infractions_cog.cancel_task(new_infraction['id'])
+                self.infractions_cog.scheduler.cancel(new_infraction['id'])
 
             # If the infraction was not marked as permanent, schedule a new expiration task
             if request_data['expires_at']:
-                self.infractions_cog.schedule_task(new_infraction['id'], new_infraction)
+                self.infractions_cog.scheduler.schedule(new_infraction['id'], new_infraction)
 
             log_text += f"""
                 Previous expiry: {old_infraction['expires_at'] or "Permanent"}

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import textwrap
 import typing as t
@@ -23,13 +22,13 @@ from .utils import UserSnowflake
 log = logging.getLogger(__name__)
 
 
-class InfractionScheduler(Scheduler):
+class InfractionScheduler:
     """Handles the application, pardoning, and expiration of infractions."""
 
     def __init__(self, bot: Bot, supported_infractions: t.Container[str]):
-        super().__init__()
-
         self.bot = bot
+        self.scheduler = Scheduler(self.__class__.__name__)
+
         self.bot.loop.create_task(self.reschedule_infractions(supported_infractions))
 
     @property
@@ -49,7 +48,7 @@ class InfractionScheduler(Scheduler):
         )
         for infraction in infractions:
             if infraction["expires_at"] is not None and infraction["type"] in supported_infractions:
-                self.schedule_task(infraction["id"], infraction)
+                self.schedule_expiration(infraction)
 
     async def reapply_infraction(
         self,
@@ -155,7 +154,7 @@ class InfractionScheduler(Scheduler):
                 await action_coro
                 if expiry:
                     # Schedule the expiration of the infraction.
-                    self.schedule_task(infraction["id"], infraction)
+                    self.schedule_expiration(infraction)
             except discord.HTTPException as e:
                 # Accordingly display that applying the infraction failed.
                 confirm_msg = ":x: failed to apply"
@@ -278,7 +277,7 @@ class InfractionScheduler(Scheduler):
 
                 # Cancel pending expiration task.
                 if infraction["expires_at"] is not None:
-                    self.cancel_task(infraction["id"])
+                    self.scheduler.cancel(infraction["id"])
 
         # Accordingly display whether the user was successfully notified via DM.
         dm_emoji = ""
@@ -415,7 +414,7 @@ class InfractionScheduler(Scheduler):
 
         # Cancel the expiration task.
         if infraction["expires_at"] is not None:
-            self.cancel_task(infraction["id"])
+            self.scheduler.cancel(infraction["id"])
 
         # Send a log message to the mod log.
         if send_log:
@@ -449,7 +448,7 @@ class InfractionScheduler(Scheduler):
         """
         raise NotImplementedError
 
-    async def _scheduled_task(self, infraction: utils.Infraction) -> None:
+    def schedule_expiration(self, infraction: utils.Infraction) -> None:
         """
         Marks an infraction expired after the delay from time of scheduling to time of expiration.
 
@@ -457,8 +456,4 @@ class InfractionScheduler(Scheduler):
         expiration task is cancelled.
         """
         expiry = dateutil.parser.isoparse(infraction["expires_at"]).replace(tzinfo=None)
-        await time.wait_until(expiry)
-
-        # Because deactivate_infraction() explicitly cancels this scheduled task, it is shielded
-        # to avoid prematurely cancelling itself.
-        await asyncio.shield(self.deactivate_infraction(infraction))
+        self.scheduler.schedule_at(expiry, infraction["id"], self.deactivate_infraction(infraction))

--- a/bot/cogs/moderation/superstarify.py
+++ b/bot/cogs/moderation/superstarify.py
@@ -146,7 +146,7 @@ class Superstarify(InfractionScheduler, Cog):
         log.debug(f"Changing nickname of {member} to {forced_nick}.")
         self.mod_log.ignore(constants.Event.member_update, member.id)
         await member.edit(nick=forced_nick, reason=reason)
-        self.schedule_task(id_, infraction)
+        self.schedule_expiration(infraction)
 
         # Send a DM to the user to notify them of their new infraction.
         await utils.notify_infraction(

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -43,6 +43,9 @@ class Scheduler:
         """
         self._log.trace(f"Scheduling task #{task_id}...")
 
+        msg = f"Cannot schedule an already started coroutine for #{task_id}"
+        assert inspect.getcoroutinestate(coroutine) == "CORO_CREATED", msg
+
         if task_id in self._scheduled_tasks:
             self._log.debug(f"Did not schedule task #{task_id}; task was already scheduled.")
             coroutine.close()

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -8,7 +8,17 @@ from functools import partial
 
 
 class Scheduler:
-    """Task scheduler."""
+    """
+    Schedule the execution of coroutines and keep track of them.
+
+    Coroutines can be scheduled immediately with `schedule` or in the future with `schedule_at`
+    or `schedule_later`. A unique ID is required to be given in order to keep track of the
+    resulting Tasks. Any scheduled task can be cancelled prematurely using `cancel` by providing
+    the same ID used to schedule it.  The `in` operator is supported for checking if a task with a
+    given ID is currently scheduled.
+
+    Any exception raised in a scheduled task is logged when the task is done.
+    """
 
     def __init__(self, name: str):
         self.name = name

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -11,6 +11,10 @@ class Scheduler:
     """
     Schedule the execution of coroutines and keep track of them.
 
+    When instantiating a Scheduler, a name must be provided. This name is used to distinguish the
+    instance's log messages from other instances. Using the name of the class or module containing
+    the instance is suggested.
+
     Coroutines can be scheduled immediately with `schedule` or in the future with `schedule_at`
     or `schedule_later`. A unique ID is required to be given in order to keep track of the
     resulting Tasks. Any scheduled task can be cancelled prematurely using `cancel` by providing

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -36,10 +36,10 @@ class Scheduler:
 
     def schedule(self, task_id: t.Hashable, coroutine: t.Coroutine) -> None:
         """
-        Schedule the execution of a coroutine.
+        Schedule the execution of a `coroutine`.
 
-        If a task with `task_id` already exists, close `coroutine` instead of scheduling it.
-        This prevents unawaited coroutine warnings.
+        If a task with `task_id` already exists, close `coroutine` instead of scheduling it. This
+        prevents unawaited coroutine warnings. Don't pass a coroutine that'll be re-used elsewhere.
         """
         self._log.trace(f"Scheduling task #{task_id}...")
 
@@ -62,6 +62,9 @@ class Scheduler:
         Schedule `coroutine` to be executed at the given naïve UTC `time`.
 
         If `time` is in the past, schedule `coroutine` immediately.
+
+        If a task with `task_id` already exists, close `coroutine` instead of scheduling it. This
+        prevents unawaited coroutine warnings. Don't pass a coroutine that'll be re-used elsewhere.
         """
         delay = (time - datetime.utcnow()).total_seconds()
         if delay > 0:
@@ -70,7 +73,12 @@ class Scheduler:
         self.schedule(task_id, coroutine)
 
     def schedule_later(self, delay: t.Union[int, float], task_id: t.Hashable, coroutine: t.Coroutine) -> None:
-        """Schedule `coroutine` to be executed after the given `delay` number of seconds."""
+        """
+        Schedule `coroutine` to be executed after the given `delay` number of seconds.
+
+        If a task with `task_id` already exists, close `coroutine` instead of scheduling it. This
+        prevents unawaited coroutine warnings. Don't pass a coroutine that'll be re-used elsewhere.
+        """
         self.schedule(task_id, self._await_later(delay, task_id, coroutine))
 
     def cancel(self, task_id: t.Hashable) -> None:

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -20,11 +20,17 @@ class Scheduler:
         return task_id in self._scheduled_tasks
 
     def schedule(self, task_id: t.Hashable, coroutine: t.Coroutine) -> None:
-        """Schedule the execution of a coroutine."""
+        """
+        Schedule the execution of a coroutine.
+
+        If a task with `task_id` already exists, close `coroutine` instead of scheduling it.
+        This prevents unawaited coroutine warnings.
+        """
         self._log.trace(f"Scheduling task #{task_id}...")
 
         if task_id in self._scheduled_tasks:
             self._log.debug(f"Did not schedule task #{task_id}; task was already scheduled.")
+            coroutine.close()
             return
 
         task = asyncio.create_task(coroutine, name=f"{self.name}_{task_id}")

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -64,7 +64,6 @@ class Scheduler:
         except KeyError:
             self._log.warning(f"Failed to unschedule {task_id} (no task found).")
         else:
-            del self._scheduled_tasks[task_id]
             task.cancel()
 
             self._log.debug(f"Unscheduled task #{task_id} {id(task)}.")

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -18,15 +18,15 @@ class Scheduler:
         """Return True if a task with the given `task_id` is currently scheduled."""
         return task_id in self._scheduled_tasks
 
-    def schedule(self, task_id: t.Hashable, task: t.Awaitable) -> None:
-        """Schedule the execution of a task."""
+    def schedule(self, task_id: t.Hashable, coroutine: t.Coroutine) -> None:
+        """Schedule the execution of a coroutine."""
         self._log.trace(f"Scheduling task #{task_id}...")
 
         if task_id in self._scheduled_tasks:
             self._log.debug(f"Did not schedule task #{task_id}; task was already scheduled.")
             return
 
-        task = asyncio.create_task(task, name=f"{self.name}_{task_id}")
+        task = asyncio.create_task(coroutine, name=f"{self.name}_{task_id}")
         task.add_done_callback(partial(self._task_done_callback, task_id))
 
         self._scheduled_tasks[task_id] = task

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -18,7 +18,7 @@ class Scheduler:
         """Return True if a task with the given `task_id` is currently scheduled."""
         return task_id in self._scheduled_tasks
 
-    def schedule_task(self, task_id: t.Hashable, task: t.Awaitable) -> None:
+    def schedule(self, task_id: t.Hashable, task: t.Awaitable) -> None:
         """Schedule the execution of a task."""
         self._log.trace(f"Scheduling task #{task_id}...")
 
@@ -32,7 +32,7 @@ class Scheduler:
         self._scheduled_tasks[task_id] = task
         self._log.debug(f"Scheduled task #{task_id} {id(task)}.")
 
-    def cancel_task(self, task_id: t.Hashable) -> None:
+    def cancel(self, task_id: t.Hashable) -> None:
         """Unschedule the task identified by `task_id`. Log a warning if the task doesn't exist."""
         self._log.trace(f"Cancelling task #{task_id}...")
 
@@ -51,7 +51,7 @@ class Scheduler:
         self._log.debug("Unscheduling all tasks")
 
         for task_id in self._scheduled_tasks.copy():
-            self.cancel_task(task_id)
+            self.cancel(task_id)
 
     def _task_done_callback(self, task_id: t.Hashable, done_task: asyncio.Task) -> None:
         """

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import logging
 import typing as t
+from datetime import datetime
 from functools import partial
 
 
@@ -31,6 +32,18 @@ class Scheduler:
 
         self._scheduled_tasks[task_id] = task
         self._log.debug(f"Scheduled task #{task_id} {id(task)}.")
+
+    def schedule_at(self, time: datetime, task_id: t.Hashable, coroutine: t.Coroutine) -> None:
+        """
+        Schedule `coroutine` to be executed at the given naïve UTC `time`.
+
+        If `time` is in the past, schedule `coroutine` immediately.
+        """
+        delay = (time - datetime.utcnow()).total_seconds()
+        if delay > 0:
+            coroutine = self._await_later(delay, coroutine)
+
+        self.schedule(task_id, coroutine)
 
     def schedule_later(self, delay: t.Union[int, float], task_id: t.Hashable, coroutine: t.Coroutine) -> None:
         """Schedule `coroutine` to be executed after the given `delay` number of seconds."""

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -39,17 +39,17 @@ class Scheduler:
         If `ignore_missing` is True, a warning will not be sent if a task isn't found.
         """
         self._log.trace(f"Cancelling task #{task_id}...")
-        task = self._scheduled_tasks.get(task_id)
 
-        if not task:
+        try:
+            task = self._scheduled_tasks.pop(task_id)
+        except KeyError:
             if not ignore_missing:
                 self._log.warning(f"Failed to unschedule {task_id} (no task found).")
-            return
+        else:
+            del self._scheduled_tasks[task_id]
+            task.cancel()
 
-        del self._scheduled_tasks[task_id]
-        task.cancel()
-
-        self._log.debug(f"Unscheduled task #{task_id} {id(task)}.")
+            self._log.debug(f"Unscheduled task #{task_id} {id(task)}.")
 
     def cancel_all(self) -> None:
         """Unschedule all known tasks."""

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -22,7 +22,7 @@ class Scheduler:
             self._log.debug(f"Did not schedule task #{task_id}; task was already scheduled.")
             return
 
-        task = asyncio.create_task(task)
+        task = asyncio.create_task(task, name=f"{self.name}_{task_id}")
         task.add_done_callback(partial(self._task_done_callback, task_id))
 
         self._scheduled_tasks[task_id] = task

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -14,6 +14,10 @@ class Scheduler:
         self._log = logging.getLogger(f"{__name__}.{name}")
         self._scheduled_tasks: t.Dict[t.Hashable, asyncio.Task] = {}
 
+    def __contains__(self, task_id: t.Hashable) -> bool:
+        """Return True if a task with the given `task_id` is currently scheduled."""
+        return task_id in self._scheduled_tasks
+
     def schedule_task(self, task_id: t.Hashable, task: t.Awaitable) -> None:
         """Schedule the execution of a task."""
         self._log.trace(f"Scheduling task #{task_id}...")


### PR DESCRIPTION
Resolves #800

The `Scheduler` must be instantiated rather than inherited. The new API relies on a coroutine being passed to one of three functions:

* `schedule()` - schedule a coroutine immediately as a `Task`
* `schedule_at()` - schedule a coroutine to run at a given `datetime.datetime`
* `schedule_later()` - schedule a coroutine to run after sleeping for a given number of seconds

The need to implement an abstract method has been done away with. The ability to pass an arbitrary coroutine makes the `Scheduler` inherently more flexible. I wanted some discussion (https://github.com/python-discord/bot/issues/800#issuecomment-647047778) on the signatures of these functions but I am content with the design I chose for the time being.

`__contains__` was implemented to support checking for scheduled tasks by ID using the `in` operator. With this new possibility, the `ignore_missing` parameter of `cancel` was made redundant and removed.

The `Scheduler` carries over the coroutine closing logic from `HelpChannels`, which was done to prevent unawaited coroutine warnings. A bug with it has also been fixed. Now all users of the `Scheduler` can take advantage of this. 

I'm aware an exception is raised when a reminder is deleted. I believe this exception was always being raised; it just wasn't visible until now. It will be fixed by #835.