### PR TITLE
Truncate charinfo results

### DIFF
--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -12,6 +12,7 @@ from discord.ext.commands import BadArgument, Cog, Context, command
 from bot.bot import Bot
 from bot.constants import Channels, MODERATION_ROLES, STAFF_ROLES
 from bot.decorators import in_whitelist, with_role
+from bot.pagination import LinePaginator
 from bot.utils import messages
 
 log = logging.getLogger(__name__)
@@ -142,15 +143,14 @@ class Utils(Cog):
             info = f"`{u_code.ljust(10)}`: {name} - {utils.escape_markdown(char)}"
             return info, u_code
 
-        charlist, rawlist = zip(*(get_info(c) for c in characters))
-
-        embed = Embed(description="\n".join(charlist))
-        embed.set_author(name="Character Info")
+        char_list, raw_list = zip(*(get_info(c) for c in characters))
+        embed = Embed().set_author(name="Character Info")
 
         if len(characters) > 1:
-            embed.add_field(name='Raw', value=f"`{''.join(rawlist)}`", inline=False)
+            # Maximum length possible is 252 so no need to truncate.
+            embed.add_field(name='Raw', value=f"`{''.join(raw_list)}`", inline=False)
 
-        await ctx.send(embed=embed)
+        await LinePaginator.paginate(char_list, ctx, embed, max_size=2000, empty=False)
 
     @command()
     async def zen(self, ctx: Context, *, search_value: Union[int, str, None] = None) -> None:

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -119,7 +119,7 @@ class Utils(Cog):
     @command()
     @in_whitelist(channels=(Channels.bot_commands,), roles=STAFF_ROLES)
     async def charinfo(self, ctx: Context, *, characters: str) -> None:
-        """Shows you information on up to 25 unicode characters."""
+        """Shows you information on up to 50 unicode characters."""
         match = re.match(r"<(a?):(\w+):(\d+)>", characters)
         if match:
             return await messages.send_denial(
@@ -129,7 +129,7 @@ class Utils(Cog):
                 "was found. Please remove it and try again."
             )
 
-        if len(characters) > 25:
+        if len(characters) > 50:
             return await messages.send_denial(ctx, f"Too many characters ({len(characters)}/25)")
 
         def get_info(char: str) -> Tuple[str, str]:
@@ -147,10 +147,10 @@ class Utils(Cog):
         embed = Embed().set_author(name="Character Info")
 
         if len(characters) > 1:
-            # Maximum length possible is 252 so no need to truncate.
+            # Maximum length possible is 502 out of 1024, so there's no need to truncate.
             embed.add_field(name='Full Raw Text', value=f"`{''.join(raw_list)}`", inline=False)
 
-        await LinePaginator.paginate(char_list, ctx, embed, max_size=2000, empty=False)
+        await LinePaginator.paginate(char_list, ctx, embed, max_lines=10, max_size=2000, empty=False)
 
     @command()
     async def zen(self, ctx: Context, *, search_value: Union[int, str, None] = None) -> None:

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -130,7 +130,7 @@ class Utils(Cog):
             )
 
         if len(characters) > 50:
-            return await messages.send_denial(ctx, f"Too many characters ({len(characters)}/25)")
+            return await messages.send_denial(ctx, f"Too many characters ({len(characters)}/50)")
 
         def get_info(char: str) -> Tuple[str, str]:
             digit = f"{ord(char):x}"

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -148,7 +148,7 @@ class Utils(Cog):
 
         if len(characters) > 1:
             # Maximum length possible is 252 so no need to truncate.
-            embed.add_field(name='Raw', value=f"`{''.join(raw_list)}`", inline=False)
+            embed.add_field(name='Full Raw Text', value=f"`{''.join(raw_list)}`", inline=False)
 
         await LinePaginator.paginate(char_list, ctx, embed, max_size=2000, empty=False)
 

--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -12,6 +12,7 @@ from discord.ext.commands import BadArgument, Cog, Context, command
 from bot.bot import Bot
 from bot.constants import Channels, MODERATION_ROLES, STAFF_ROLES
 from bot.decorators import in_whitelist, with_role
+from bot.utils import messages
 
 log = logging.getLogger(__name__)
 
@@ -120,22 +121,15 @@ class Utils(Cog):
         """Shows you information on up to 25 unicode characters."""
         match = re.match(r"<(a?):(\w+):(\d+)>", characters)
         if match:
-            embed = Embed(
-                title="Non-Character Detected",
-                description=(
-                    "Only unicode characters can be processed, but a custom Discord emoji "
-                    "was found. Please remove it and try again."
-                )
+            return await messages.send_denial(
+                ctx,
+                "**Non-Character Detected**\n"
+                "Only unicode characters can be processed, but a custom Discord emoji "
+                "was found. Please remove it and try again."
             )
-            embed.colour = Colour.red()
-            await ctx.send(embed=embed)
-            return
 
         if len(characters) > 25:
-            embed = Embed(title=f"Too many characters ({len(characters)}/25)")
-            embed.colour = Colour.red()
-            await ctx.send(embed=embed)
-            return
+            return await messages.send_denial(ctx, f"Too many characters ({len(characters)}/25)")
 
         def get_info(char: str) -> Tuple[str, str]:
             digit = f"{ord(char):x}"


### PR DESCRIPTION
Fixes #897 

Just uses the `LinePaginator`. The `raw` field is present and has the exact same value on every page. I'm concerned it may be unclear whether the value is only for the current page or for the entire input (the truth is the latter).

![bild](https://user-images.githubusercontent.com/1515135/88108153-3c29f080-cb5d-11ea-9dfc-7c7e08a6c49d.png)

I also updated the command to use the new `send_denial` utility function since the existing code was quite similar to what the helper does. The difference is that `send_denial` has those comedic titles.

![bild](https://user-images.githubusercontent.com/1515135/88108492-cd996280-cb5d-11ea-8bcb-8c3b7d6d761b.png)


![bild](https://user-images.githubusercontent.com/1515135/88108490-c83c1800-cb5d-11ea-954b-03c00497ea21.png)