### PR TITLE
Support specifying top-level aliases in the command decorator

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -2,10 +2,14 @@ import asyncio
 import logging
 import os
 import sys
+from functools import partial, partialmethod
 from logging import Logger, handlers
 from pathlib import Path
 
 import coloredlogs
+from discord.ext import commands
+
+from bot.command import Command
 
 TRACE_LEVEL = logging.TRACE = 5
 logging.addLevelName(TRACE_LEVEL, "TRACE")
@@ -66,3 +70,9 @@ logging.getLogger(__name__)
 # On Windows, the selector event loop is required for aiodns.
 if os.name == "nt":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
+# Monkey-patch discord.py decorators to use the Command subclass which supports root aliases.
+# Must be patched before any cogs are added.
+commands.command = partial(commands.command, cls=Command)
+commands.GroupMixin.command = partialmethod(commands.GroupMixin.command, cls=Command)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -130,6 +130,26 @@ class Bot(commands.Bot):
         super().add_cog(cog)
         log.info(f"Cog loaded: {cog.qualified_name}")
 
+    def add_command(self, command: commands.Command) -> None:
+        """Add `command` as normal and then add its root aliases to the bot."""
+        super().add_command(command)
+        self._add_root_aliases(command)
+
+    def remove_command(self, name: str) -> Optional[commands.Command]:
+        """
+        Remove a command/alias as normal and then remove its root aliases from the bot.
+
+        Individual root aliases cannot be removed by this function.
+        To remove them, either remove the entire command or manually edit `bot.all_commands`.
+        """
+        command = super().remove_command(name)
+        if command is None:
+            # Even if it's a root alias, there's no way to get the Bot instance to remove the alias.
+            return
+
+        self._remove_root_aliases(command)
+        return command
+
     def clear(self) -> None:
         """
         Clears the internal state of the bot and recreates the connector and sessions.
@@ -235,3 +255,24 @@ class Bot(commands.Bot):
             scope.set_extra("kwargs", kwargs)
 
             log.exception(f"Unhandled exception in {event}.")
+
+    def _add_root_aliases(self, command: commands.Command) -> None:
+        """Recursively add root aliases for `command` and any of its subcommands."""
+        if isinstance(command, commands.Group):
+            for subcommand in command.commands:
+                self._add_root_aliases(subcommand)
+
+        for alias in command.root_aliases:
+            if alias in self.all_commands:
+                raise commands.CommandRegistrationError(alias, alias_conflict=True)
+
+            self.all_commands[alias] = command
+
+    def _remove_root_aliases(self, command: commands.Command) -> None:
+        """Recursively remove root aliases for `command` and any of its subcommands."""
+        if isinstance(command, commands.Group):
+            for subcommand in command.commands:
+                self._remove_root_aliases(subcommand)
+
+        for alias in command.root_aliases:
+            self.all_commands.pop(alias, None)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -262,7 +262,7 @@ class Bot(commands.Bot):
             for subcommand in command.commands:
                 self._add_root_aliases(subcommand)
 
-        for alias in command.root_aliases:
+        for alias in getattr(command, "root_aliases", ()):
             if alias in self.all_commands:
                 raise commands.CommandRegistrationError(alias, alias_conflict=True)
 
@@ -274,5 +274,5 @@ class Bot(commands.Bot):
             for subcommand in command.commands:
                 self._remove_root_aliases(subcommand)
 
-        for alias in command.root_aliases:
+        for alias in getattr(command, "root_aliases", ()):
             self.all_commands.pop(alias, None)

--- a/bot/cogs/alias.py
+++ b/bot/cogs/alias.py
@@ -3,13 +3,12 @@ import logging
 
 from discord import Colour, Embed
 from discord.ext.commands import (
-    Cog, Command, Context, Greedy,
+    Cog, Command, Context,
     clean_content, command, group,
 )
 
 from bot.bot import Bot
-from bot.cogs.extensions import Extension
-from bot.converters import FetchedMember, TagNameConverter
+from bot.converters import TagNameConverter
 from bot.pagination import LinePaginator
 
 log = logging.getLogger(__name__)
@@ -51,56 +50,6 @@ class Alias (Cog):
             ctx, embed, empty=False, max_lines=20
         )
 
-    @command(name="resources", aliases=("resource",), hidden=True)
-    async def site_resources_alias(self, ctx: Context) -> None:
-        """Alias for invoking <prefix>site resources."""
-        await self.invoke(ctx, "site resources")
-
-    @command(name="tools", hidden=True)
-    async def site_tools_alias(self, ctx: Context) -> None:
-        """Alias for invoking <prefix>site tools."""
-        await self.invoke(ctx, "site tools")
-
-    @command(name="watch", hidden=True)
-    async def bigbrother_watch_alias(self, ctx: Context, user: FetchedMember, *, reason: str) -> None:
-        """Alias for invoking <prefix>bigbrother watch [user] [reason]."""
-        await self.invoke(ctx, "bigbrother watch", user, reason=reason)
-
-    @command(name="unwatch", hidden=True)
-    async def bigbrother_unwatch_alias(self, ctx: Context, user: FetchedMember, *, reason: str) -> None:
-        """Alias for invoking <prefix>bigbrother unwatch [user] [reason]."""
-        await self.invoke(ctx, "bigbrother unwatch", user, reason=reason)
-
-    @command(name="home", hidden=True)
-    async def site_home_alias(self, ctx: Context) -> None:
-        """Alias for invoking <prefix>site home."""
-        await self.invoke(ctx, "site home")
-
-    @command(name="faq", hidden=True)
-    async def site_faq_alias(self, ctx: Context) -> None:
-        """Alias for invoking <prefix>site faq."""
-        await self.invoke(ctx, "site faq")
-
-    @command(name="rules", aliases=("rule",), hidden=True)
-    async def site_rules_alias(self, ctx: Context, rules: Greedy[int], *_: str) -> None:
-        """Alias for invoking <prefix>site rules."""
-        await self.invoke(ctx, "site rules", *rules)
-
-    @command(name="reload", hidden=True)
-    async def extensions_reload_alias(self, ctx: Context, *extensions: Extension) -> None:
-        """Alias for invoking <prefix>extensions reload [extensions...]."""
-        await self.invoke(ctx, "extensions reload", *extensions)
-
-    @command(name="defon", hidden=True)
-    async def defcon_enable_alias(self, ctx: Context) -> None:
-        """Alias for invoking <prefix>defcon enable."""
-        await self.invoke(ctx, "defcon enable")
-
-    @command(name="defoff", hidden=True)
-    async def defcon_disable_alias(self, ctx: Context) -> None:
-        """Alias for invoking <prefix>defcon disable."""
-        await self.invoke(ctx, "defcon disable")
-
     @command(name="exception", hidden=True)
     async def tags_get_traceback_alias(self, ctx: Context) -> None:
         """Alias for invoking <prefix>tags get traceback."""
@@ -131,21 +80,6 @@ class Alias (Cog):
     ) -> None:
         """Alias for invoking <prefix>docs get [symbol]."""
         await self.invoke(ctx, "docs get", symbol)
-
-    @command(name="nominate", hidden=True)
-    async def nomination_add_alias(self, ctx: Context, user: FetchedMember, *, reason: str) -> None:
-        """Alias for invoking <prefix>talentpool add [user] [reason]."""
-        await self.invoke(ctx, "talentpool add", user, reason=reason)
-
-    @command(name="unnominate", hidden=True)
-    async def nomination_end_alias(self, ctx: Context, user: FetchedMember, *, reason: str) -> None:
-        """Alias for invoking <prefix>nomination end [user] [reason]."""
-        await self.invoke(ctx, "nomination end", user, reason=reason)
-
-    @command(name="nominees", hidden=True)
-    async def nominees_alias(self, ctx: Context) -> None:
-        """Alias for invoking <prefix>tp watched."""
-        await self.invoke(ctx, "talentpool watched")
 
 
 def setup(bot: Bot) -> None:

--- a/bot/cogs/defcon.py
+++ b/bot/cogs/defcon.py
@@ -162,7 +162,7 @@ class Defcon(Cog):
 
             self.bot.stats.gauge("defcon.threshold", days)
 
-    @defcon_group.command(name='enable', aliases=('on', 'e'))
+    @defcon_group.command(name='enable', aliases=('on', 'e'), root_aliases=("defon",))
     @with_role(Roles.admins, Roles.owners)
     async def enable_command(self, ctx: Context) -> None:
         """
