### PR TITLE
Invoke fuzzywuzzy's processor before matching

### DIFF
--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -150,8 +150,8 @@ class CustomHelpCommand(HelpCommand):
 
         # Run fuzzywuzzy's processor beforehand, and avoid matching if processed string is empty
         # This avoids fuzzywuzzy from raising a warning on inputs with only non-alphanumeric characters
-        if full_process(string):
-            result = process.extractBests(string, choices, scorer=fuzz.ratio, score_cutoff=60, processor=None)
+        if (processed := full_process(string)):
+            result = process.extractBests(processed, choices, scorer=fuzz.ratio, score_cutoff=60, processor=None)
         else:
             result = []
 

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -8,6 +8,7 @@ from typing import List, Union
 from discord import Colour, Embed, Member, Message, NotFound, Reaction, User
 from discord.ext.commands import Bot, Cog, Command, Context, Group, HelpCommand
 from fuzzywuzzy import fuzz, process
+from fuzzywuzzy.utils import full_process
 
 from bot import constants
 from bot.constants import Channels, Emojis, STAFF_ROLES
@@ -146,7 +147,13 @@ class CustomHelpCommand(HelpCommand):
         Will return an instance of the `HelpQueryNotFound` exception with the error message and possible matches.
         """
         choices = await self.get_all_help_choices()
-        result = process.extractBests(string, choices, scorer=fuzz.ratio, score_cutoff=60)
+
+        # Run fuzzywuzzy's processor beforehand, and avoid matching if processed string is empty
+        # This avoids fuzzywuzzy from raising a warning on inputs with only non-alphanumeric characters
+        if full_process(string):
+            result = process.extractBests(string, choices, scorer=fuzz.ratio, score_cutoff=60, processor=None)
+        else:
+            result = []
 
         return HelpQueryNotFound(f'Query "{string}" not found.', dict(result))
 


### PR DESCRIPTION
Fixes #980 

Trying to match a string with only non-alphanumeric characters results in a warning by fuzzywuzzy.
Processing the string before matching lets us avoid the warning, which uses the root logger and thus isn't supressible.