### PR TITLE
Cancel scheduled tasks when cogs unload

### DIFF
--- a/bot/cogs/filtering.py
+++ b/bot/cogs/filtering.py
@@ -99,6 +99,10 @@ class Filtering(Cog):
 
         self.bot.loop.create_task(self.reschedule_offensive_msg_deletion())
 
+    def cog_unload(self) -> None:
+        """Cancel scheduled tasks."""
+        self.scheduler.cancel_all()
+
     def _get_filterlist_items(self, list_type: str, *, allowed: bool) -> list:
         """Fetch items from the filter_list_cache."""
         return self.bot.filter_list_cache[f"{list_type.upper()}.{allowed}"].keys()

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -31,6 +31,10 @@ class InfractionScheduler:
 
         self.bot.loop.create_task(self.reschedule_infractions(supported_infractions))
 
+    def cog_unload(self) -> None:
+        """Cancel scheduled tasks."""
+        self.scheduler.cancel_all()
+
     @property
     def mod_log(self) -> ModLog:
         """Get the currently loaded ModLog cog instance."""

--- a/bot/cogs/moderation/silence.py
+++ b/bot/cogs/moderation/silence.py
@@ -152,7 +152,8 @@ class Silence(commands.Cog):
         return False
 
     def cog_unload(self) -> None:
-        """Send alert with silenced channels on unload."""
+        """Send alert with silenced channels and cancel scheduled tasks on unload."""
+        self.scheduler.cancel_all()
         if self.muted_channels:
             channels_string = ''.join(channel.mention for channel in self.muted_channels)
             message = f"<@&{Roles.moderators}> channels left silenced on cog unload: {channels_string}"

--- a/bot/cogs/reminders.py
+++ b/bot/cogs/reminders.py
@@ -37,6 +37,10 @@ class Reminders(Cog):
 
         self.bot.loop.create_task(self.reschedule_reminders())
 
+    def cog_unload(self) -> None:
+        """Cancel scheduled tasks."""
+        self.scheduler.cancel_all()
+
     async def reschedule_reminders(self) -> None:
         """Get all current reminders from the API and reschedule them."""
         await self.bot.wait_until_guild_available()


### PR DESCRIPTION
When cogs reload, they used new Scheduler instances, which aren't aware of previously scheduled tasks. This led to duplicate scheduled tasks when cogs re-scheduled tasks upon initialisation.

Fixes #1080
Fixes BOT-7H