### PR TITLE
Allow ordering talentpool/bigbrother watched users by oldest added

### DIFF
--- a/bot/cogs/watchchannels/bigbrother.py
+++ b/bot/cogs/watchchannels/bigbrother.py
@@ -35,14 +35,29 @@ class BigBrother(WatchChannel, Cog, name="Big Brother"):
 
     @bigbrother_group.command(name='watched', aliases=('all', 'list'))
     @with_role(*MODERATION_ROLES)
-    async def watched_command(self, ctx: Context, update_cache: bool = True) -> None:
+    async def watched_command(
+        self, ctx: Context, oldest_first: bool = False, update_cache: bool = True
+    ) -> None:
         """
         Shows the users that are currently being monitored by Big Brother.
+
+        The optional kwarg `oldest_first` can be used to order the list by oldest watched.
 
         The optional kwarg `update_cache` can be used to update the user
         cache using the API before listing the users.
         """
-        await self.list_watched_users(ctx, update_cache=update_cache)
+        await self.list_watched_users(ctx, oldest_first=oldest_first, update_cache=update_cache)
+
+    @bigbrother_group.command(name='oldest')
+    @with_role(*MODERATION_ROLES)
+    async def oldest_command(self, ctx: Context, update_cache: bool = True) -> None:
+        """
+        Shows Big Brother monitored users ordered by oldest watched.
+
+        The optional kwarg `update_cache` can be used to update the user
+        cache using the API before listing the users.
+        """
+        await ctx.invoke(self.watched_command, oldest_first=True, update_cache=update_cache)
 
     @bigbrother_group.command(name='watch', aliases=('w',))
     @with_role(*MODERATION_ROLES)

--- a/bot/cogs/watchchannels/bigbrother.py
+++ b/bot/cogs/watchchannels/bigbrother.py
@@ -42,7 +42,7 @@ class BigBrother(WatchChannel, Cog, name="Big Brother"):
         The optional kwarg `update_cache` can be used to update the user
         cache using the API before listing the users.
         """
-        await self.list_watched_users(ctx, update_cache)
+        await self.list_watched_users(ctx, update_cache=update_cache)
 
     @bigbrother_group.command(name='watch', aliases=('w',))
     @with_role(*MODERATION_ROLES)

--- a/bot/cogs/watchchannels/talentpool.py
+++ b/bot/cogs/watchchannels/talentpool.py
@@ -38,14 +38,18 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
 
     @nomination_group.command(name='watched', aliases=('all', 'list'))
     @with_role(*MODERATION_ROLES)
-    async def watched_command(self, ctx: Context, update_cache: bool = True) -> None:
+    async def watched_command(
+        self, ctx: Context, oldest_first: bool = False, update_cache: bool = True
+    ) -> None:
         """
         Shows the users that are currently being monitored in the talent pool.
+
+        The optional kwarg `oldest_first` can be used to order the list by oldest nomination.
 
         The optional kwarg `update_cache` can be used to update the user
         cache using the API before listing the users.
         """
-        await self.list_watched_users(ctx, update_cache)
+        await self.list_watched_users(ctx, oldest_first=oldest_first, update_cache=update_cache)
 
     @nomination_group.command(name='watch', aliases=('w', 'add', 'a'))
     @with_role(*STAFF_ROLES)

--- a/bot/cogs/watchchannels/talentpool.py
+++ b/bot/cogs/watchchannels/talentpool.py
@@ -51,6 +51,17 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
         """
         await self.list_watched_users(ctx, oldest_first=oldest_first, update_cache=update_cache)
 
+    @nomination_group.command(name='oldest')
+    @with_role(*MODERATION_ROLES)
+    async def oldest_command(self, ctx: Context, update_cache: bool = True) -> None:
+        """
+        Shows talent pool monitored users ordered by oldest nomination.
+
+        The optional kwarg `update_cache` can be used to update the user
+        cache using the API before listing the users.
+        """
+        await ctx.invoke(self.watched_command, oldest_first=True, update_cache=update_cache)
+
     @nomination_group.command(name='watch', aliases=('w', 'add', 'a'))
     @with_role(*STAFF_ROLES)
     async def watch_command(self, ctx: Context, user: FetchedMember, *, reason: str) -> None:

--- a/bot/cogs/watchchannels/watchchannel.py
+++ b/bot/cogs/watchchannels/watchchannel.py
@@ -287,7 +287,9 @@ class WatchChannel(metaclass=CogABCMeta):
 
         await self.webhook_send(embed=embed, username=msg.author.display_name, avatar_url=msg.author.avatar_url)
 
-    async def list_watched_users(self, ctx: Context, update_cache: bool = True) -> None:
+    async def list_watched_users(
+        self, ctx: Context, oldest_first: bool = False, update_cache: bool = True
+    ) -> None:
         """
         Gives an overview of the watched user list for this channel.
 
@@ -305,7 +307,11 @@ class WatchChannel(metaclass=CogABCMeta):
             time_delta = self._get_time_delta(inserted_at)
             lines.append(f"• <@{user_id}> (added {time_delta})")
 
+        if oldest_first:
+            lines.reverse()
+
         lines = lines or ("There's nothing here yet.",)
+
         embed = Embed(
             title=f"{self.__class__.__name__} watched users ({'updated' if update_cache else 'cached'})",
             color=Color.blue()

--- a/bot/cogs/watchchannels/watchchannel.py
+++ b/bot/cogs/watchchannels/watchchannel.py
@@ -293,6 +293,8 @@ class WatchChannel(metaclass=CogABCMeta):
         """
         Gives an overview of the watched user list for this channel.
 
+        The optional kwarg `oldest_first` orders the list by oldest entry.
+
         The optional kwarg `update_cache` specifies whether the cache should
         be refreshed by polling the API.
         """


### PR DESCRIPTION
This PR modifies `!talentpool watched` and adds a new command `!talentpool oldest` to allow convenient listing of talent pool nominees by oldest added.

# Screenshots

New argument is added to `!talentpool watched`:
![image](https://user-images.githubusercontent.com/41782385/87379145-2303cb80-c5c2-11ea-96b7-6e063cb4e01b.png)

`!talentpool watched` with `oldest_first = True`:
![image](https://user-images.githubusercontent.com/41782385/87379181-3dd64000-c5c2-11ea-8470-749ffdf27379.png)

`!talentpool oldest` is added for convenience:
![image](https://user-images.githubusercontent.com/41782385/87379237-59d9e180-c5c2-11ea-91d5-df32bc01bbb2.png)
