### PR TITLE
Change regex so it catches new discord URL

### DIFF
--- a/bot/cogs/webhook_remover.py
+++ b/bot/cogs/webhook_remover.py
@@ -8,7 +8,7 @@ from bot.bot import Bot
 from bot.cogs.moderation.modlog import ModLog
 from bot.constants import Channels, Colours, Event, Icons
 
-WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discordapp\.com/api/webhooks/\d+/)\S+/?", re.I)
+WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(app)?\.com/api/webhooks/\d+/)\S+/?", re.I)
 
 ALERT_MESSAGE_TEMPLATE = (
     "{user}, looks like you posted a Discord webhook URL. Therefore, your "

--- a/bot/cogs/webhook_remover.py
+++ b/bot/cogs/webhook_remover.py
@@ -8,7 +8,7 @@ from bot.bot import Bot
 from bot.cogs.moderation.modlog import ModLog
 from bot.constants import Channels, Colours, Event, Icons
 
-WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(?:app)\.com/api/webhooks/\d+/)\S+/?", re.I)
+WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(?:app)?\.com/api/webhooks/\d+/)\S+/?", re.I)
 
 ALERT_MESSAGE_TEMPLATE = (
     "{user}, looks like you posted a Discord webhook URL. Therefore, your "

--- a/bot/cogs/webhook_remover.py
+++ b/bot/cogs/webhook_remover.py
@@ -8,7 +8,7 @@ from bot.bot import Bot
 from bot.cogs.moderation.modlog import ModLog
 from bot.constants import Channels, Colours, Event, Icons
 
-WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(app)?\.com/api/webhooks/\d+/)\S+/?", re.I)
+WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(?:app)\.com/api/webhooks/\d+/)\S+/?", re.I)
 
 ALERT_MESSAGE_TEMPLATE = (
     "{user}, looks like you posted a Discord webhook URL. Therefore, your "

--- a/bot/cogs/webhook_remover.py
+++ b/bot/cogs/webhook_remover.py
@@ -8,7 +8,7 @@ from bot.bot import Bot
 from bot.cogs.moderation.modlog import ModLog
 from bot.constants import Channels, Colours, Event, Icons
 
-WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(?:app)?\.com/api/webhooks/\d+/)\S+/?", re.I)
+WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(?:app)?\.com/api/webhooks/\d+/)\S+/?", re.IGNORECASE)
 
 ALERT_MESSAGE_TEMPLATE = (
     "{user}, looks like you posted a Discord webhook URL. Therefore, your "


### PR DESCRIPTION
Currently, discord is in process of switching to `discord.com` domain, while you can still get webhook URLs under `discordapp.com`, new ones are also under `discord.com`.
Our current regex won't catch new URLs resulting in messages containing valid URL not being removed.
This PR makes our regex catch both `discordapp.com` URLs aswell as `discord.com`.