### PR TITLE
Added infraction search menu from user embed

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -399,7 +399,7 @@ class Information(Cog):
                 if reaction.emoji == INFR_EMOJI:
                     search = ctx.bot.get_command("infraction search")
                     if search:
-                        await search(ctx, user.id)
+                        asyncio.create_task(search(ctx, user.id))
 
             log.debug("Ending user menu and clearing reactions.")
             with suppress(NotFound):


### PR DESCRIPTION
Addresses point 1 in #654. I planned to wait with this one, but we use this combination of commands so often I decided it's worth adding it even if gets partially rewritten by a future PR.

As explained in the issue, we use `!user` and `!infr search` so often we might as well have a reaction leading from one to another.

### Implementation
* The main issue here was to make the information on whether a user has infractions accessible from the `user_info` function. 
   - I wasn't a fan of propagating a boolean value through the helper functions just to that end. 
   - I attempted to rework how the command is divided into its helper function, for example by dividing the part fetching information from the db, and the part that is creating the embed, but the end result was awkward. 
   - Eventually I ended up with accessing the embed fields and checking if the appropriate field has the "No infractions" string. I don't like looking for information I already had access to in one of the inner functions, and it's also volatile to format changes, so I'm open to suggestions.
* ~~I wrote the menu function with extensibility in mind, so that it'll be easy to add more reactions if we want.~~
* I didn't address the part of the issue that says it shouldn't add the reaction for user embeds of moderators. We do make infractions searches on moderators sometimes for whatever reasons, so I don't see the harm in having it there as well.