### PR TITLE
Added interleaving text in code blocks option

### DIFF
--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -88,7 +88,7 @@ class Snekbox(Cog):
         """Extract code from the Markdown, format it, and insert it into the code template."""
         match = FORMATTED_CODE_REGEX.fullmatch(code)
 
-        # Despite the wildcard being lazy, this is a fullmatch so we need to check the presence of the delim explicitly.
+        # Despite the wildcard being lazy, the pattern is from start to end and will eat any delimiters in the middle.
         if match and match.group("delim") not in match.group("code"):
             code, block, lang, delim = match.group("code", "block", "lang", "delim")
             code = textwrap.dedent(code)
@@ -100,7 +100,7 @@ class Snekbox(Cog):
 
         else:
             code_parts = CODE_BLOCK_REGEX.finditer(code)
-            merge = '\n'.join(map(lambda part: part.group("code"), code_parts))
+            merge = '\n'.join(part.group("code") for part in code_parts)
             if merge:
                 code = textwrap.dedent(merge)
                 log.trace(f"Merged one or more code blocks from text combined with code:\n{code}")

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -77,9 +77,9 @@ class Snekbox(Cog):
         """
         Extract code from the Markdown, format it, and insert it into the code template.
 
-        If there is Markdown, ignores surrounding text.
-        If there are several Markdown parts in the message, concatenates only the code blocks.
-        If there is inline code but no code blocks, takes the first instance of inline code.
+        If there is any code block, ignore text outside the code block.
+        Use the first code block, but prefer a fenced code block.
+        If there are several fenced code blocks, concatenate only the fenced code blocks.
         """
         if match := list(FORMATTED_CODE_REGEX.finditer(code)):
             blocks = [block for block in match if block.group("block")]

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -31,6 +31,15 @@ FORMATTED_CODE_REGEX = re.compile(
     r"\s*$",                                # any trailing whitespace until the end of the string
     re.DOTALL | re.IGNORECASE               # "." also matches newlines, case insensitive
 )
