### PR TITLE
Add range-len tag

### DIFF
--- a/bot/resources/tags/range-len.md
+++ b/bot/resources/tags/range-len.md
@@ -1,19 +1,15 @@
-Iterating over `range(len(...))` is a common approach to accessing each item
-in an ordered collection.
+Iterating over `range(len(...))` is a common approach to accessing each item in an ordered collection.
 
 ```py
 for i in range(len(my_list)):
     do_something(my_list[i])
 ```
 
-The pythonic syntax is much simpler, and is
-guaranteed to produce elements in the same order:
+The pythonic syntax is much simpler, and is guaranteed to produce elements in the same order:
 
 ```py
 for item in my_list:
     do_something(item)
 ```
 
-Python has other solutions for cases when the index itself might be needed.
-To get the element at the same index from two or more lists, use [zip](https://docs.python.org/3/library/functions.html#zip).
-To get both the index and the element at that index, use [enumerate](https://docs.python.org/3/library/functions.html#enumerate).
+Python has other solutions for cases when the index itself might be needed. To get the element at the same index from two or more lists, use [zip](https://docs.python.org/3/library/functions.html#zip). To get both the index and the element at that index, use [enumerate](https://docs.python.org/3/library/functions.html#enumerate).

--- a/bot/resources/tags/range-len.md
+++ b/bot/resources/tags/range-len.md
@@ -1,0 +1,19 @@
+Iterating over `range(len(...))` is a common approach to accessing each item
+in an ordered collection.
+
+```py
+for i in range(len(my_list)):
+    do_something(my_list[i])
+```
+
+The pythonic syntax is much simpler, and is
+guaranteed to produce elements in the same order:
+
+```py
+for item in my_list:
+    do_something(item)
+```
+
+Python has other solutions for cases when the index itself might be needed.
+To get the element at the same index from two or more lists, use [zip](https://docs.python.org/3/library/functions.html#zip).
+To get both the index and the element at that index, use [enumerate](https://docs.python.org/3/library/functions.html#enumerate).

--- a/bot/resources/tags/range-len.md
+++ b/bot/resources/tags/range-len.md
@@ -1,15 +1,11 @@
 Iterating over `range(len(...))` is a common approach to accessing each item in an ordered collection.
-
 ```py
 for i in range(len(my_list)):
     do_something(my_list[i])
 ```
-
 The pythonic syntax is much simpler, and is guaranteed to produce elements in the same order:
-
 ```py
 for item in my_list:
     do_something(item)
 ```
-
 Python has other solutions for cases when the index itself might be needed. To get the element at the same index from two or more lists, use [zip](https://docs.python.org/3/library/functions.html#zip). To get both the index and the element at that index, use [enumerate](https://docs.python.org/3/library/functions.html#enumerate).


### PR DESCRIPTION
This would be a message we could whip out when we see `range(len(...))` for loops during help sessions. I intentionally left out a lot of interesting details to keep the message concise.

I recall there being a RealPython article about "pythonic loops" and was hoping to link to it, but it looks like it's now paid content. I saw that our guides are under construction and I'd be happy to write a guide on loops with an emphasis on pythonicness.

I don't know that linking to the official Python docs is a digestible resource for some learners, especially those who don't have experience in other languages, so I'm very much open to alternatives for those.