### PR TITLE
Verification: broaden 50_007 error code handling to all Discord exception types

### DIFF
--- a/bot/exts/moderation/incidents.py
+++ b/bot/exts/moderation/incidents.py
@@ -319,7 +319,7 @@ class Incidents(Cog):
         try:
             await confirmation_task
         except asyncio.TimeoutError:
-            log.warning(f"Did not receive incident deletion confirmation within {timeout} seconds!")
+            log.info(f"Did not receive incident deletion confirmation within {timeout} seconds!")
         else:
             log.trace("Deletion was confirmed")
 

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -109,6 +109,25 @@ def is_verified(member: discord.Member) -> bool:
     return len(set(member.roles) - unverified_roles) > 0
 
 
+async def safe_dm(coro: t.Coroutine) -> None:
+    """
+    Execute `coro` ignoring disabled DM warnings.
+
+    The 50_0007 error code indicates that the target user does not accept DMs.
+    As it turns out, this error code can appear on both 400 and 403 statuses,
+    we therefore catch any Discord exception.
+
+    If the request fails on any other error code, the exception propagates,
+    and must be handled by the caller.
+    """
+    try:
+        await coro
+    except discord.HTTPException as discord_exc:
+        log.trace(f"DM dispatch failed on status {discord_exc.status} with code: {discord_exc.code}")
+        if discord_exc.code != 50_007:  # If any reason other than disabled DMs
+            raise
+
+
 class Verification(Cog):
     """
     User verification and role management.
@@ -330,11 +349,9 @@ class Verification(Cog):
         async def kick_request(member: discord.Member) -> None:
             """Send `KICKED_MESSAGE` to `member` and kick them from the guild."""
             try:
-                await member.send(KICKED_MESSAGE)
-            except discord.Forbidden as exc_403:
-                log.trace(f"DM dispatch failed on 403 error with code: {exc_403.code}")
-                if exc_403.code != 50_007:  # 403 raised for any other reason than disabled DMs
-                    raise StopExecution(reason=exc_403)
+                await safe_dm(member.send(KICKED_MESSAGE))  # Suppress disabled DMs
+            except discord.HTTPException as suspicious_exception:
+                raise StopExecution(reason=suspicious_exception)
             await member.kick(reason=f"User has not verified in {constants.Verification.kicked_after} days")
 
         n_kicked = await self._send_requests(members, kick_request, Limit(batch_size=2, sleep_secs=1))


### PR DESCRIPTION
Fixes #1179.

# Context

When sending DMs to Discord users, it is necessary to consider that they may not be accepting them. The canonical way to respond to such situations is to either suppress `discord.Forbidden` (`403`) or to catch & handle it in some way.

However, we've come to learn 2 things:
* A `403` response may potentially indicate something worse than just disabled DMs (@jb3)
* It's possible to receive a `400` status instead of a `403` when DMing a user with closed DMs (#1179)

Discord exceptions carry not only the status, but also a Discord-specific error code. The code `50_007` indicates disabled DMs, and as per #1179 can appear on non-`403` statuses as well.

# Changes

Equipped with this new knowledge, I've made the following adjustments. All DM dispatches in the Verification cog are gated through a new helper `safe_dm`, which will:
* Catch any `discord.HTTPException`
* Suppress the exception if the code was `50_0007`
* Re-raise the exception if the code is different

When sending the "you have been kicked" notification from the verification task, we will now:
* Suppress any Discord exception with the `50_007` error code
* Stop the task and alert `@Admins` on *any* non-`50_007` exception (regardless of status)

**This is different to the previous behaviour**, which would *only* stop the task on non-`50_007` `403`s, and ignore all other exceptions.

For DMs happening outside of the task (on-join DM & rules-accepted DM), we suppress *any* `50_007` Discord exception and log *any* other at error level.