### PR TITLE
Include rolled over bot logs in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ ENV/
 
 # Logfiles
 log.*
+*.log.*
 
 # Custom user configuration
 config.yml


### PR DESCRIPTION
The `RotatingFileHandler` that's used for logging creates backups by appending `.#` to the file name that was passed in (for example `bot.log` -> `bot.log.1` in our case); these cases are currently excluded from the gitignore