### PR TITLE
Escape Markdown in reddit post titles

### DIFF
--- a/bot/cogs/reddit.py
+++ b/bot/cogs/reddit.py
@@ -10,6 +10,7 @@ from aiohttp import BasicAuth, ClientError
 from discord import Colour, Embed, TextChannel
 from discord.ext.commands import Cog, Context, group
 from discord.ext.tasks import loop
+from discord.utils import escape_markdown
 
 from bot.bot import Bot
 from bot.constants import Channels, ERROR_REPLIES, Emojis, Reddit as RedditConfig, STAFF_ROLES, Webhooks
@@ -187,6 +188,8 @@ class Reddit(Cog):
             author = data["author"]
 
             title = textwrap.shorten(data["title"], width=64, placeholder="...")
+            # Normal brackets interfere with Markdown.
+            title = escape_markdown(title).replace("[", "⦋").replace("]", "⦌")
             link = self.URL + data["permalink"]
 
             embed.description += (


### PR DESCRIPTION
Most escaping is done with `discord.utils.escape_markdown`. However, that doesn't cover Markdown URLs. Instead, that is covered by replacing square brackets with look-alike Unicode characters. For the replacement characters, I chose `⦋` (Left Square Bracket with Underbar) and `⦌`(Right Square Bracket with Underbar). They seemed to be the most readable options, despite still not lining up well with neighbouring text.

![bild](https://user-images.githubusercontent.com/1515135/90320600-83569780-def7-11ea-9517-1ccbbfd8916e.png)

Fixes #1030