### PR TITLE
Verification: add note to kicked members

### DIFF
--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -367,7 +367,7 @@ class Verification(Cog):
             "actor": self.bot.user.id,  # Bot actions this autonomously
             "expires_at": None,
             "hidden": True,
-            "reason": f"Kicked for not having verified after {constants.Verification.kicked_after} days",
+            "reason": "Verification kick",
             "type": "note",
             "user": member.id,
         }

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -396,6 +396,7 @@ class Verification(Cog):
             except discord.HTTPException as suspicious_exception:
                 raise StopExecution(reason=suspicious_exception)
             await member.kick(reason=f"User has not verified in {constants.Verification.kicked_after} days")
+            await self._add_kick_note(member)
 
         n_kicked = await self._send_requests(members, kick_request, Limit(batch_size=2, sleep_secs=1))
         self.bot.stats.incr("verification.kicked", count=n_kicked)

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -11,6 +11,7 @@ from discord.ext.commands import Cog, Context, command, group, has_any_role
 from discord.utils import snowflake_time
 
 from bot import constants
+from bot.api import ResponseCodeError
 from bot.bot import Bot
 from bot.decorators import has_no_roles, in_whitelist
 from bot.exts.moderation.modlog import ModLog
@@ -354,6 +355,28 @@ class Verification(Cog):
             log.info(f"Failed to send {len(members) - n_success} requests due to following statuses: {bad_statuses}")
 
         return n_success
+
+    async def _add_kick_note(self, member: discord.Member) -> None:
+        """
+        Post a note regarding `member` being kicked to site.
+
+        Allows keeping track of kicked members for auditing purposes.
+        """
+        payload = {
+            "active": False,
+            "actor": self.bot.user.id,  # Bot actions this autonomously
+            "expires_at": None,
+            "hidden": True,
+            "reason": f"Kicked for not having verified after {constants.Verification.kicked_after} days",
+            "type": "note",
+            "user": member.id,
+        }
+
+        log.trace(f"Posting kick note: {payload!r}")
+        try:
+            await self.bot.api_client.post("bot/infractions", json=payload)
+        except ResponseCodeError as api_exc:
+            log.warning("Failed to post kick note", exc_info=api_exc)
 
     async def _kick_members(self, members: t.Collection[discord.Member]) -> int:
         """

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -372,7 +372,7 @@ class Verification(Cog):
             "user": member.id,
         }
 
-        log.trace(f"Posting kick note: {payload!r}")
+        log.trace(f"Posting kick note for member {member} ({member.id})")
         try:
             await self.bot.api_client.post("bot/infractions", json=payload)
         except ResponseCodeError as api_exc:


### PR DESCRIPTION
We've now had the Verification task kicking dormant unverified users from the guild for some time, and @lemonsaurus has raised the issue of having no easy way to determine whether a specific user was previously kicked by the system, and how many times.

## Solution

In order to amend this issue, we decided to post a note infraction to site on-kick. This will give mods the ability to see that a specific user was kicked in their infraction history:

![image](https://user-images.githubusercontent.com/44734341/95866001-a40c6380-0d67-11eb-8421-e52f055478a2.png)

My bot is called `lana del rey` and the alt I kicked is called `lana del rey 2`, sorry that's confusing.

## Implementation details

I decided to write my own small wrapper for the post call, as what's available in the current mod tooling is not compatible. Notes are usually routed through `post_infraction`, which is written with the assumption of being called from a command ~ it wants a `discord.Context` to infer some of the information, and then uses the context to send an error message to should the post fail.

https://github.com/python-discord/bot/blob/eb82da94b5101e8399b0ac168d049cbf2d3ec93b/bot/exts/moderation/infraction/_utils.py#L71-L79

Auto-mod gets around this by building up a ctx locally & then mutating it, I'd rather not do that.

## Considerations

This shouldn't race with the member syncer because the member will not be removed from the DB once the are kicked, *but* they are patched with `in_guild=False` once the guild leave event comes. Should we decide to remove member records from the DB on-leave, this approach will no longer be feasible.

This was discussed, but worth mentioning: because all kicked members will now have infraction records, they will remain in the DB even after the monthly cleanse. We agreed that this is ok.

## Review & testing

Testing this is a little tricky, but I try to give everyone the `@Verified` role in the dev environment to make them immune to kicks, adjust the config to kick on day 0, then kick my alt. It's possible to comment out the `member.kick` call above the post if you want. The payload is logged at trace level so you can see who you've kicked and whose infr history to search. Let me know if you need help orchestrating this.

For review please make sure that I'm constructing the payload correctly, but I copied it over from existing mod tooling & consulted site docs, so I think it's fine. Also please pay extra attention to what effect this may have on the member DB & our data policy, and whether this could race with some other feature.