### PR TITLE
Don't patch ctx.message.author in antispam

### DIFF
--- a/bot/cogs/antispam.py
+++ b/bot/cogs/antispam.py
@@ -219,7 +219,6 @@ class AntiSpam(Cog):
             # Get context and make sure the bot becomes the actor of infraction by patching the `author` attributes
             context = await self.bot.get_context(msg)
             context.author = self.bot.user
-            context.message.author = self.bot.user
 
             # Since we're going to invoke the tempmute command directly, we need to manually call the converter.
             dt_remove_role_after = await self.expiration_date_converter.convert(context, f"{remove_role_after}S")

--- a/bot/cogs/moderation/modlog.py
+++ b/bot/cogs/moderation/modlog.py
@@ -120,6 +120,10 @@ class ModLog(Cog, name="ModLog"):
             else:
                 content = "@everyone"
 
+        # Truncate content to 2000 characters and append an ellipsis.
+        if content and len(content) > 2000:
+            content = content[:2000 - 3] + "..."
+
         channel = self.bot.get_channel(channel_id)
         log_message = await channel.send(
             content=content,

--- a/bot/cogs/moderation/scheduler.py
+++ b/bot/cogs/moderation/scheduler.py
@@ -161,6 +161,7 @@ class InfractionScheduler:
                     self.schedule_expiration(infraction)
             except discord.HTTPException as e:
                 # Accordingly display that applying the infraction failed.
+                # Don't use ctx.message.author; antispam only patches ctx.author.
                 confirm_msg = ":x: failed to apply"
                 expiry_msg = ""
                 log_content = ctx.author.mention
@@ -190,6 +191,7 @@ class InfractionScheduler:
         await ctx.send(f"{dm_result}{confirm_msg}{infr_message}.")
 
         # Send a log message to the mod log.
+        # Don't use ctx.message.author for the actor; antispam only patches ctx.author.
         log.trace(f"Sending apply mod log for infraction #{id_}.")
         await self.mod_log.send_log_message(
             icon_url=icon,
@@ -198,7 +200,7 @@ class InfractionScheduler:
             thumbnail=user.avatar_url_as(static_format="png"),
             text=textwrap.dedent(f"""
                 Member: {user.mention} (`{user.id}`)
-                Actor: {ctx.message.author}{dm_log_text}{expiry_log_text}
+                Actor: {ctx.author}{dm_log_text}{expiry_log_text}
                 Reason: {reason}
             """),
             content=log_content,
@@ -242,7 +244,7 @@ class InfractionScheduler:
         log_text = await self.deactivate_infraction(response[0], send_log=False)
 
         log_text["Member"] = f"{user.mention}(`{user.id}`)"
-        log_text["Actor"] = str(ctx.message.author)
+        log_text["Actor"] = str(ctx.author)
         log_content = None
         id_ = response[0]['id']
         footer = f"ID: {id_}"

--- a/bot/cogs/moderation/utils.py
+++ b/bot/cogs/moderation/utils.py
@@ -70,7 +70,7 @@ async def post_infraction(
     log.trace(f"Posting {infr_type} infraction for {user} to the API.")
 
     payload = {
-        "actor": ctx.message.author.id,
+        "actor": ctx.author.id,  # Don't use ctx.message.author; antispam only patches ctx.author.
         "hidden": hidden,
         "reason": reason,
         "type": infr_type,


### PR DESCRIPTION
The modification propagated across all code that is using the same `Message` object, including all other `on_message` listeners. This caused weird bugs e.g. the filtering cog thinking the bot authored a message that triggered a filter.

Patching only `ctx.author` means the implementation is more fragile. Infraction code must ensure it only retrieves the author via `ctx.author` and not through `ctx.message`.

How to reproduce the bug:

1. Put 3 second sleep before this line https://github.com/python-discord/bot/blob/b27c286f2ce648d021eed0c8e07476066b86dd98/bot/cogs/filtering.py#L292
2. Send a message with 15 _custom_ Discord emotes
3. Send another message with 15 emotes but also include an invite link that will trigger the filter
4. Observe the same exception as in #1005

You can follow the above steps this PR branch and see the exception no longer gets raised.

Fixes #1005
Fixes BOT-7D