### PR TITLE
Duck pond: ignore reactions in DMs

### DIFF
--- a/bot/exts/fun/duck_pond.py
+++ b/bot/exts/fun/duck_pond.py
@@ -145,8 +145,8 @@ class DuckPond(Cog):
         amount of ducks specified in the config under duck_pond/threshold, it will
         send the message off to the duck pond.
         """
-        # Ignore DMs.
-        if payload.guild_id is None:
+        # Ignore other guilds and DMs.
+        if payload.guild_id != constants.Guild.id:
             return
 
         # Was this reaction issued in a blacklisted channel?
@@ -182,7 +182,13 @@ class DuckPond(Cog):
     @Cog.listener()
     async def on_raw_reaction_remove(self, payload: RawReactionActionEvent) -> None:
         """Ensure that people don't remove the green checkmark from duck ponded messages."""
+        # Ignore other guilds and DMs.
+        if payload.guild_id != constants.Guild.id:
+            return
+
         channel = discord.utils.get(self.bot.get_all_channels(), id=payload.channel_id)
+        if channel is None:
+            return
 
         # Prevent the green checkmark from being removed
         if payload.emoji.name == "✅":

--- a/bot/exts/fun/duck_pond.py
+++ b/bot/exts/fun/duck_pond.py
@@ -145,6 +145,10 @@ class DuckPond(Cog):
         amount of ducks specified in the config under duck_pond/threshold, it will
         send the message off to the duck pond.
         """
+        # Ignore DMs.
+        if payload.guild_id is None:
+            return
+
         # Was this reaction issued in a blacklisted channel?
         if payload.channel_id in constants.DuckPond.channel_blacklist:
             return
@@ -154,6 +158,9 @@ class DuckPond(Cog):
             return
 
         channel = discord.utils.get(self.bot.get_all_channels(), id=payload.channel_id)
+        if channel is None:
+            return
+
         message = await channel.fetch_message(payload.message_id)
         member = discord.utils.get(message.guild.members, id=payload.user_id)
 


### PR DESCRIPTION
Also handle the channel not being found, which may be due to a cache issue or because it got deleted.

Fixes #1183
Fixes BOT-8T