### PR TITLE
Catch 404 in wait_for_deletion when reacting

### DIFF
--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -34,7 +34,11 @@ async def wait_for_deletion(
 
     if attach_emojis:
         for emoji in deletion_emojis:
-            await message.add_reaction(emoji)
+            try:
+                await message.add_reaction(emoji)
+            except discord.NotFound:
+                log.trace(f"Aborting wait_for_deletion: message {message.id} deleted prematurely.")
+                return
 
     def check(reaction: discord.Reaction, user: discord.Member) -> bool:
         """Check that the deletion emoji is reacted by the appropriate user."""


### PR DESCRIPTION
The message may be deleted before the bot gets a chance to react.

Fixes #1181