### PR TITLE
Ignore webhooks for nickname filter

### DIFF
--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -120,7 +120,10 @@ class Filtering(Cog):
     async def on_message(self, msg: Message) -> None:
         """Invoke message filter for new messages."""
         await self._filter_message(msg)
-        await self.check_bad_words_in_name(msg.author)
+
+        # Ignore webhook messages.
+        if msg.webhook_id is None:
+            await self.check_bad_words_in_name(msg.author)
 
     @Cog.listener()
     async def on_message_edit(self, before: Message, after: Message) -> None:


### PR DESCRIPTION
Fixes #1027

I considered ignoring webhooks for all filters, but decided against it since some webhooks relay external user-generated content like reddit posts and mailing lists.