### PR TITLE
Fix millisecond time for command processing time

### DIFF
--- a/bot/exts/utils/ping.py
+++ b/bot/exts/utils/ping.py
@@ -33,7 +33,7 @@ class Latency(commands.Cog):
         """
         # datetime.datetime objects do not have the "milliseconds" attribute.
         # It must be converted to seconds before converting to milliseconds.
-        bot_ping = (datetime.utcnow() - ctx.message.created_at).total_seconds() / 1000
+        bot_ping = (datetime.utcnow() - ctx.message.created_at).total_seconds() * 1000
         bot_ping = f"{bot_ping:.{ROUND_LATENCY}f} ms"
 
         try:


### PR DESCRIPTION
Fixes a faulty conversion from seconds to milliseconds, for the `.ping` command. No matter how heavy load the bot is under, it currently displays `Command processing time: 0.000ms`. This PR aims to solve that, by fixing the conversion from seconds to milliseconds done.