### PR TITLE
Remove null chars before posting deleted messages

### DIFF
--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -63,7 +63,7 @@ class ModLog(Cog, name="ModLog"):
                         'id': message.id,
                         'author': message.author.id,
                         'channel_id': message.channel.id,
-                        'content': message.content,
+                        'content': message.content.replace("\0", ""),  # Null chars cause 400.
                         'embeds': [embed.to_dict() for embed in message.embeds],
                         'attachments': attachment,
                     }


### PR DESCRIPTION
Our API doesn't allow null characters in the content field. It may be present because of a self bot that is able to send such character.

Could consider sending an alert if a null char is detected, as it is most likely a self bot. But that is a bit out of scope for now.

Fixes #1182
Fixes BOT-8E