### PR TITLE
Whitelist Core Dev Sprinters from our filters

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -456,6 +456,7 @@ class Roles(metaclass=YAMLGetter):
     owners: int
     partners: int
     python_community: int
+    sprinters: int
     team_leaders: int
     unverified: int
     verified: int  # This is the Developers role on PyDis, here named verified for readability reasons.

--- a/bot/exts/filters/antimalware.py
+++ b/bot/exts/filters/antimalware.py
@@ -6,7 +6,7 @@ from discord import Embed, Message, NotFound
 from discord.ext.commands import Cog
 
 from bot.bot import Bot
-from bot.constants import Channels, STAFF_ROLES, URLs
+from bot.constants import Channels, Filter, URLs
 
 log = logging.getLogger(__name__)
 
@@ -61,7 +61,7 @@ class AntiMalware(Cog):
 
         # Check if user is staff, if is, return
         # Since we only care that roles exist to iterate over, check for the attr rather than a User/Member instance
-        if hasattr(message.author, "roles") and any(role.id in STAFF_ROLES for role in message.author.roles):
+        if hasattr(message.author, "roles") and any(role.id in Filter.role_whitelist for role in message.author.roles):
             return
 
         embed = Embed()

--- a/bot/exts/filters/antispam.py
+++ b/bot/exts/filters/antispam.py
@@ -15,7 +15,6 @@ from bot.constants import (
     AntiSpam as AntiSpamConfig, Channels,
     Colours, DEBUG_MODE, Event, Filter,
     Guild as GuildConfig, Icons,
-    STAFF_ROLES,
 )
 from bot.converters import Duration
 from bot.exts.moderation.modlog import ModLog
@@ -149,7 +148,7 @@ class AntiSpam(Cog):
             or message.guild.id != GuildConfig.id
             or message.author.bot
             or (message.channel.id in Filter.channel_whitelist and not DEBUG_MODE)
-            or (any(role.id in STAFF_ROLES for role in message.author.roles) and not DEBUG_MODE)
+            or (any(role.id in Filter.role_whitelist for role in message.author.roles) and not DEBUG_MODE)
         ):
             return
 

--- a/config-default.yml
+++ b/config-default.yml
@@ -119,6 +119,7 @@ style:
         voice_state_green: "https://cdn.discordapp.com/emojis/656899770094452754.png"
         voice_state_red: "https://cdn.discordapp.com/emojis/656899769905709076.png"
 
+
 guild:
     id: 267624335836053506
     invite: "https://discord.gg/python"
@@ -225,6 +226,7 @@ guild:
         muted:              &MUTED_ROLE         277914926603829249
         partners:                               323426753857191936
         python_community:   &PY_COMMUNITY_ROLE  458226413825294336
+        sprinters:          &SPRINTERS          758422482289426471
 
         unverified:                             739794855945044069
         verified:                               352427296948486144  # @Developers on PyDis
@@ -260,6 +262,7 @@ guild:
         python_news:        &PYNEWS_WEBHOOK 704381182279942324
         reddit:                             635408384794951680
         talent_pool:                        569145364800602132
+
 
 filter:
     # What do we filter?
@@ -298,6 +301,7 @@ filter:
         - *OWNERS_ROLE
         - *HELPERS_ROLE
         - *PY_COMMUNITY_ROLE
+        - *SPRINTERS
 
 
 keys:
@@ -325,6 +329,7 @@ urls:
     # Misc URLs
     bot_avatar:      "https://raw.githubusercontent.com/discord-python/branding/master/logos/logo_circle/logo_circle.png"
     github_bot_repo: "https://github.com/python-discord/bot"
+
 
 anti_spam:
     # Clean messages that violate a rule.
@@ -459,9 +464,11 @@ help_channels:
     notify_roles:
         - *HELPERS_ROLE
 
+
 redirect_output:
     delete_invocation: true
     delete_delay: 15
+
 
 duck_pond:
     threshold: 4
@@ -477,6 +484,7 @@ duck_pond:
         - *STAFF_ANNOUNCEMENTS
         - *MOD_ANNOUNCEMENTS
         - *ADMIN_ANNOUNCEMENTS
+
 
 python_news:
     mail_lists:


### PR DESCRIPTION
To make sure we're not interrupting the Core Devs when they're having their Core Dev Sprint, I've added the `Sprinters` role to our constants and added them to our filter whitelist. To make this easier, I've now made it so all filter features that use a role whitelist use the same role whitelist constant. That makes maintenance a bit easier.

In the process, I've also added a few line breaks in `config-default.yml` to kaizen it up: Now all groups have two line breaks between them. 