### PR TITLE
Use wait_for_deletion from bot/utils/messages.py rather than help_cleanup

### DIFF
--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -1,11 +1,10 @@
 import itertools
 import logging
-from asyncio import TimeoutError
 from collections import namedtuple
 from contextlib import suppress
 from typing import List, Union
 
-from discord import Colour, Embed, Member, Message, NotFound, Reaction, User
+from discord import Colour, Embed
 from discord.ext.commands import Bot, Cog, Command, Context, Group, HelpCommand
 from fuzzywuzzy import fuzz, process
 from fuzzywuzzy.utils import full_process
@@ -14,6 +13,7 @@ from bot import constants
 from bot.constants import Channels, Emojis, STAFF_ROLES
 from bot.decorators import redirect_output
 from bot.pagination import LinePaginator
+from bot.utils.messages import wait_for_deletion
 
 log = logging.getLogger(__name__)
 
@@ -22,27 +22,6 @@ DELETE_EMOJI = Emojis.trashcan
 PREFIX = constants.Bot.prefix
 
 Category = namedtuple("Category", ["name", "description", "cogs"])
-
-
-async def help_cleanup(bot: Bot, author: Member, message: Message) -> None:
-    """
-    Runs the cleanup for the help command.
-
-    Adds the :trashcan: reaction that, when clicked, will delete the help message.
-    After a 300 second timeout, the reaction will be removed.
-    """
-    def check(reaction: Reaction, user: User) -> bool:
-        """Checks the reaction is :trashcan:, the author is original author and messages are the same."""
-        return str(reaction) == DELETE_EMOJI and user.id == author.id and reaction.message.id == message.id
-
-    await message.add_reaction(DELETE_EMOJI)
-
-    with suppress(NotFound):
-        try:
-            await bot.wait_for("reaction_add", check=check, timeout=300)
-            await message.delete()
-        except TimeoutError:
-            await message.remove_reaction(DELETE_EMOJI, bot.user)
 
 
 class HelpQueryNotFound(ValueError):
@@ -206,7 +185,7 @@ class CustomHelpCommand(HelpCommand):
         """Send help for a single command."""
         embed = await self.command_formatting(command)
         message = await self.context.send(embed=embed)
-        await help_cleanup(self.context.bot, self.context.author, message)
+        await wait_for_deletion(message, (self.context.author.id,), self.context.bot)
 
     @staticmethod
     def get_commands_brief_details(commands_: List[Command], return_as_list: bool = False) -> Union[List[str], str]:
@@ -245,7 +224,7 @@ class CustomHelpCommand(HelpCommand):
             embed.description += f"\n**Subcommands:**\n{command_details}"
 
         message = await self.context.send(embed=embed)
-        await help_cleanup(self.context.bot, self.context.author, message)
+        await wait_for_deletion(message, (self.context.author.id,), self.context.bot)
 
     async def send_cog_help(self, cog: Cog) -> None:
         """Send help for a cog."""
@@ -261,7 +240,7 @@ class CustomHelpCommand(HelpCommand):
             embed.description += f"\n\n**Commands:**\n{command_details}"
 
         message = await self.context.send(embed=embed)
-        await help_cleanup(self.context.bot, self.context.author, message)
+        await wait_for_deletion(message, (self.context.author.id,), self.context.bot)
 
     @staticmethod
     def _category_key(command: Command) -> str:

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -10,7 +10,7 @@ from fuzzywuzzy import fuzz, process
 from fuzzywuzzy.utils import full_process
 
 from bot import constants
-from bot.constants import Channels, Emojis, STAFF_ROLES
+from bot.constants import Channels, STAFF_ROLES
 from bot.decorators import redirect_output
 from bot.pagination import LinePaginator
 from bot.utils.messages import wait_for_deletion
@@ -18,7 +18,6 @@ from bot.utils.messages import wait_for_deletion
 log = logging.getLogger(__name__)
 
 COMMANDS_PER_PAGE = 8
-DELETE_EMOJI = Emojis.trashcan
 PREFIX = constants.Bot.prefix
 
 Category = namedtuple("Category", ["name", "description", "cogs"])


### PR DESCRIPTION
Fixes #1122. `bot/cogs/help.py` uses its own cleanup called `help_cleanup` rather than the premade cleanup (`wait_for_deletion`) from `bot/utils/messages.py`. This is an inconsistency because all messages with cleanup use `wait_for_deletion`.