### PR TITLE
Improvements for the rules command

### DIFF
--- a/bot/exts/info/site.py
+++ b/bot/exts/info/site.py
@@ -122,10 +122,14 @@ class Site(Cog):
             return
 
         full_rules = await self.bot.api_client.get('rules', params={'link_format': 'md'})
-        invalid_indices = tuple(
-            pick
-            for pick in rules
-            if pick < 1 or pick > len(full_rules)
+
+        # Remove duplicates and sort the invalid rule indices
+        invalid_indices = sorted(
+            set(
+                pick
+                for pick in rules
+                if pick < 1 or pick > len(full_rules)
+            )
         )
 
         if invalid_indices:
@@ -135,6 +139,9 @@ class Site(Cog):
 
         for rule in rules:
             self.bot.stats.incr(f"rule_uses.{rule}")
+
+        # Remove duplicates and sort the rule indices
+        rules = sorted(set(rules))
 
         final_rules = tuple(f"**{pick}.** {full_rules[pick - 1]}" for pick in rules)
 

--- a/bot/exts/info/site.py
+++ b/bot/exts/info/site.py
@@ -122,25 +122,16 @@ class Site(Cog):
 
         full_rules = await self.bot.api_client.get('rules', params={'link_format': 'md'})
 
-        # Remove duplicates and sort the invalid rule indices
-        invalid_indices = sorted(
-            set(
-                pick
-                for pick in rules
-                if pick < 1 or pick > len(full_rules)
-            )
-        )
+        # Remove duplicates and sort the rule indices
+        rules = sorted(set(rules))
+        invalid = ', '.join(str(index) for index in rules if index < 1 or index > len(full_rules))
 
-        if invalid_indices:
-            indices = ', '.join(str(index) for index in invalid_indices)
-            await ctx.send(f":x: Invalid rule indices: {indices}")
+        if invalid:
+            await ctx.send(f":x: Invalid rule indices: {invalid}")
             return
 
         for rule in rules:
             self.bot.stats.incr(f"rule_uses.{rule}")
-
-        # Remove duplicates and sort the rule indices
-        rules = sorted(set(rules))
 
         final_rules = tuple(f"**{pick}.** {full_rules[pick - 1]}" for pick in rules)
 

--- a/bot/exts/info/site.py
+++ b/bot/exts/info/site.py
@@ -129,7 +129,7 @@ class Site(Cog):
         )
 
         if invalid_indices:
-            indices = ', '.join(map(str, invalid_indices))
+            indices = ', '.join(str(index) for index in invalid_indices)
             await ctx.send(f":x: Invalid rule indices: {indices}")
             return
 

--- a/bot/exts/info/site.py
+++ b/bot/exts/info/site.py
@@ -107,8 +107,7 @@ class Site(Cog):
     @site_group.command(name="rules", aliases=("r", "rule"), root_aliases=("rules", "rule"))
     async def site_rules(self, ctx: Context, rules: Greedy[int]) -> None:
         """Provides a link to all rules or, if specified, displays specific rule(s)."""
-        rules_embed = Embed(title='Rules', color=Colour.blurple())
-        rules_embed.url = f"{PAGES_URL}/rules"
+        rules_embed = Embed(title='Rules', color=Colour.blurple(), url=f'{PAGES_URL}/rules')
 
         if not rules:
             # Rules were not submitted. Return the default description.

--- a/bot/exts/info/site.py
+++ b/bot/exts/info/site.py
@@ -1,7 +1,7 @@
 import logging
 
 from discord import Colour, Embed
-from discord.ext.commands import Cog, Context, group
+from discord.ext.commands import Cog, Context, Greedy, group
 
 from bot.bot import Bot
 from bot.constants import URLs
@@ -105,7 +105,7 @@ class Site(Cog):
         await ctx.send(embed=embed)
 
     @site_group.command(name="rules", aliases=("r", "rule"), root_aliases=("rules", "rule"))
-    async def site_rules(self, ctx: Context, *rules: int) -> None:
+    async def site_rules(self, ctx: Context, rules: Greedy[int]) -> None:
         """Provides a link to all rules or, if specified, displays specific rule(s)."""
         rules_embed = Embed(title='Rules', color=Colour.blurple())
         rules_embed.url = f"{PAGES_URL}/rules"


### PR DESCRIPTION
## Description
This PR has a few improvements for the `!rules` command. Instead of using the splat operator (`*`), we are now using the `Greedy` converter to allow members to add extra text after the rule indices. I've also removed duplicate rule indices by using sets, and then sorting them afterwards.

## Screenshots
Text after rule indices:
![image](https://user-images.githubusercontent.com/52584399/95004758-9fa0b780-05bd-11eb-9794-9645a828ae27.png)

Before duplication removal (note the 357 pages):
![image](https://user-images.githubusercontent.com/52584399/95004795-fa3a1380-05bd-11eb-85f0-5a112be491db.png)

After duplication removal (note the 3 pages):
![image](https://user-images.githubusercontent.com/52584399/95004803-2190e080-05be-11eb-991f-10de78c15bf6.png)
