### PR TITLE
Make client parameter mandatory for wait_for_deletion

### DIFF
--- a/bot/cogs/bot.py
+++ b/bot/cogs/bot.py
@@ -337,7 +337,7 @@ class BotCog(Cog, name="Bot"):
                         self.codeblock_message_ids[msg.id] = bot_message.id
 
                         self.bot.loop.create_task(
-                            wait_for_deletion(bot_message, user_ids=(msg.author.id,), client=self.bot)
+                            wait_for_deletion(bot_message, (msg.author.id,), self.bot)
                         )
                     else:
                         return

--- a/bot/cogs/snekbox.py
+++ b/bot/cogs/snekbox.py
@@ -220,9 +220,7 @@ class Snekbox(Cog):
                 response = await ctx.send("Attempt to circumvent filter detected. Moderator team has been alerted.")
             else:
                 response = await ctx.send(msg)
-            self.bot.loop.create_task(
-                wait_for_deletion(response, user_ids=(ctx.author.id,), client=ctx.bot)
-            )
+            self.bot.loop.create_task(wait_for_deletion(response, (ctx.author.id,), ctx.bot))
 
             log.info(f"{ctx.author}'s job had a return code of {results['returncode']}")
         return response

--- a/bot/cogs/tags.py
+++ b/bot/cogs/tags.py
@@ -236,7 +236,7 @@ class Tags(Cog):
                 await wait_for_deletion(
                     await ctx.send(embed=Embed.from_dict(tag['embed'])),
                     [ctx.author.id],
-                    client=self.bot
+                    self.bot
                 )
             elif founds and len(tag_name) >= 3:
                 await wait_for_deletion(
@@ -247,7 +247,7 @@ class Tags(Cog):
                         )
                     ),
                     [ctx.author.id],
-                    client=self.bot
+                    self.bot
                 )
 
         else:

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -19,24 +19,19 @@ log = logging.getLogger(__name__)
 async def wait_for_deletion(
     message: Message,
     user_ids: Sequence[Snowflake],
+    client: Client,
     deletion_emojis: Sequence[str] = (Emojis.trashcan,),
     timeout: float = 60 * 5,
     attach_emojis: bool = True,
-    client: Optional[Client] = None
 ) -> None:
     """
     Wait for up to `timeout` seconds for a reaction by any of the specified `user_ids` to delete the message.
 
     An `attach_emojis` bool may be specified to determine whether to attach the given
-    `deletion_emojis` to the message in the given `context`
-
-    A `client` instance may be optionally specified, otherwise client will be taken from the
-    guild of the message.
+    `deletion_emojis` to the message in the given `context`.
     """
-    if message.guild is None and client is None:
+    if message.guild is None:
         raise ValueError("Message must be sent on a guild")
-
-    bot = client or message.guild.me
 
     if attach_emojis:
         for emoji in deletion_emojis:
@@ -51,7 +46,7 @@ async def wait_for_deletion(
         )
 
     with contextlib.suppress(asyncio.TimeoutError):
-        await bot.wait_for('reaction_add', check=check, timeout=timeout)
+        await client.wait_for('reaction_add', check=check, timeout=timeout)
         await message.delete()
 
 


### PR DESCRIPTION
A client instance is necessary for the core feature of this function. There is no way to obtain it from the other arguments. The previous code was wrong to think `discord.Guild.me` is an equivalent.

Fixes #1112