### PR TITLE
Upload eval output with codeblock escapes to pastebin

### DIFF
--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -150,6 +150,7 @@ class Snekbox(Cog):
             output = output.replace("<!@", "<!@\u200B")  # Zero-width space
 
         if ESCAPE_REGEX.findall(output):
+            paste_link = await self.upload_output(original_output)
             return "Code block escape attempt detected; will not output result", paste_link
 
         truncated = False

--- a/tests/bot/exts/utils/test_snekbox.py
+++ b/tests/bot/exts/utils/test_snekbox.py
@@ -117,12 +117,12 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
             ('<!@', ("<!@\u200B", None), r'Convert <!@ to <!@\u200B'),
             (
                 '\u202E\u202E\u202E',
-                ('Code block escape attempt detected; will not output result', None),
+                ('Code block escape attempt detected; will not output result', 'https://testificate.com/'),
                 'Detect RIGHT-TO-LEFT OVERRIDE'
             ),
             (
                 '\u200B\u200B\u200B',
-                ('Code block escape attempt detected; will not output result', None),
+                ('Code block escape attempt detected; will not output result', 'https://testificate.com/'),
                 'Detect ZERO WIDTH SPACE'
             ),
             ('long\nbeard', ('001 | long\n002 | beard', None), 'Two line output'),


### PR DESCRIPTION
closes: #918 

Attempts to upload eval output to the paste service to give some output to the user in case the escape filter is triggered