### PR TITLE
Don't ping everyone in #mod-alerts when tripping filter via DMs.

### DIFF
--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -339,7 +339,7 @@ class Filtering(Cog):
                             text=message,
                             thumbnail=msg.author.avatar_url_as(static_format="png"),
                             channel_id=Channels.mod_alerts,
-                            ping_everyone=Filter.ping_everyone,
+                            ping_everyone=Filter.ping_everyone if not is_private else False,
                             additional_embeds=additional_embeds,
                             additional_embeds_msg=additional_embeds_msg
                         )


### PR DESCRIPTION
We don't need a ping in #mod-alerts whenever someone is tripping a filter (like invites or bad language) in a DM to the bot. We can still send an embed, so that we can action it, but there is no urgent need to respond if it's just a direct message to the bot.

This is particularly true now that we have #dm-log.