### PR TITLE
DM relay - minor fixes

### DIFF
--- a/bot/cogs/dm_relay.py
+++ b/bot/cogs/dm_relay.py
@@ -8,6 +8,7 @@ from discord.ext.commands import Cog
 
 from bot import constants
 from bot.bot import Bot
+from bot.converters import UserMentionOrID
 from bot.utils import RedisCache
 from bot.utils.checks import in_whitelist_check, with_role_check
 from bot.utils.messages import send_attachments
@@ -29,7 +30,7 @@ class DMRelay(Cog):
         self.bot.loop.create_task(self.fetch_webhook())
 
     @commands.command(aliases=("reply",))
-    async def send_dm(self, ctx: commands.Context, member: Optional[discord.Member], *, message: str) -> None:
+    async def send_dm(self, ctx: commands.Context, member: Optional[UserMentionOrID], *, message: str) -> None:
         """
         Allows you to send a DM to a user from the bot.
 

--- a/bot/cogs/dm_relay.py
+++ b/bot/cogs/dm_relay.py
@@ -48,10 +48,12 @@ class DMRelay(Cog):
             if member:
                 await member.send(message)
                 await ctx.message.add_reaction("✅")
+                self.bot.stats.incr("dm_relay.dm_sent")
                 return
             elif last_dm_user:
                 await last_dm_user.send(message)
                 await ctx.message.add_reaction("✅")
+                self.bot.stats.incr("dm_relay.dm_sent")
                 return
             else:
                 log.debug("This bot has never gotten a DM, or the RedisCache has been cleared.")
@@ -84,6 +86,7 @@ class DMRelay(Cog):
                 avatar_url=message.author.avatar_url
             )
             await self.dm_cache.set("last_user", message.author.id)
+            self.bot.stats.incr("dm_relay.dm_received")
 
         # Handle any attachments
         if message.attachments:

--- a/bot/cogs/dm_relay.py
+++ b/bot/cogs/dm_relay.py
@@ -80,7 +80,7 @@ class DMRelay(Cog):
             await send_webhook(
                 webhook=self.webhook,
                 content=message.clean_content,
-                username=message.author.display_name,
+                username=f"{message.author.display_name} ({message.author.id})",
                 avatar_url=message.author.avatar_url
             )
             await self.dm_cache.set("last_user", message.author.id)

--- a/bot/cogs/dm_relay.py
+++ b/bot/cogs/dm_relay.py
@@ -60,9 +60,6 @@ class DMRelay(Cog):
         else:
             await ctx.message.add_reaction("✅")
             self.bot.stats.incr("dm_relay.dm_sent")
-        except discord.errors.Forbidden:
-            log.debug("User has disabled DMs.")
-            await ctx.message.add_reaction("❌")
 
     async def fetch_webhook(self) -> None:
         """Fetches the webhook object, so we can post to it."""

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -341,10 +341,7 @@ class UserMentionOrID(UserConverter):
 
     async def convert(self, ctx: Context, argument: str) -> discord.User:
         """Convert the `arg` to a `discord.User`."""
-        print(argument)
         match = self._get_id_match(argument) or re.match(r'<@!?([0-9]+)>$', argument)
-
-        print(match)
 
         if match is not None:
             return await super().convert(ctx, argument)

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -330,6 +330,28 @@ def proxy_user(user_id: str) -> discord.Object:
     return user
 
 
+class UserMentionOrID(UserConverter):
+    """
+    Converts to a `discord.User`, but only if a mention or userID is provided.
+
+    Unlike the default `UserConverter`, it does allow conversion from name, or name#descrim.
+
+    This is useful in cases where that lookup strategy would lead to ambiguity.
+    """
+
+    async def convert(self, ctx: Context, argument: str) -> discord.User:
+        """Convert the `arg` to a `discord.User`."""
+        print(argument)
+        match = self._get_id_match(argument) or re.match(r'<@!?([0-9]+)>$', argument)
+
+        print(match)
+
+        if match is not None:
+            return await super().convert(ctx, argument)
+        else:
+            raise BadArgument(f"`{argument}` is not a User mention or a User ID.")
+
+
 class FetchedUser(UserConverter):
     """
     Converts to a `discord.User` or, if it fails, a `discord.Object`.


### PR DESCRIPTION
This hotfix PR makes three minor changes - We restore user caching, add the user ID to the author name, and add some stats.

## User caching
We previously had a feature to allow a `!reply` without specifying the target user. This was removed because we were afraid that the number of DMs would be so great that the risk of replying to the wrong user was high.

As it turns out, this traffic is much lower than anticipated and the risk of replying to the wrong user appears to be low. That, coupled with the fact that we shouldn't really be using `!reply` for anything serious, has made me decide to restore this functionality.

## Adding the user ID to the username
When we get a DM, there's no actual user mention since it's relayed via a webhook. That means that a moderator would have to search for that user and figure out what their ID is in order to do stuff like infraction searches.

To make this easier, I'm adding the user ID to the author name:
![image](https://user-images.githubusercontent.com/2098517/87508254-3f117680-c66f-11ea-95b0-a7ed4b41ada4.png)


## Stats!
We're now incrementing `dm_relay.dm_sent` whenever we send a DM, and `dm_relay.dm_received` whenever we receive one. This should allow us to track how many DMs the bot sends and receives.