### PR TITLE
Shorter `!code` message

### DIFF
--- a/bot/resources/tags/codeblock.md
+++ b/bot/resources/tags/codeblock.md
@@ -4,4 +4,4 @@ Here's how to format Python code on Discord:
 print('Hello world!')
 \```
 
-**These are backticks, not quotes.** Backticks can usually be found to the left of the `1` key.  
+**These are backticks, not quotes.** See [here](https://superuser.com/questions/254076/how-do-i-type-the-tick-and-backtick-characters-on-windows/254077#254077) if you can't find the backtick key.

--- a/bot/resources/tags/codeblock.md
+++ b/bot/resources/tags/codeblock.md
@@ -4,4 +4,4 @@ Here's how to format Python code on Discord:
 print('Hello world!')
 \```
 
-**These are backticks, not quotes.** See [here](https://superuser.com/questions/254076/how-do-i-type-the-tick-and-backtick-characters-on-windows/254077#254077) if you can't find the backtick key.
+**These are backticks, not quotes.** Check [this](https://superuser.com/questions/254076/how-do-i-type-the-tick-and-backtick-characters-on-windows/254077#254077) out if you can't find the backtick key.

--- a/bot/resources/tags/codeblock.md
+++ b/bot/resources/tags/codeblock.md
@@ -1,17 +1,7 @@
-Discord has support for Markdown, which allows you to post code with full syntax highlighting. Please use these whenever you paste code, as this helps improve the legibility and makes it easier for us to help you.
+Here's how to format Python code on Discord:
 
-To do this, use the following method:
-
-\```python
+\```py
 print('Hello world!')
 \```
 
-Note:  
-• **These are backticks, not quotes.** Backticks can usually be found on the tilde key.  
-• You can also use py as the language instead of python  
-• The language must be on the first line next to the backticks with **no** space between them  
-
-This will result in the following:
-```py
-print('Hello world!')
-```
+**These are backticks, not quotes.** Backticks can usually be found to the left of the `1` key.  


### PR DESCRIPTION
Here's a significantly shorter version of the `!code` message, arrived at by committee in the #organization channel. The goal is to just hit the key point, namely how to format Python code in the here and now, and then get back to the ongoing discussion or help session.

Lemon suggested that we write our own page on where the backtick key is located and we can switch the link out should that ever be completed.
