### PR TITLE
Centralized handling of mod channel check

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -468,6 +468,7 @@ class Guild(metaclass=YAMLGetter):
     id: int
     invite: str  # Discord invite, gets embedded in chat
     moderation_channels: List[int]
+    moderation_categories: List[int]
     moderation_roles: List[int]
     modlog_blacklist: List[int]
     reminder_whitelist: List[int]
@@ -627,6 +628,9 @@ STAFF_ROLES = Guild.staff_roles
 
 # Channel combinations
 MODERATION_CHANNELS = Guild.moderation_channels
+
+# Category combinations
+MODERATION_CATEGORIES = Guild.moderation_categories
 
 # Bot replies
 NEGATIVE_REPLIES = [

--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -14,6 +14,7 @@ from bot import constants
 from bot.bot import Bot
 from bot.decorators import in_whitelist
 from bot.pagination import LinePaginator
+from bot.utils.channel import is_mod_channel
 from bot.utils.checks import cooldown_with_role_bypass, has_no_roles_check, in_whitelist_check
 from bot.utils.time import time_since
 
@@ -241,14 +242,8 @@ class Information(Cog):
             ),
         ]
 
-        # Use getattr to future-proof for commands invoked via DMs.
-        show_verbose = (
-            ctx.channel.id in constants.MODERATION_CHANNELS
-            or getattr(ctx.channel, "category_id", None) == constants.Categories.modmail
-        )
-
         # Show more verbose output in moderation channels for infractions and nominations
-        if show_verbose:
+        if is_mod_channel(ctx.channel):
             fields.append(await self.expanded_user_infraction_counts(user))
             fields.append(await self.user_nomination_counts(user))
         else:

--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -12,11 +12,12 @@ from discord.ext.commands import Context
 from bot import constants
 from bot.api import ResponseCodeError
 from bot.bot import Bot
-from bot.constants import Colours, MODERATION_CHANNELS
+from bot.constants import Colours
 from bot.exts.moderation.infraction import _utils
 from bot.exts.moderation.infraction._utils import UserSnowflake
 from bot.exts.moderation.modlog import ModLog
 from bot.utils import messages, scheduling, time
+from bot.utils.channel import is_mod_channel
 
 log = logging.getLogger(__name__)
 
@@ -136,7 +137,7 @@ class InfractionScheduler:
             )
             if reason:
                 end_msg = f" (reason: {textwrap.shorten(reason, width=1500, placeholder='...')})"
-        elif ctx.channel.id not in MODERATION_CHANNELS:
+        elif not is_mod_channel(ctx.channel):
             log.trace(
                 f"Infraction #{id_} context is not in a mod channel; omitting infraction count."
             )

--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -137,11 +137,7 @@ class InfractionScheduler:
             )
             if reason:
                 end_msg = f" (reason: {textwrap.shorten(reason, width=1500, placeholder='...')})"
