### PR TITLE
Support alternate gating methods

### DIFF
--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -553,7 +553,7 @@ class Verification(Cog):
             log.exception("DM dispatch failed on unexpected error code")
 
     @Cog.listener()
-    async def on_member_update(self, before: discord.Member, after: discord.Member):
+    async def on_member_update(self, before: discord.Member, after: discord.Member) -> None:
         """Check if we need to send a verification DM to a gated user."""
         before_roles = [r.id for r in before.roles]
         after_roles = [r.id for r in after.roles]

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -173,7 +173,7 @@ class Verification(Cog):
     # ]
     task_cache = RedisCache()
 
-    # Cache who needs to receive an alternate verified DM.
+    # Create a cache for storing recipients of the alternate welcome DM.
     member_gating_cache = RedisCache()
 
     def __init__(self, bot: Bot) -> None:

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -545,7 +545,7 @@ class Verification(Cog):
         # gate and will not need a welcome DM with verification instructions.
         # We will send them an alternate DM once they verify with the welcome
         # video.
-        if raw_member["is_pending"]:
+        if raw_member.get("is_pending"):
             await self.member_gating_cache.set(member.id, True)
             return
 

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -555,8 +555,8 @@ class Verification(Cog):
     @Cog.listener()
     async def on_member_update(self, before: discord.Member, after: discord.Member) -> None:
         """Check if we need to send a verification DM to a gated user."""
-        before_roles = [r.id for r in before.roles]
-        after_roles = [r.id for r in after.roles]
+        before_roles = [role.id for role in before.roles]
+        after_roles = [role.id for role in after.roles]
 
         if constants.Roles.verified not in before_roles and constants.Roles.verified in after_roles:
             if await self.member_gating_cache.pop(after.id):

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -541,7 +541,10 @@ class Verification(Cog):
 
         raw_member = await self.bot.http.get_member(member.guild.id, member.id)
 
-        # Only send the message to users going through our gating system
+        # If the user has the is_pending flag set, they will be using the alternate
+        # gate and will not need a welcome DM with verification instructions.
+        # We will send them an alternate DM once they verify with the welcome
+        # video.
         if raw_member["is_pending"]:
             await self.member_gating_cache.set(raw_member.id, True)
             return

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -546,7 +546,7 @@ class Verification(Cog):
         # We will send them an alternate DM once they verify with the welcome
         # video.
         if raw_member["is_pending"]:
-            await self.member_gating_cache.set(raw_member.id, True)
+            await self.member_gating_cache.set(member.id, True)
             return
 
         log.trace(f"Sending on join message to new member: {member.id}")

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -559,13 +559,11 @@ class Verification(Cog):
         after_roles = [r.id for r in after.roles]
 
         if constants.Roles.verified not in before_roles and constants.Roles.verified in after_roles:
-            if await self.member_gating_cache.get(after.id):
+            if await self.member_gating_cache.pop(after.id):
                 try:
                     await safe_dm(after.send(ALTERNATE_VERIFIED_MESSAGE))
                 except discord.HTTPException:
                     log.exception("DM dispatch failed on unexpected error code")
-                finally:
-                    self.member_gating_cache.pop(after.id)
 
     @Cog.listener()
     async def on_message(self, message: discord.Message) -> None:

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -561,6 +561,10 @@ class Verification(Cog):
         if constants.Roles.verified not in before_roles and constants.Roles.verified in after_roles:
             if await self.member_gating_cache.pop(after.id):
                 try:
+                    # If the member has not received a DM from our !accept command
+                    # and has gone through the alternate gating system we should send
+                    # our alternate welcome DM which includes info such as our welcome
+                    # video.
                     await safe_dm(after.send(ALTERNATE_VERIFIED_MESSAGE))
                 except discord.HTTPException:
                     log.exception("DM dispatch failed on unexpected error code")


### PR DESCRIPTION
This PR extends the verification cog to support users joining through alternate gating methods.

It will send a separate DM for any user verifying through a gating method which is not `!accept` and will completely disable the welcome DM.

![image](https://user-images.githubusercontent.com/20439493/95141717-cd2a6400-0769-11eb-955f-a4bba4453787.png)
