### PR TITLE
CI: avoid failing whole job if a cache task fails

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,6 @@ jobs:
       BOT_TOKEN: bar
       REDDIT_CLIENT_ID: spam
       REDDIT_SECRET: ham
-      WOLFRAM_API_KEY: baz
       REDIS_PASSWORD: ''
 
     steps:
@@ -38,6 +37,7 @@ jobs:
           key: python | $(Agent.OS) | "$(python.pythonLocation)" | 0 | ./Pipfile | ./Pipfile.lock
           cacheHitVar: PY_ENV_RESTORED
           path: $(PYTHONUSERBASE)
+        continueOnError: true
 
       - script: echo '##vso[task.prependpath]$(PYTHONUSERBASE)/bin'
         displayName: 'Prepend PATH'
@@ -65,6 +65,7 @@ jobs:
         inputs:
           key: pre-commit | "$(python.pythonLocation)" | 0 | .pre-commit-config.yaml
           path: $(PRE_COMMIT_HOME)
+        continueOnError: true
 
       # pre-commit's venv doesn't allow user installs - not that they're really needed anyway.
       - script: export PIP_USER=0; pre-commit run --all-files


### PR DESCRIPTION
Restoring from cache is non-critical. The CI can recover if cache tasks fail.

I'm not sure if we can rely on `cacheHitVar` remaining unset when a cache task fails. This variable is used in the condition of pipenv steps:

```yaml
condition: and(succeeded(), ne(variables.PY_ENV_RESTORED, 'true'))
```

If it's not true, then pipenv won't be installed along with dependencies. If the cache task sets the variable before trying to restore (and failing), then this will make the job fail anyway since pipenv won't get installed. That's really no worse than the job failing at the cache task without `continueOnError: true`. Therefore, I don't mind waiting and seeing if this happens. I could be proactive and add a more complicated, ugly condition to the pipenv steps, but I'd rather not.