### PR TITLE
Move PEP command embed URL to title

### DIFF
--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -84,7 +84,7 @@ class Utils(Cog):
                 # Assemble the embed
                 pep_embed = Embed(
                     title=f"**PEP {pep_number} - {pep_header['Title']}**",
-                    description=f"[Link]({self.base_pep_url}{pep_number:04})",
+                    url=f"{self.base_pep_url}{pep_number:04}"
                 )
 
                 pep_embed.set_thumbnail(url=ICON_URL)

--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -250,7 +250,7 @@ class Utils(Cog):
         """Send information about PEP 0."""
         pep_embed = Embed(
             title="**PEP 0 - Index of Python Enhancement Proposals (PEPs)**",
-            description="[Link](https://www.python.org/dev/peps/)"
+            url="https://www.python.org/dev/peps/"
         )
         pep_embed.set_thumbnail(url=ICON_URL)
         pep_embed.add_field(name="Status", value="Active")


### PR DESCRIPTION
Closes #1176

Link the PEP article using the embed title, rather than a separate `Link` in the description field.

Before:
![image](https://user-images.githubusercontent.com/44734341/94907656-c3baa680-04a0-11eb-8496-61282ef40aff.png)

After:
![image](https://user-images.githubusercontent.com/44734341/94907673-cae1b480-04a0-11eb-8d68-654a24075b21.png)