### PR TITLE
Send attachments improvements

### DIFF
--- a/bot/exts/moderation/dm_relay.py
+++ b/bot/exts/moderation/dm_relay.py
@@ -90,7 +90,11 @@ class DMRelay(Cog):
         # Handle any attachments
         if message.attachments:
             try:
-                await send_attachments(message, self.webhook)
+                await send_attachments(
+                    message,
+                    self.webhook,
+                    username=f"{message.author.display_name} ({message.author.id})"
+                )
             except (discord.errors.Forbidden, discord.errors.NotFound):
                 e = discord.Embed(
                     description=":x: **This message contained an attachment, but it could not be retrieved**",

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -68,10 +68,11 @@ async def send_attachments(
     embed which links to them. Extra kwargs will be passed to send() when sending the attachment.
     """
     webhook_send_kwargs = {
-        'username': sub_clyde(message.author.display_name),
+        'username': message.author.display_name,
         'avatar_url': message.author.avatar_url,
     }
     webhook_send_kwargs.update(kwargs)
+    webhook_send_kwargs['username'] = sub_clyde(webhook_send_kwargs['username'])
 
     large = []
     urls = []

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -57,6 +57,7 @@ async def send_attachments(
     message: discord.Message,
     destination: Union[discord.TextChannel, discord.Webhook],
     link_large: bool = True,
+    use_cached: bool = False,
     **kwargs
 ) -> List[str]:
     """
@@ -85,7 +86,7 @@ async def send_attachments(
             # but some may get through hence the try-catch.
             if attachment.size <= destination.guild.filesize_limit - 512:
                 with BytesIO() as file:
-                    await attachment.save(file, use_cached=True)
+                    await attachment.save(file, use_cached=use_cached)
                     attachment_file = discord.File(file, filename=attachment.filename)
 
                     if isinstance(destination, discord.TextChannel):


### PR DESCRIPTION
Closes #1137 and closes #1139 
I think this also closes #909 

I just changed the default for `use_cached` to False, and didn't change it to set to True manually anywhere as I couldn't find anywhere that it was needed, antispam was the main one I checked but doesn't seem to try to fetch deleted messages from what I can see. Would be nice if somebody could confirm this