### PR TITLE
Bold link to asking guide in help channel embeds

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -36,7 +36,7 @@ the **Help: Dormant** category.
 
 Try to write the best question you can by providing a detailed description and telling us what \
 you've tried already. For more information on asking a good question, \
-check out our guide on [asking good questions]({ASKING_GUIDE_URL}).
+check out our guide on [**asking good questions**]({ASKING_GUIDE_URL}).
 """
 
 DORMANT_MSG = f"""
@@ -47,7 +47,7 @@ channel until it becomes available again.
 If your question wasn't answered yet, you can claim a new help channel from the \
 **Help: Available** category by simply asking your question again. Consider rephrasing the \
 question to maximize your chance of getting a good answer. If you're not sure how, have a look \
-through our guide for [asking a good question]({ASKING_GUIDE_URL}).
+through our guide for [**asking a good question**]({ASKING_GUIDE_URL}).
 """
 
 CoroutineFunc = t.Callable[..., t.Coroutine]


### PR DESCRIPTION
A small attempt to hopefully make people click more on the link to the guide on asking good questions by bolding it.

Current embeds:
![image](https://user-images.githubusercontent.com/18114431/91238826-9c0c4c00-e746-11ea-8e95-90c79fe50ac2.png)
![image](https://user-images.githubusercontent.com/18114431/91238867-ae868580-e746-11ea-87ef-fe39662bf529.png)