+CODE_BLOCK_REGEX = re.compile(
+    r"```"                                  # code block delimiter: 3 batckticks
+    r"([a-z]+\n)?"                          # match optional language (only letters plus newline)
+    r"(?:[ \t]*\n)*"                        # any blank (empty or tabs/spaces only) lines before the code
+    r"(?P<code>.*?)"                        # extract all code inside the markup
+    r"\s*"                                  # any more whitespace before the end of the code markup
+    r"```",                                 # code block end
+    re.DOTALL | re.IGNORECASE               # "." also matches newlines, case insensitive
+)
 RAW_CODE_REGEX = re.compile(
     r"^(?:[ \t]*\n)*"                       # any blank (empty or tabs/spaces only) lines before the code
     r"(?P<code>.*?)"                        # extract all the rest as code
@@ -78,7 +87,9 @@ class Snekbox(Cog):
     def prepare_input(code: str) -> str:
         """Extract code from the Markdown, format it, and insert it into the code template."""
         match = FORMATTED_CODE_REGEX.fullmatch(code)
-        if match:
+
+        # Despite the wildcard being lazy, this is a fullmatch so we need to check the presence of the delim explicitly.
+        if match and match.group("delim") not in match.group("code"):
             code, block, lang, delim = match.group("code", "block", "lang", "delim")
             code = textwrap.dedent(code)
             if block:
@@ -86,12 +97,20 @@ class Snekbox(Cog):
             else:
                 info = f"{delim}-enclosed inline code"
             log.trace(f"Extracted {info} for evaluation:\n{code}")
+
         else:
-            code = textwrap.dedent(RAW_CODE_REGEX.fullmatch(code).group("code"))
-            log.trace(
-                f"Eval message contains unformatted or badly formatted code, "
-                f"stripping whitespace only:\n{code}"
-            )
+            code_parts = CODE_BLOCK_REGEX.finditer(code)
+            merge = '\n'.join(map(lambda part: part.group("code"), code_parts))
+            if merge:
+                code = textwrap.dedent(merge)
+                log.trace(f"Merged one or more code blocks from text combined with code:\n{code}")
+
+            else:
+                code = textwrap.dedent(RAW_CODE_REGEX.fullmatch(code).group("code"))
+                log.trace(
+                    f"Eval message contains unformatted or badly formatted code, "
+                    f"stripping whitespace only:\n{code}"
+                )
 
         return code
 

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -74,7 +74,13 @@ class Snekbox(Cog):
 
     @staticmethod
     def prepare_input(code: str) -> str:
-        """Extract code from the Markdown, format it, and insert it into the code template."""
+        """
+        Extract code from the Markdown, format it, and insert it into the code template.
+
+        If there is Markdown, ignores surrounding text.
+        If there are several Markdown parts in the message, concatenates only the code blocks.
+        If there is inline code but no code blocks, takes the first instance of inline code.
+        """
         if match := list(FORMATTED_CODE_REGEX.finditer(code)):
             blocks = [block for block in match if block.group("block")]
 

--- a/tests/bot/exts/utils/test_snekbox.py
+++ b/tests/bot/exts/utils/test_snekbox.py
@@ -52,6 +52,13 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
             ('`print("Hello world!")`', 'print("Hello world!")', 'one line code block'),
             ('```\nprint("Hello world!")```', 'print("Hello world!")', 'multiline code block'),
             ('```py\nprint("Hello world!")```', 'print("Hello world!")', 'multiline python code block'),
+            ('text```print("Hello world!")```text', 'print("Hello world!")', 'code block surrounded by text'),
+            ('```print("Hello world!")```\ntext\n```py\nprint("Hello world!")```',
+             'print("Hello world!")\nprint("Hello world!")', 'two code blocks with text in-between'),
+            ('`print("Hello world!")`\ntext\n```print("How\'s it going?")```',
+             'print("How\'s it going?")', 'code block preceded by inline code'),
+            ('`print("Hello world!")`\ntext\n`print("Hello world!")`',
+             'print("Hello world!")', 'one inline code block of two')
         )
         for case, expected, testname in cases:
             with self.subTest(msg=f'Extract code from {testname}.'):


### PR DESCRIPTION
Closes #1104 

If the message contains both plaintext and code blocks, the text will be ignored.
If several code blocks are present, they are concatenated.

#### Implementation rationale
1. The issue with inline code is that it's used often inside an explanation to mark certain keywords.
For example:
> You can use the `join` function to concatenate a collection of strings:
> ```py
> strings = ('abc', 'xyz', 'asdf')
> print(' '.join(strings))


If we allow text to be added around the code, it wouldn't make sense to take those inline code segments into account.
We could decide to take into account only those that appear at the beginning of a line, but it would still easily trip users. I could just as easily write: 
>  `join` is a function to concatenate a collection of strings: ...

2. Therefore the idea is to make sure that if someone wants to add text, they should state their intention clearly for what part of the message they want to be the code, therefore allowing only code blocks in that case. Hence the separate regex.

Since it has separate regex, the pattern has to be matched separately once we know that not the whole message is formatted as code.

3. As per what was discussed on the issue, I added the option for separate code blocks.
Since we allow several code blocks, we need to make sure that the first regex doesn't result in a full match.
The wildcard for the code is lazy, but the pattern requires that it is followed from the beginning of the string to its end (^, $). therefore it will match the whole string:
"""\```py
print('hi')
\```
hello
\```
print('bye')
\```"""

Instead of just the first block, and will prevent the part of the code that handles multiple blocks from being reached, resulting in an error.
To fix it, I added a condition that makes sure that the delimiter doesn't appear inside the code:

[`if match and match.group("delim") not in match.group("code"):`](https://github.com/mbaruh/bot/blob/20c5a6946a140ef9e79f8a7c4edb60e2d5372298/bot/exts/utils/snekbox.py#L92-L93)

I considered at first amending `FORMATTED_CODE_REGEX`, but that would over-complicate it and could create bugs with the original function of the command.
There are other conditions that could be made, and I could switch the order of what's checked first, but I didn't see any specific advantage.