### PR TITLE
HelpChannels: use more reliable check for claimed channel

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -694,7 +694,7 @@ class HelpChannels(commands.Cog):
         async with self.on_message_lock:
             log.trace(f"on_message lock acquired for {message.id}.")
 
-            if not self.is_in_category(channel, constants.Categories.help_available):
+            if await self.help_channel_claimants.contains(channel.id):
                 log.debug(
                     f"Message {message.id} will not make #{channel} ({channel.id}) in-use "
                     f"because another message in the channel already triggered that."


### PR DESCRIPTION
Using the channel's category isn't reliable since it may take Discord a while to actually move the channel once it's received a request from the bot. I suppose using redis technically has the same problem, but it should be much faster and less susceptible to lag than Discord. If it's still a problem down the road, we can consider waiting for the channel update event from Discord. I didn't go for that solution right away since it's relatively more complicated and the gateway cannot exactly always be relied upon either.

Fixes #1074