### PR TITLE
Set async-rediscache logging level to warning

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -65,7 +65,6 @@ logging.getLogger("discord").setLevel(logging.WARNING)
 logging.getLogger("websockets").setLevel(logging.WARNING)
 logging.getLogger("chardet").setLevel(logging.WARNING)
 logging.getLogger("async_rediscache").setLevel(logging.WARNING)
-logging.getLogger(__name__)
 
 
 # On Windows, the selector event loop is required for aiodns.

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -64,6 +64,7 @@ coloredlogs.install(logger=root_log, stream=sys.stdout)
 logging.getLogger("discord").setLevel(logging.WARNING)
 logging.getLogger("websockets").setLevel(logging.WARNING)
 logging.getLogger("chardet").setLevel(logging.WARNING)
+logging.getLogger("async_rediscache").setLevel(logging.WARNING)
 logging.getLogger(__name__)
 
 


### PR DESCRIPTION
async-rediscache does quite a few debug logs per operation, which drown out the bot logs around them without bringing information of much relevance when developing on the bot, pushing the logging level to only show warnings should keep the logs from the module only to what may matter.

Currently the module only does a couple of error logs and one critical log in places where an exception is raised anyway, but this will make sure that warnings still go through in case they are added in the future.
