### PR TITLE
Adjust verification & incidents log levels

### DIFF
--- a/bot/exts/moderation/incidents.py
+++ b/bot/exts/moderation/incidents.py
@@ -237,7 +237,7 @@ class Incidents(Cog):
         not all information was relayed, return False. This signals that the original
         message is not safe to be deleted, as we will lose some information.
         """
-        log.debug(f"Archiving incident: {incident.id} (outcome: {outcome}, actioned by: {actioned_by})")
+        log.info(f"Archiving incident: {incident.id} (outcome: {outcome}, actioned by: {actioned_by})")
         embed, attachment_file = await make_embed(incident, outcome, actioned_by)
 
         try:

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -286,7 +286,7 @@ class Verification(Cog):
 
         Returns the amount of successful requests. Failed requests are logged at info level.
         """
-        log.info(f"Sending {len(members)} requests")
+        log.trace(f"Sending {len(members)} requests")
         n_success, bad_statuses = 0, set()
 
         for progress, member in enumerate(members, start=1):


### PR DESCRIPTION
With Dozzle now being functional, I think it becomes even more important to carefully consider logging levels. I'd like to propose two tiny changes for the cogs that I've worked on.

## Verification

Every 30 minutes, the verification member update task produces the following:
![image](https://user-images.githubusercontent.com/44734341/94033164-fab5fb80-fdc0-11ea-909e-89af21388893.png)

The 3rd and 5th lines are entirely redundant, and are dropped to `TRACE` level in bcca56c. The 1st line also doesn't add much, but it'd be useful to have it in situations where no members eligible for kicking/roleing are found, to know that the task is still alive.

## Incidents

Incidents do not currently produce an `INFO` log when attempting to relay a message, which I think is a shame. We've had a situation recently where it'd have been useful to quickly check whether this line was hit or not. 5038aea amends this.

Feel free to propose more changes.