### PR TITLE
Updated the names of reddit emotes

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -77,9 +77,9 @@ style:
         ducky_santa:    &DUCKY_SANTA    655360331002019870
 
         # emotes used for #reddit
-        upvotes:        "<:reddit_upvotes:638729835245731840>"
-        comments:       "<:reddit_comments:638729835073765387>"
-        user:           "<:reddit_user:638729835442602003>"
+        upvotes:        "<:reddit_upvotes:755845219890757644> "
+        comments:       "<:reddit_comments:755845255001014384>"
+        user:           "<:reddit_users:755845303822974997>"
 
     icons:
         crown_blurple: "https://cdn.discordapp.com/emojis/469964153289965568.png"

--- a/config-default.yml
+++ b/config-default.yml
@@ -76,9 +76,10 @@ style:
         ducky_maul:     &DUCKY_MAUL     640137724958867467
         ducky_santa:    &DUCKY_SANTA    655360331002019870
 
-        upvotes:        "<:upvotes:638729835245731840>"
-        comments:       "<:comments:638729835073765387>"
-        user:           "<:user:638729835442602003>"
+        # emotes used for #reddit
+        upvotes:        "<:reddit_upvotes:638729835245731840>"
+        comments:       "<:reddit_comments:638729835073765387>"
+        user:           "<:reddit_user:638729835442602003>"
 
     icons:
         crown_blurple: "https://cdn.discordapp.com/emojis/469964153289965568.png"

--- a/config-default.yml
+++ b/config-default.yml
@@ -77,7 +77,7 @@ style:
         ducky_santa:    &DUCKY_SANTA    655360331002019870
 
         # emotes used for #reddit
-        upvotes:        "<:reddit_upvotes:755845219890757644> "
+        upvotes:        "<:reddit_upvotes:755845219890757644>"
         comments:       "<:reddit_comments:755845255001014384>"
         user:           "<:reddit_users:755845303822974997>"
 


### PR DESCRIPTION
Names of emotes used in `#reddit` have been changed to have `reddit_` prefixed in their name, config must be updated so bot still can use those emotes without problems.