### PR TITLE
Voice Gate: User activity blocks

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -600,6 +600,7 @@ class VoiceGate(metaclass=YAMLGetter):
     minimum_days_verified: int
     minimum_messages: int
     bot_message_delete_delay: int
+    minimum_activity_blocks: int
 
 
 class Event(Enum):

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -60,9 +60,9 @@ class VoiceGate(Cog):
                 embed = discord.Embed(
                     title="Not found",
                     description=(
-                        "We were unable to find user data for you. ",
-                        "Please try again shortly, ",
-                        "if this problem persists please contact the server staff through Modmail.",
+                        "We were unable to find user data for you. "
+                        "Please try again shortly, "
+                        "if this problem persists please contact the server staff through Modmail."
                     ),
                     color=Colour.red()
                 )

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -51,7 +51,7 @@ class VoiceGate(Cog):
         - You must have over a certain number of messages within the Discord server
         - You must have accepted our rules over a certain number of days ago
         - You must not be actively banned from using our voice channels
-        - You must have been active for over a certain number of 10-minute blocks.
+        - You must have been active for over a certain number of 10-minute blocks
         """
         try:
             data = await self.bot.api_client.get(f"bot/users/{ctx.author.id}/metricity_data")

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -25,6 +25,7 @@ MESSAGE_FIELD_MAP = {
     "verified_at": f"have been verified for less than {GateConf.minimum_days_verified} days",
     "voice_banned": "have an active voice ban infraction",
     "total_messages": f"have sent less than {GateConf.minimum_messages} messages",
+    "activity_blocks": f"have been active for less than {GateConf.minimum_activity_blocks} ten-minute blocks"
 }
 
 
@@ -50,6 +51,7 @@ class VoiceGate(Cog):
         - You must have over a certain number of messages within the Discord server
         - You must have accepted our rules over a certain number of days ago
         - You must not be actively banned from using our voice channels
+        - You must have been active for over a certain number of 10-minute blocks.
         """
         try:
             data = await self.bot.api_client.get(f"bot/users/{ctx.author.id}/metricity_data")
@@ -88,7 +90,8 @@ class VoiceGate(Cog):
         checks = {
             "verified_at": data["verified_at"] > datetime.utcnow() - timedelta(days=GateConf.minimum_days_verified),
             "total_messages": data["total_messages"] < GateConf.minimum_messages,
-            "voice_banned": data["voice_banned"]
+            "voice_banned": data["voice_banned"],
+            "activity_blocks": data["activity_blocks"] < GateConf.activity_blocks
         }
         failed = any(checks.values())
         failed_reasons = [MESSAGE_FIELD_MAP[key] for key, value in checks.items() if value is True]

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -60,8 +60,8 @@ class VoiceGate(Cog):
                 embed = discord.Embed(
                     title="Not found",
                     description=(
-                        "We were unable to find user data for you. "
-                        "Please try again shortly, "
+                        "We were unable to find user data for you. ",
+                        "Please try again shortly, ",
                         "if this problem persists please contact the server staff through Modmail.",
                     ),
                     color=Colour.red()

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -91,7 +91,7 @@ class VoiceGate(Cog):
             "verified_at": data["verified_at"] > datetime.utcnow() - timedelta(days=GateConf.minimum_days_verified),
             "total_messages": data["total_messages"] < GateConf.minimum_messages,
             "voice_banned": data["voice_banned"],
-            "activity_blocks": data["activity_blocks"] < GateConf.activity_blocks
+            "activity_blocks": data["activity_blocks"] < GateConf.minimum_activity_blocks
         }
         failed = any(checks.values())
         failed_reasons = [MESSAGE_FIELD_MAP[key] for key, value in checks.items() if value is True]

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -25,7 +25,7 @@ MESSAGE_FIELD_MAP = {
     "verified_at": f"have been verified for less than {GateConf.minimum_days_verified} days",
     "voice_banned": "have an active voice ban infraction",
     "total_messages": f"have sent less than {GateConf.minimum_messages} messages",
-    "activity_blocks": f"have been active for less than {GateConf.minimum_activity_blocks} ten-minute blocks"
+    "activity_blocks": f"have been active for fewer than {GateConf.minimum_activity_blocks} ten-minute blocks",
 }
 
 

--- a/config-default.yml
+++ b/config-default.yml
@@ -521,6 +521,7 @@ voice_gate:
     minimum_days_verified: 3  # How many days the user must have been verified for
     minimum_messages: 50  # How many messages a user must have to be eligible for voice
     bot_message_delete_delay: 10  # Seconds before deleting bot's response in Voice Gate
+    minimum_activity_blocks: 3 # Number of 10 minute blocks during which a user must have been active
 
 
 config:

--- a/config-default.yml
+++ b/config-default.yml
@@ -521,7 +521,7 @@ voice_gate:
     minimum_days_verified: 3  # How many days the user must have been verified for
     minimum_messages: 50  # How many messages a user must have to be eligible for voice
     bot_message_delete_delay: 10  # Seconds before deleting bot's response in Voice Gate
-    minimum_activity_blocks: 3 # Number of 10 minute blocks during which a user must have been active
+    minimum_activity_blocks: 3  # Number of 10 minute blocks during which a user must have been active
 
 
 config:


### PR DESCRIPTION
This PR introduces a new check for the voice gate to ensure that a users activity comes from a larger period of time rather than a burst all at once. This should deter spammers.

The way that the check works is that user activity is chunked up into 10 minute blocks which are then counted.

For example:
```
[16:05] User A: Hello!
[16:06] User A: Hello world!
```

This is one activity block because it all happened within the 16:00-16:10 block.

```
[16:05] User B: Hello!
[16:15] User B: Hello world!
```

This is two activity blocks because they fall into the 16:00-16:10 block and then 16:10-16:20 block.

This will all be described in the voice gate channel to help users understand the system.

The current threshold is more of a stab in the dark than the message threshold which is based on actual data, but looking at users we have voice banned it would certainly deter some of them.

Site-side PR: https://github.com/python-discord/site/pull/418