### PR TITLE
Change default API URL to internal docker network.

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 from typing import Optional
 from urllib.parse import quote as quote_url
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -58,7 +59,7 @@ class APIClient:
 
     @staticmethod
     def _url_for(endpoint: str) -> str:
-        return f"{URLs.site_schema}{URLs.site_api}/{quote_url(endpoint)}"
+        return urlparse(f"{URLs.site_api}/{quote_url(endpoint)}", "http").geturl()
 
     async def _create_session(self, **session_kwargs) -> None:
         """

--- a/config-default.yml
+++ b/config-default.yml
@@ -318,7 +318,7 @@ keys:
 urls:
     # PyDis site vars
     site:        &DOMAIN       "pythondiscord.com"
-    site_api:    &API    !JOIN ["api.", *DOMAIN]
+    site_api:    &API          "api.site"
     site_paste:  &PASTE  !JOIN ["paste.", *DOMAIN]
     site_staff:  &STAFF  !JOIN ["staff.", *DOMAIN]
     site_schema: &SCHEMA       "https://"


### PR DESCRIPTION
Currently, we're experiencing some issues requesting API data via the public domain, likely caused by some Cloudflare weirdness.

This change sets the internal domain `api.site`, referenceable through the internal Docker DNS only, as the default API domain in config.

This should be **not** merged until https://github.com/python-discord/site/pull/413 and https://github.com/python-discord/salt/pull/21 are both merged and tested manually to resolve correctly.