### PR TITLE
Move bolding markdown outside of text link in help channel messages.

### DIFF
--- a/bot/cogs/help_channels.py
+++ b/bot/cogs/help_channels.py
@@ -36,7 +36,7 @@ the **Help: Dormant** category.
 
 Try to write the best question you can by providing a detailed description and telling us what \
 you've tried already. For more information on asking a good question, \
-check out our guide on [**asking good questions**]({ASKING_GUIDE_URL}).
+check out our guide on **[asking good questions]({ASKING_GUIDE_URL})**.
 """
 
 DORMANT_MSG = f"""
@@ -47,7 +47,7 @@ channel until it becomes available again.
 If your question wasn't answered yet, you can claim a new help channel from the \
 **Help: Available** category by simply asking your question again. Consider rephrasing the \
 question to maximize your chance of getting a good answer. If you're not sure how, have a look \
-through our guide for [**asking a good question**]({ASKING_GUIDE_URL}).
+through our guide for **[asking a good question]({ASKING_GUIDE_URL})**.
 """
 
 CoroutineFunc = t.Callable[..., t.Coroutine]


### PR DESCRIPTION
On some clients (android), the markdown is commonly not rendered properly within text links, in this case the bolding didn't happen and the markdown asterisks remainder as plaintext.
Moving them outside of the link text fixes the issue
![](https://i.imgur.com/OQE62Zp.png)