@@ -175,7 +175,7 @@ class Defcon(Cog):
         await self._defcon_action(ctx, days=0, action=Action.ENABLED)
         await self.update_channel_topic()
 
-    @defcon_group.command(name='disable', aliases=('off', 'd'))
+    @defcon_group.command(name='disable', aliases=('off', 'd'), root_aliases=("defoff",))
     @with_role(Roles.admins, Roles.owners)
     async def disable_command(self, ctx: Context) -> None:
         """Disable DEFCON mode. Useful in a pinch, but be sure you know what you're doing!"""

--- a/bot/cogs/extensions.py
+++ b/bot/cogs/extensions.py
@@ -107,7 +107,7 @@ class Extensions(commands.Cog):
 
         await ctx.send(msg)
 
-    @extensions_group.command(name="reload", aliases=("r",))
+    @extensions_group.command(name="reload", aliases=("r",), root_aliases=("reload",))
     async def reload_command(self, ctx: Context, *extensions: Extension) -> None:
         r"""
         Reload extensions given their fully qualified or unqualified names.

--- a/bot/cogs/help.py
+++ b/bot/cogs/help.py
@@ -189,7 +189,9 @@ class CustomHelpCommand(HelpCommand):
         command_details = f"**```{PREFIX}{name} {command.signature}```**\n"
 
         # show command aliases
-        aliases = ", ".join(f"`{alias}`" if not parent else f"`{parent} {alias}`" for alias in command.aliases)
+        aliases = [f"`{alias}`" if not parent else f"`{parent} {alias}`" for alias in command.aliases]
+        aliases += [f"`{alias}`" for alias in getattr(command, "root_aliases", ())]
+        aliases = ", ".join(sorted(aliases))
         if aliases:
             command_details += f"**Can also use:** {aliases}\n\n"
 

--- a/bot/cogs/site.py
+++ b/bot/cogs/site.py
@@ -23,7 +23,7 @@ class Site(Cog):
         """Commands for getting info about our website."""
         await ctx.send_help(ctx.command)
 
-    @site_group.command(name="home", aliases=("about",))
+    @site_group.command(name="home", aliases=("about",), root_aliases=("home",))
     async def site_main(self, ctx: Context) -> None:
         """Info about the website itself."""
         url = f"{URLs.site_schema}{URLs.site}/"
@@ -40,7 +40,7 @@ class Site(Cog):
 
         await ctx.send(embed=embed)
 
-    @site_group.command(name="resources")
+    @site_group.command(name="resources", root_aliases=("resources", "resource"))
     async def site_resources(self, ctx: Context) -> None:
         """Info about the site's Resources page."""
         learning_url = f"{PAGES_URL}/resources"
