### PR TITLE
Support multiple categories for code jam team creation

### DIFF
--- a/tests/bot/cogs/test_jams.py
+++ b/tests/bot/cogs/test_jams.py
@@ -80,13 +80,14 @@ class JamCreateTeamTests(unittest.IsolatedAsyncioTestCase):
             self.guild.categories = categories
 
             with self.subTest(categories=categories):
-                await self.cog.get_category(self.guild)
+                actual_category = await self.cog.get_category(self.guild)
 
                 self.guild.create_category_channel.assert_awaited_once()
                 category_overwrites = self.guild.create_category_channel.call_args[1]["overwrites"]
 
                 self.assertFalse(category_overwrites[self.guild.default_role].read_messages)
                 self.assertTrue(category_overwrites[self.guild.me].read_messages)
+                self.assertEqual(self.guild.create_category_channel.return_value, actual_category)
 
     async def test_category_channel_exist(self):
         """Should not try to create category channel."""

--- a/tests/bot/cogs/test_jams.py
+++ b/tests/bot/cogs/test_jams.py
@@ -72,7 +72,7 @@ class JamCreateTeamTests(unittest.IsolatedAsyncioTestCase):
         subtests = (
             [],
             [get_mock_category(jams.MAX_CHANNELS - 1, jams.CATEGORY_NAME)],
-            [get_mock_category(48, "other")],
+            [get_mock_category(jams.MAX_CHANNELS - 2, "other")],
         )
 
         for categories in subtests:
@@ -91,11 +91,11 @@ class JamCreateTeamTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_category_channel_exist(self):
         """Should not try to create category channel."""
-        expected_category = get_mock_category(48, jams.CATEGORY_NAME)
+        expected_category = get_mock_category(jams.MAX_CHANNELS - 2, jams.CATEGORY_NAME)
         self.guild.categories = [
-            get_mock_category(48, "other"),
+            get_mock_category(jams.MAX_CHANNELS - 2, "other"),
             expected_category,
-            get_mock_category(6, jams.CATEGORY_NAME),
+            get_mock_category(0, jams.CATEGORY_NAME),
         ]
 
         actual_category = await self.cog.get_category(self.guild)

--- a/tests/bot/cogs/test_jams.py
+++ b/tests/bot/cogs/test_jams.py
@@ -67,15 +67,26 @@ class JamCreateTeamTests(unittest.IsolatedAsyncioTestCase):
         self.cog.add_roles.assert_awaited_once()
         self.ctx.send.assert_awaited_once()
 
-    async def test_category_dont_exist(self):
-        """Should create code jam category."""
-        await self.cog.get_category(self.guild)
+    async def test_category_doesnt_exist(self):
+        """Should create a new code jam category."""
+        subtests = (
+            [],
+            [get_mock_category(jams.MAX_CHANNELS - 1, jams.CATEGORY_NAME)],
+            [get_mock_category(48, "other")],
+        )
 
-        self.guild.create_category_channel.assert_awaited_once()
-        category_overwrites = self.guild.create_category_channel.call_args[1]["overwrites"]
+        for categories in subtests:
+            self.guild.reset_mock()
+            self.guild.categories = categories
 
-        self.assertFalse(category_overwrites[self.guild.default_role].read_messages)
-        self.assertTrue(category_overwrites[self.guild.me].read_messages)
+            with self.subTest(categories=categories):
+                await self.cog.get_category(self.guild)
+
+                self.guild.create_category_channel.assert_awaited_once()
+                category_overwrites = self.guild.create_category_channel.call_args[1]["overwrites"]
+
+                self.assertFalse(category_overwrites[self.guild.default_role].read_messages)
+                self.assertTrue(category_overwrites[self.guild.me].read_messages)
 
     async def test_category_channel_exist(self):
         """Should not try to create category channel."""


### PR DESCRIPTION
Discord has a limit of 50 channels per category. Each team needs 2 channels (text and voice). This change creates a new category if all existing categories are full. It prioritises the category with the highest position. If the previously full category gets freed up, the new team will be placed in it, assuming the category is still higher than the more recent category.

Critical priority because we anticipate over 25 teams in the upcoming jam (less than a week away).