### PR TITLE
Utils: show error message for long poll titles

### DIFF
--- a/bot/cogs/utils.py
+++ b/bot/cogs/utils.py
@@ -232,6 +232,8 @@ class Utils(Cog):
         A maximum of 20 options can be provided, as Discord supports a max of 20
         reactions on a single message.
         """
+        if len(title) > 256:
+            raise BadArgument("The title cannot be longer than 256 characters.")
         if len(options) < 2:
             raise BadArgument("Please provide at least 2 options.")
         if len(options) > 20:


### PR DESCRIPTION
Embeds have a maximum length of 256 for titles.

Fixes #1079
Fixes BOT-7Q