@@ -56,7 +56,7 @@ class Site(Cog):
 
         await ctx.send(embed=embed)
 
-    @site_group.command(name="tools")
+    @site_group.command(name="tools", root_aliases=("tools",))
     async def site_tools(self, ctx: Context) -> None:
         """Info about the site's Tools page."""
         tools_url = f"{PAGES_URL}/resources/tools"
@@ -87,7 +87,7 @@ class Site(Cog):
 
         await ctx.send(embed=embed)
 
-    @site_group.command(name="faq")
+    @site_group.command(name="faq", root_aliases=("faq",))
     async def site_faq(self, ctx: Context) -> None:
         """Info about the site's FAQ page."""
         url = f"{PAGES_URL}/frequently-asked-questions"
@@ -104,7 +104,7 @@ class Site(Cog):
 
         await ctx.send(embed=embed)
 
-    @site_group.command(aliases=['r', 'rule'], name='rules')
+    @site_group.command(name="rules", aliases=("r", "rule"), root_aliases=("rules", "rule"))
     async def site_rules(self, ctx: Context, *rules: int) -> None:
         """Provides a link to all rules or, if specified, displays specific rule(s)."""
         rules_embed = Embed(title='Rules', color=Colour.blurple())

--- a/bot/cogs/watchchannels/bigbrother.py
+++ b/bot/cogs/watchchannels/bigbrother.py
@@ -59,7 +59,7 @@ class BigBrother(WatchChannel, Cog, name="Big Brother"):
         """
         await ctx.invoke(self.watched_command, oldest_first=True, update_cache=update_cache)
 
-    @bigbrother_group.command(name='watch', aliases=('w',))
+    @bigbrother_group.command(name='watch', aliases=('w',), root_aliases=('watch',))
     @with_role(*MODERATION_ROLES)
     async def watch_command(self, ctx: Context, user: FetchedMember, *, reason: str) -> None:
         """
