### PR TITLE
Ensure verified users can see verified message.

### DIFF
--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -22,7 +22,7 @@ FAILED_MESSAGE = (
 )
 
 MESSAGE_FIELD_MAP = {
-    "verified_at": f"have been verified for less {GateConf.minimum_days_verified} days",
+    "verified_at": f"have been verified for less than {GateConf.minimum_days_verified} days",
     "voice_banned": "have an active voice ban infraction",
     "total_messages": f"have sent less than {GateConf.minimum_messages} messages",
 }

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -113,6 +113,10 @@ class VoiceGate(Cog):
             description="You have been granted permission to use voice channels in Python Discord.",
             color=Colour.green()
         )
+
+        if ctx.author.voice:
+            embed.description += "\n\nPlease reconnect to your voice channel to be granted your new permissions."
+
         try:
             await ctx.author.send(embed=embed)
             await ctx.send(f"{ctx.author}, please check your DMs.")

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from contextlib import suppress
 from datetime import datetime, timedelta
@@ -50,9 +51,6 @@ class VoiceGate(Cog):
         - You must have accepted our rules over a certain number of days ago
         - You must not be actively banned from using our voice channels
         """
-        # Send this as first thing in order to return after sending DM
-        await ctx.send(f"{ctx.author.mention}, check your DMs.")
-
         try:
             data = await self.bot.api_client.get(f"bot/users/{ctx.author.id}/metricity_data")
         except ResponseCodeError as e:
@@ -104,12 +102,12 @@ class VoiceGate(Cog):
             )
             try:
                 await ctx.author.send(embed=embed)
+                await ctx.send(f"{ctx.author}, please check your DMs.")
             except discord.Forbidden:
                 await ctx.channel.send(ctx.author.mention, embed=embed)
             return
 
         self.mod_log.ignore(Event.member_update, ctx.author.id)
-        await ctx.author.add_roles(discord.Object(Roles.voice_verified), reason="Voice Gate passed")
         embed = discord.Embed(
             title="Voice gate passed",
             description="You have been granted permission to use voice channels in Python Discord.",
@@ -117,8 +115,14 @@ class VoiceGate(Cog):
         )
         try:
             await ctx.author.send(embed=embed)
+            await ctx.send(f"{ctx.author}, please check your DMs.")
         except discord.Forbidden:
             await ctx.channel.send(ctx.author.mention, embed=embed)
+
+        # wait a little bit so those who don't get DMs see the response in-channel before losing perms to see it.
+        await asyncio.sleep(3)
+        await ctx.author.add_roles(discord.Object(Roles.voice_verified), reason="Voice Gate passed")
+
         self.bot.stats.incr("voice_gate.passed")
 
     @Cog.listener()


### PR DESCRIPTION
When verified users get their role, they cannot see the voice-verification channel anymore, so I've added a 3 second delay for granting the role in order to ensure there's some time for them to see the response. 

I've also moved the DM message to only be sent if the DM message succeeds, and to not mention them in-channel to avoid distracting them from the DM notification unnecessarily, as I'm sure they'll see a near-instant response to their command usage in that channel.

I have also been requested to make a grammatical fix as well as to let users know to reconnect to voice to have it apply the change in permissions after verification.