### PR TITLE
Add the ability to purge and ban in one command.

### DIFF
--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -71,6 +71,23 @@ class Infractions(InfractionScheduler, commands.Cog):
         """Permanently ban a user for the given reason and stop watching them with Big Brother."""
         await self.apply_ban(ctx, user, reason)
 
+    @command()
+    async def purgeban(
+        self,
+        ctx: Context,
+        user: FetchedMember,
+        purge_days: t.Optional[int] = 1,
+        *,
+        reason: t.Optional[str] = None
+    ) -> None:
+        """
+        Same as ban but removes all their messages for the given number of days, default being 1.
+
+        `purge_days` can only be values between 0 and 7.
+        Anything outside these bounds are automatically adjusted to their respective limits.
+        """
+        await self.apply_ban(ctx, user, reason, max(min(purge_days, 7), 0))
+
     # endregion
     # region: Temporary infractions
 
@@ -246,7 +263,14 @@ class Infractions(InfractionScheduler, commands.Cog):
         await self.apply_infraction(ctx, infraction, user, action)
 
     @respect_role_hierarchy(member_arg=2)
-    async def apply_ban(self, ctx: Context, user: UserSnowflake, reason: t.Optional[str], **kwargs) -> None:
+    async def apply_ban(
+        self,
+        ctx: Context,
+        user: UserSnowflake,
+        reason: t.Optional[str],
+        purge_days: t.Optional[int] = 0,
+        **kwargs
+    ) -> None:
         """
         Apply a ban infraction with kwargs passed to `post_infraction`.
 
@@ -278,7 +302,7 @@ class Infractions(InfractionScheduler, commands.Cog):
         if reason:
             reason = textwrap.shorten(reason, width=512, placeholder="...")
 
-        action = ctx.guild.ban(user, reason=reason, delete_message_days=0)
+        action = ctx.guild.ban(user, reason=reason, delete_message_days=purge_days)
         await self.apply_infraction(ctx, infraction, user, action)
 
         if infraction.get('expires_at') is not None:

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -71,7 +71,7 @@ class Infractions(InfractionScheduler, commands.Cog):
         """Permanently ban a user for the given reason and stop watching them with Big Brother."""
         await self.apply_ban(ctx, user, reason)
 
-    @command()
+    @command(aliases=('pban',))
     async def purgeban(
         self,
         ctx: Context,


### PR DESCRIPTION
Multiple times there's been cases where we've needed to purge a users messages due to spam or unsavoury content after banning via the bot command. As discord do support providing an argument to automatically purge a set number of days worth of messages when banning the user, it could potentially save mods a lot of time and effort.

Relevant links:
[Docs for Guild.ban()](https://discordpy.readthedocs.io/en/neo-docs/api.html#discord.Guild.ban)

The implementation I've gone with is to add a new, separate command to deal with purging on bans, called, hopefully intuitively, `purgeban`.

The command has the following signature:
`!purgeban <user> [purge_days=1] [reason]`

The usage is exactly the same as the original `ban` command, except we can _optionally_ add a number before the reason that represents the days worth of messages to be deleted.

E.g.:
 - `!ban 394529085923262464 This is a ban reason`
   - This would ban the user with ID 394529085923262464, removing 1 day of messages.
 - `!ban 394529085923262464 3 This is a ban reason`
   - This would ban the user with ID 394529085923262464, removing 3 days of messages.

This _does_ introduce a potential issue of reasons that start with numbers causing it to be interpreted as the purge_days value, however this should be minimised with the clearly distinct alternate command usage; if they're remembering to seek out specifically the purgeban command, they'll likely to explicitly remember to not start the reason with a number.