@@ -70,7 +70,7 @@ class BigBrother(WatchChannel, Cog, name="Big Brother"):
         """
         await self.apply_watch(ctx, user, reason)
 
-    @bigbrother_group.command(name='unwatch', aliases=('uw',))
+    @bigbrother_group.command(name='unwatch', aliases=('uw',), root_aliases=('unwatch',))
     @with_role(*MODERATION_ROLES)
     async def unwatch_command(self, ctx: Context, user: FetchedMember, *, reason: str) -> None:
         """Stop relaying messages by the given `user`."""

--- a/bot/cogs/watchchannels/talentpool.py
+++ b/bot/cogs/watchchannels/talentpool.py
@@ -37,7 +37,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
         """Highlights the activity of helper nominees by relaying their messages to the talent pool channel."""
         await ctx.send_help(ctx.command)
 
-    @nomination_group.command(name='watched', aliases=('all', 'list'))
+    @nomination_group.command(name='watched', aliases=('all', 'list'), root_aliases=("nominees",))
     @with_role(*MODERATION_ROLES)
     async def watched_command(
         self, ctx: Context, oldest_first: bool = False, update_cache: bool = True
@@ -63,7 +63,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
         """
         await ctx.invoke(self.watched_command, oldest_first=True, update_cache=update_cache)
 
-    @nomination_group.command(name='watch', aliases=('w', 'add', 'a'))
+    @nomination_group.command(name='watch', aliases=('w', 'add', 'a'), root_aliases=("nominate",))
     @with_role(*STAFF_ROLES)
     async def watch_command(self, ctx: Context, user: FetchedMember, *, reason: str) -> None:
         """
@@ -157,7 +157,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
             max_size=1000
         )
 
-    @nomination_group.command(name='unwatch', aliases=('end', ))
+    @nomination_group.command(name='unwatch', aliases=('end', ), root_aliases=("unnominate",))
     @with_role(*MODERATION_ROLES)
     async def unwatch_command(self, ctx: Context, user: FetchedMember, *, reason: str) -> None:
         """

--- a/bot/command.py
+++ b/bot/command.py
@@ -13,3 +13,6 @@ class Command(commands.Command):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.root_aliases = kwargs.get("root_aliases", [])
+
+        if not isinstance(self.root_aliases, (list, tuple)):
+            raise TypeError("Root aliases of a command must be a list or a tuple of strings.")

--- a/bot/command.py
+++ b/bot/command.py
@@ -1,0 +1,15 @@
+from discord.ext import commands
+
+
+class Command(commands.Command):
+    """
+    A `discord.ext.commands.Command` subclass which supports root aliases.
+
+    A `root_aliases` keyword argument is added, which is a sequence of alias names that will act as
+    top-level commands rather than being aliases of the command's group. It's stored as an attribute
+    also named `root_aliases`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.root_aliases = kwargs.get("root_aliases", [])

--- a/tests/bot/cogs/test_cogs.py
+++ b/tests/bot/cogs/test_cogs.py
@@ -53,6 +53,7 @@ class CommandNameTests(unittest.TestCase):
         """Return a list of all qualified names, including aliases, for the `command`."""
         names = [f"{command.full_parent_name} {alias}".strip() for alias in command.aliases]
         names.append(command.qualified_name)
+        names += getattr(command, "root_aliases", [])
 
         return names
 


### PR DESCRIPTION
Closes #707 

## Feature overview

A new keyword argument has been added to the `discord.ext.commands.GroupMixin.command` decorator. The kwarg `root_aliases` allows a sequence of alias names to be specified which are meant to act as top-level commands. For example,

```py
@site_group.command(name="rules", aliases=("r", "rule"), root_aliases=("rules", "rule"))
```

### Help command

These aliases also show up in the help command (they're sorted too)

![bild](https://user-images.githubusercontent.com/1515135/90982888-2a9e8480-e51f-11ea-9711-6fe80bb64436.png)

### Implementation

There is no separate command created. They're implemented quite similarly to normal aliases, which are mappings of several names to the same command object.

## Remaining aliases

There are a couple of the old aliases left:

1. A tag alias. It could easily be implemented inside the tags cog as a mapping that the command checks before looking up the tag.
2. Reverse aliases for `docs get` and `tags get`: `get docs` and `get tags`. I played around with the idea of removing the `get` aliases, but they have some complications. 

I'd really like to get rid of them. Perhaps they should be removed without any replacement, as I doubt these aliases are used often. Tags are more convenient to fetch directly with the fuzzy search. Docs are more convenient through the `!d <symbol name>` alias.
