### PR TITLE
Reminder: no feedback message when no mention is used

### DIFF
--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -286,10 +286,11 @@ class Reminders(Cog):
 
         now = datetime.utcnow() - timedelta(seconds=1)
         humanized_delta = humanize_delta(relativedelta(expiration, now))
-        mention_string = (
-            f"Your reminder will arrive in {humanized_delta} "
-            f"and will mention {len(mentions)} other(s)!"
-        )
+        mention_string = f"Your reminder will arrive in {humanized_delta}"
+
+        if mentions:
+            mention_string += f" and will mention {len(mentions)} other(s)"
+        mention_string += "!"
 
         # Confirm to the user that it worked.
         await self._send_confirmation(


### PR DESCRIPTION
Remove the `and will mention x other(s)` message when no mention is attached to the reminder. 