### PR TITLE
Help channel message pin fixes

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -738,6 +738,7 @@ class HelpChannels(commands.Cog):
 
     async def is_empty(self, channel: discord.TextChannel) -> bool:
         """Return True if there's an AVAILABLE_MSG and the messages leading up are bot messages."""
+        log.trace(f"Checking if #{channel} ({channel.id}) is empty.")
         found = False
 
         # A limit of 100 results in a single API call.
@@ -745,9 +746,11 @@ class HelpChannels(commands.Cog):
         # Not gonna do an extensive search for it cause it's too expensive.
         async for msg in channel.history(limit=100):
             if not msg.author.bot:
+                log.trace(f"#{channel} ({channel.id}) has a non-bot message.")
                 return False
 
             if self.match_bot_embed(msg, AVAILABLE_MSG):
+                log.trace(f"#{channel} ({channel.id}) has the available message embed.")
                 found = True
                 break
 

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -858,6 +858,9 @@ class HelpChannels(commands.Cog):
         channel_str = f"#{channel} ({channel.id})"
 
         msg_id = await self.question_messages.pop(channel.id)
+        if msg_id is None:
+            log.debug(f"{channel_str} doesn't have a message pinned.")
+            return
 
         try:
             await self.bot.http.unpin_message(channel.id, msg_id)

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -739,7 +739,6 @@ class HelpChannels(commands.Cog):
     async def is_empty(self, channel: discord.TextChannel) -> bool:
         """Return True if there's an AVAILABLE_MSG and the messages leading up are bot messages."""
         log.trace(f"Checking if #{channel} ({channel.id}) is empty.")
-        found = False
 
         # A limit of 100 results in a single API call.
         # If AVAILABLE_MSG isn't found within 100 messages, then assume the channel is not empty.
@@ -751,10 +750,9 @@ class HelpChannels(commands.Cog):
 
             if self.match_bot_embed(msg, AVAILABLE_MSG):
                 log.trace(f"#{channel} ({channel.id}) has the available message embed.")
-                found = True
-                break
+                return True
 
-        return found
+        return False
 
     async def check_cooldowns(self) -> None:
         """Remove expired cooldowns and re-schedule active ones."""

--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -855,17 +855,21 @@ class HelpChannels(commands.Cog):
 
     async def unpin(self, channel: discord.TextChannel) -> None:
         """Unpin the initial question message sent in `channel`."""
+        channel_str = f"#{channel} ({channel.id})"
+
         msg_id = await self.question_messages.pop(channel.id)
 
         try:
             await self.bot.http.unpin_message(channel.id, msg_id)
         except discord.HTTPException as e:
             if e.code == 10008:
-                log.trace(f"Message {msg_id} don't exist, can't unpin.")
+                log.debug(f"Message {msg_id} in {channel_str} doesn't exist; can't unpin.")
             else:
-                log.warn(f"Got unexpected status {e.code} when unpinning message {msg_id}: {e.text}")
+                log.exception(
+                    f"Error unpinning message {msg_id} in {channel_str}: {e.status} ({e.code})"
+                )
         else:
-            log.trace(f"Unpinned message {msg_id}.")
+            log.trace(f"Unpinned message {msg_id} in {channel_str}.")
 
     async def wait_for_dormant_channel(self) -> discord.TextChannel:
         """Wait for a dormant channel to become available in the queue and return it."""

--- a/config-default.yml
+++ b/config-default.yml
@@ -432,8 +432,8 @@ help_channels:
     # Allowed duration of inactivity before making a channel dormant
     idle_minutes: 30
 
-    # Allowed duration of inactivity when question message deleted
-    # and no one other sent before message making channel dormant.
+    # Allowed duration of inactivity when channel is empty (due to deleted messages)
+    # before message making a channel dormant
     deleted_idle_minutes: 5
 
     # Maximum number of channels to put in the available category


### PR DESCRIPTION
Fixes #1082 - don't unpin message if the message ID is `None`. This only really happened when the pin feature was added and the cache was empty, but it doesn't hurt to check anyway.

The check for an empty channel was not accounting for the bot's `pins_add` message and therefore did not re-schedule the channel to be made dormant earlier when messages were deleted. It has been fixed by searching for the bot's available message embed within the last 100 messages and ensuring every message leading up to the embed was also a bot message. This means all bot messages are ignored, such as command invocations and the code block format embed.

Lastly, the pin and unpin code was refactored into separate functions. The refactor also makes them share error handling code, which reduces redundancy.