-        elif not is_mod_channel(ctx.channel):
-            log.trace(
-                f"Infraction #{id_} context is not in a mod channel; omitting infraction count."
-            )
-        else:
+        elif is_mod_channel(ctx.channel):
             log.trace(f"Fetching total infraction count for {user}.")
 
             infractions = await self.bot.api_client.get(

--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -15,7 +15,7 @@ from bot.exts.moderation.infraction.infractions import Infractions
 from bot.exts.moderation.modlog import ModLog
 from bot.pagination import LinePaginator
 from bot.utils import messages, time
-from bot.utils.checks import in_whitelist_check
+from bot.utils.channel import is_mod_channel
 
 log = logging.getLogger(__name__)
 
@@ -295,13 +295,7 @@ class ModManagement(commands.Cog):
         """Only allow moderators inside moderator channels to invoke the commands in this cog."""
         checks = [
             await commands.has_any_role(*constants.MODERATION_ROLES).predicate(ctx),
-            in_whitelist_check(
-                ctx,
-                channels=constants.MODERATION_CHANNELS,
-                categories=[constants.Categories.modmail],
-                redirect=None,
-                fail_silently=True,
-            )
+            is_mod_channel(ctx.channel)
         ]
         return all(checks)
 

--- a/bot/utils/channel.py
+++ b/bot/utils/channel.py
@@ -2,7 +2,7 @@ import logging
 
 import discord
 
-from bot.constants import Categories
+from bot.constants import Categories, MODERATION_CHANNELS
 
 log = logging.getLogger(__name__)
 
@@ -13,6 +13,14 @@ def is_help_channel(channel: discord.TextChannel) -> bool:
     categories = (Categories.help_available, Categories.help_in_use)
 
     return any(is_in_category(channel, category) for category in categories)
+
+
+def is_mod_channel(channel: discord.TextChannel) -> bool:
+    """Return True if `channel` is one of the moderation channels or in one of the moderation categories."""
+    log.trace(f"Checking if #{channel} is a mod channel.")
+    categories = (Categories.modmail, Categories.logs)
+
+    return channel.id in MODERATION_CHANNELS or any(is_in_category(channel, category) for category in categories)
 
 
 def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:

--- a/bot/utils/channel.py
+++ b/bot/utils/channel.py
@@ -2,7 +2,8 @@ import logging
 
 import discord
 
-from bot.constants import Categories, MODERATION_CHANNELS
+from bot import constants
+from bot.constants import Categories
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +21,8 @@ def is_mod_channel(channel: discord.TextChannel) -> bool:
     log.trace(f"Checking if #{channel} is a mod channel.")
     categories = (Categories.modmail, Categories.logs)
 
-    return channel.id in MODERATION_CHANNELS or any(is_in_category(channel, category) for category in categories)
+    return channel.id in constants.MODERATION_CHANNELS \
+        or any(is_in_category(channel, category) for category in categories)
 
 
 def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:

--- a/bot/utils/channel.py
+++ b/bot/utils/channel.py
@@ -21,8 +21,8 @@ def is_mod_channel(channel: discord.TextChannel) -> bool:
     log.trace(f"Checking if #{channel} is a mod channel.")
     categories = (Categories.modmail, Categories.logs)
 
-    return channel.id in constants.MODERATION_CHANNELS \
-        or any(is_in_category(channel, category) for category in categories)
+    return (channel.id in constants.MODERATION_CHANNELS
+            or any(is_in_category(channel, category) for category in categories))
 
 
 def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:

--- a/bot/utils/channel.py
+++ b/bot/utils/channel.py
@@ -17,13 +17,18 @@ def is_help_channel(channel: discord.TextChannel) -> bool:
 
 
 def is_mod_channel(channel: discord.TextChannel) -> bool:
-    """Return True if `channel` is one of the moderation channels or in one of the moderation categories."""
-    log.trace(f"Checking if #{channel} is a mod channel.")
+    """True if `channel` is considered a mod channel."""
+    if channel.id in constants.MODERATION_CHANNELS:
+        log.trace(f"Channel #{channel} is a configured mod channel")
+        return True
 
-    return (
-        channel.id in constants.MODERATION_CHANNELS
-        or any(is_in_category(channel, category) for category in constants.MODERATION_CATEGORIES)
-    )
+    elif any(is_in_category(channel, category) for category in constants.MODERATION_CATEGORIES):
+        log.trace(f"Channel #{channel} is in a configured mod category")
+        return True
+
+    else:
+        log.trace(f"Channel #{channel} is not a mod channel")
+        return False
 
 
 def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:

--- a/bot/utils/channel.py
+++ b/bot/utils/channel.py
@@ -19,10 +19,11 @@ def is_help_channel(channel: discord.TextChannel) -> bool:
 def is_mod_channel(channel: discord.TextChannel) -> bool:
     """Return True if `channel` is one of the moderation channels or in one of the moderation categories."""
     log.trace(f"Checking if #{channel} is a mod channel.")
-    categories = (Categories.modmail, Categories.logs)
 
-    return (channel.id in constants.MODERATION_CHANNELS
-            or any(is_in_category(channel, category) for category in categories))
+    return (
+        channel.id in constants.MODERATION_CHANNELS
+        or any(is_in_category(channel, category) for category in constants.MODERATION_CATEGORIES)
+    )
 
 
 def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:

--- a/config-default.yml
+++ b/config-default.yml
@@ -128,8 +128,8 @@ guild:
         help_available:                     691405807388196926
         help_in_use:                        696958401460043776
         help_dormant:                       691405908919451718
-        modmail:                            714494672835444826
-        logs:                               468520609152892958
+        modmail:            &MODMAIL        714494672835444826
+        logs:               &LOGS           468520609152892958
 
     channels:
         # Public announcement and news channels
@@ -199,6 +199,10 @@ guild:
         # Watch
         big_brother_logs:   &BB_LOGS        468507907357409333
         talent_pool:        &TALENT_POOL    534321732593647616
+
+    moderation_categories:
+        - *MODMAIL
+        - *LOGS
 
     moderation_channels:
         - *ADMINS

--- a/config-default.yml
+++ b/config-default.yml
@@ -129,6 +129,7 @@ guild:
         help_in_use:                        696958401460043776
         help_dormant:                       691405908919451718
         modmail:                            714494672835444826
+        logs:                               468520609152892958
 
     channels:
         # Public announcement and news channels
@@ -179,7 +180,7 @@ guild:
         incidents:                          714214212200562749
         incidents_archive:                  720668923636351037
         mods:               &MODS           305126844661760000
-        mod_alerts:         &MOD_ALERTS     473092532147060736
+        mod_alerts:                         473092532147060736
         mod_spam:           &MOD_SPAM       620607373828030464
         organisation:       &ORGANISATION   551789653284356126
         staff_lounge:       &STAFF_LOUNGE   464905259261755392
@@ -202,7 +203,6 @@ guild:
     moderation_channels:
         - *ADMINS
         - *ADMIN_SPAM
-        - *MOD_ALERTS
         - *MODS
         - *MOD_SPAM
 


### PR DESCRIPTION
Closes #1175 

The purpose of this PR is to provide one location in the code which is responsible for checking whether a given channel is a mod channel.

Currently this check is performed in the following locations:
* `!user` - If it's a mod channel, it will also display notes and nominations.
* The moderation management cog - only works in mod channels.
* When issuing infractions - mod channels will display infraction number, and total number of infractions for the user.

Issues begin when the definition of what's considered a mod channel changes. The most recent occurrence is the introduction of Modmail, which led to issue https://github.com/python-discord/bot/issues/1125.
However, because those checks are scattered, after that issue was resolved we were still left with https://github.com/python-discord/bot/issues/1175 - which is closed by this PR.

On top of that, despite `#mod-alerts` being whitelisted as a mod channel for quite some time, it didn't display infractions total as that is a separate check, leading to https://github.com/python-discord/bot/issues/1127.

Additionally, I changed all log channels to be considered mod channels, as there were instances where we wanted to run an infraction search in one of the log channels that wasn't `#mod-alerts` but couldn't.

In the future, if we wish to change the definition of what a mod channel is, we can just change the function `is_mod_channel` I'm adding here, and all related commands will work accordingly.