### PR TITLE
Check that embed desc is not Empty before stripping.

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -428,8 +428,11 @@ class HelpChannels(commands.Cog):
         if not message or not message.embeds:
             return False
 
-        embed = message.embeds[0]
-        return message.author == self.bot.user and embed.description.strip() == description.strip()
+        bot_msg_desc = message.embeds[0].description
+        if bot_msg_desc is discord.Embed.Empty:
+            log.trace("Last message was a bot embed but it was empty.")
+            return False
+        return message.author == self.bot.user and bot_msg_desc.strip() == description.strip()
 
     @staticmethod
     def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:


### PR DESCRIPTION
Fixes #1036 

I checked uses of embeds in other parts of the code to see if any of them perform methods on embed attributes, but couldn't find any. I might've missed something though.

The ones that use embed attributes as conditions (`if not embed.url`) are fine as `Embed.Empty` objects are falsy.