### PR TITLE
Enhanced user command

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -268,6 +268,17 @@ class Emojis(metaclass=YAMLGetter):
     status_idle: str
     status_dnd: str
 
+    badge_staff: str
+    badge_partner: str
+    badge_hypesquad: str
+    badge_bug_hunter: str
+    badge_hypesquad_bravery: str
+    badge_hypesquad_brilliance: str
+    badge_hypesquad_balance: str
+    badge_early_supporter: str
+    badge_bug_hunter_level_2: str
+    badge_verified_bot_developer: str
+
     incident_actioned: str
     incident_unactioned: str
     incident_investigating: str

--- a/config-default.yml
+++ b/config-default.yml
@@ -38,6 +38,17 @@ style:
         status_dnd:     "<:status_dnd:470326272082313216>"
         status_offline: "<:status_offline:470326266537705472>"
 
+        badge_staff: "<:discord_staff:743882896498098226>"
+        badge_partner: "<:partner:743882897131569323>"
+        badge_hypesquad: "<:hypesquad_events:743882896892362873>"
+        badge_bug_hunter: "<:bug_hunter_lvl1:743882896372269137>"
+        badge_hypesquad_bravery: "<:hypesquad_bravery:743882896745693335>"
+        badge_hypesquad_brilliance: "<:hypesquad_brilliance:743882896938631248>"
+        badge_hypesquad_balance: "<:hypesquad_balance:743882896460480625>"
+        badge_early_supporter: "<:early_supporter:743882896909140058>"
+        badge_bug_hunter_level_2: "<:bug_hunter_lvl2:743882896611344505>"
+        badge_verified_bot_developer: "<:verified_bot_dev:743882897299210310>"
+
         incident_actioned:      "<:incident_actioned:719645530128646266>"
         incident_unactioned:    "<:incident_unactioned:719645583245180960>"
         incident_investigating: "<:incident_investigating:719645658671480924>"


### PR DESCRIPTION
Introduces new information into the `!user` command showing user badges & statuses on all different Discord platforms as well as switching our headers out for embed fields.

<img width="616" alt="Screenshot 2020-08-14 at 21 20 59" src="https://user-images.githubusercontent.com/20439493/90289566-0e8e4980-de74-11ea-9437-0b58d6cbaa22.png">
