### PR TITLE
Suppress NotFound when removing help command reactions

### DIFF
--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -36,13 +36,12 @@ async def help_cleanup(bot: Bot, author: Member, message: Message) -> None:
 
     await message.add_reaction(DELETE_EMOJI)
 
-    try:
-        await bot.wait_for("reaction_add", check=check, timeout=300)
-        await message.delete()
-    except TimeoutError:
-        await message.remove_reaction(DELETE_EMOJI, bot.user)
-    except NotFound:
-        pass
+    with suppress(NotFound):
+        try:
+            await bot.wait_for("reaction_add", check=check, timeout=300)
+            await message.delete()
+        except TimeoutError:
+            await message.remove_reaction(DELETE_EMOJI, bot.user)
 
 
 class HelpQueryNotFound(ValueError):


### PR DESCRIPTION
The message may be deleted somehow before the `wait_for` times out.

Fixes #1050