### PR TITLE
Add timeit eval command

### DIFF
--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -37,6 +37,11 @@ RAW_CODE_REGEX = re.compile(
     r"\s*$",  # any trailing whitespace until the end of the string
     re.DOTALL  # "." also matches newlines
 )
+ESCAPE_CODE_TRANS = str.maketrans({
+            "\n": "\\n",
+            "'": "\'",
+            '"': '\"'
+        })
 
 MAX_PASTE_LEN = 1000
 
@@ -234,6 +239,11 @@ class Snekbox(Cog):
 
         return output, None
 
+    @staticmethod
+    def escape_code(code: str) -> str:
+        """Escapes quotes and newlines in code string."""
+        return code.translate(ESCAPE_TRANS)
+
     async def send_timeit(self, ctx: Context, code: str) -> Message:
         """
         Evaluate code with timing, format it, and send the output to the corresponding channel.
@@ -241,7 +251,7 @@ class Snekbox(Cog):
         Return the bot response.
         """
         async with ctx.typing():
-            code = code.replace("'", r"\'")
+            code = self.escape_code(code)
             code = f"import timeit\n" \
                    f"timeit.main(['{code}'])"
 

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -384,29 +384,22 @@ class Snekbox(Cog):
 
         await self.run_eval(ctx, code, self.send_eval)
 
-        if Roles.helpers in (role.id for role in ctx.author.roles):
-            self.bot.stats.incr("snekbox_usages.roles.helpers")
-        else:
-            self.bot.stats.incr("snekbox_usages.roles.developers")
+    @command(name="timeit", aliases=("ti",))
+    @guild_only()
+    @in_whitelist(channels=EVAL_CHANNELS, categories=EVAL_CATEGORIES, roles=EVAL_ROLES)
+    async def timeit_command(self, ctx: Context, *, code: str = None) -> None:
+        """
+        Profile Python Code to find execution time
 
         This command supports multiple lines of code, including code wrapped inside a formatted code
         block. Code can be re-evaluated by editing the original message within 10 seconds and
         clicking the reaction that subsequently appears.
 
-        log.info(f"Received code from {ctx.author} for evaluation:\n{code}")
+        We've done our best to make this sandboxed, but do let us know if you manage to find an
+        issue with it!
+        """
 
-        while True:
-            self.jobs[ctx.author.id] = datetime.datetime.now()
-            code = self.prepare_input(code)
-            try:
-                response = await self.send_eval(ctx, code)
-            finally:
-                del self.jobs[ctx.author.id]
-
-            code = await self.continue_eval(ctx, response)
-            if not code:
-                break
-            log.info(f"Re-evaluating code from message {ctx.message.id}:\n{code}")
+        await self.run_eval(ctx, code, self.send_timeit)
 
 
 def predicate_eval_message_edit(ctx: Context, old_msg: Message, new_msg: Message) -> bool:

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -317,7 +317,7 @@ class Snekbox(Cog):
         log.trace(f"Getting context for message {message.id}.")
         new_ctx = await self.bot.get_context(message)
 
-        if new_ctx.command is self.eval_command:
+        if new_ctx.command in (self.eval_command, self.timeit_command):
             log.trace(f"Message {message.id} invokes eval command.")
             split = message.content.split(maxsplit=1)
             code = split[1] if len(split) > 1 else None


### PR DESCRIPTION
Implemented the timeit command proposed in issue #1025 

This command is very similar to calling `python -m  timeit <code>`, It maintains all of the previous features of the `eval` command with the addition of timing the code using `timeit`.

![image](https://user-images.githubusercontent.com/35881002/95936387-a932d800-0d92-11eb-8f93-eaa4fb728def.png)
