### PR TITLE
fix(statsd): Gracefully handle socket.gaierro in AsyncStatsClient

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -165,7 +165,7 @@ class Bot(commands.Bot):
         if self._resolver:
             await self._resolver.close()
 
-        if self.stats and self.stats._transport:
+        if self.stats._transport:
             self.stats._transport.close()
 
         if self.redis_session:
@@ -187,12 +187,7 @@ class Bot(commands.Bot):
     async def login(self, *args, **kwargs) -> None:
         """Re-create the connector and set up sessions before logging into Discord."""
         self._recreate()
-
-        if self.stats:
-            await self.stats.create_socket()
-        else:
-            log.info("self.stats is not defined, skipping create_socket step in login")
-
+        await self.stats.create_socket()
         await super().login(*args, **kwargs)
 
     async def on_guild_available(self, guild: discord.Guild) -> None:
@@ -238,10 +233,7 @@ class Bot(commands.Bot):
 
     async def on_error(self, event: str, *args, **kwargs) -> None:
         """Log errors raised in event listeners rather than printing them to stderr."""
-        if self.stats:
-            self.stats.incr(f"errors.event.{event}")
-        else:
-            log.info(f"self.stats is not defined, skipping errors.event.{event} increment in on_error")
+        self.stats.incr(f"errors.event.{event}")
 
         with push_scope() as scope:
             scope.set_tag("event", event)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -15,6 +15,7 @@ from bot import DEBUG_MODE, api, constants
 from bot.async_stats import AsyncStatsClient
 
 log = logging.getLogger('bot')
+LOCALHOST = "127.0.0.1"
 
 
 class Bot(commands.Bot):
@@ -44,12 +45,12 @@ class Bot(commands.Bot):
             # Since statsd is UDP, there are no errors for sending to a down port.
             # For this reason, setting the statsd host to 127.0.0.1 for development
             # will effectively disable stats.
-            statsd_url = "127.0.0.1"
+            statsd_url = LOCALHOST
 
         try:
             self.stats = AsyncStatsClient(self.loop, statsd_url, 8125, prefix="bot")
         except socket.gaierror as socket_error:
-            self.stats = None
+            self.stats = AsyncStatsClient(self.loop, LOCALHOST)
             self.loop.call_later(30, self.retry_statsd_connection, statsd_url)
             log.warning(f"Statsd client failed to instantiate with error:\n{socket_error}")
 


### PR DESCRIPTION
Per issue #1185  the bot might go down if the statsd client fails to connect during instantiation. This can be caused by an outage on their part, or network issues.
If this happens getaddrinfo will raise a socket.gaierror.
This PR catched the error, sets self.stats to None for the time being, and handles that elsewhere.
In addition, fallback logic was added to attempt to reconnect, in the off-chance it's a temporary outage