### PR TITLE
Fixed hardcoded prefix in __main__.py

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -58,7 +58,7 @@ bot = Bot(
     redis_session=redis_session,
     loop=loop,
     command_prefix=when_mentioned_or(constants.Bot.prefix),
-    activity=discord.Game(name="Commands: !help"),
+    activity=discord.Game(name=f"Commands: {constants.Bot.prefix}help"),
     case_insensitive=True,
     max_messages=10_000,
     allowed_mentions=discord.AllowedMentions(everyone=False, roles=allowed_roles),


### PR DESCRIPTION
This is a little commit, but the prefix was hardcoded in [\_\_main\_\_.py](https://github.com/python-discord/bot/blob/b081db8418aedf113bab17e0f44313840b965b8e/bot/__main__.py#L61). This PR should fix it.