### PR TITLE
Updated langs to include python-repl

### DIFF
--- a/bot/exts/info/codeblock/_parsing.py
+++ b/bot/exts/info/codeblock/_parsing.py
@@ -12,7 +12,7 @@ from bot.utils import has_lines
 log = logging.getLogger(__name__)
 
 BACKTICK = "`"
-PY_LANG_CODES = ("python", "python-repl", "pycon", "py")  # Order is important; "py" is last cause it's a subset.
+PY_LANG_CODES = ("python-repl", "python", "pycon", "py")  # Order is important; "py" is last cause it's a subset.
 _TICKS = {
     BACKTICK,
     "'",

--- a/bot/exts/info/codeblock/_parsing.py
+++ b/bot/exts/info/codeblock/_parsing.py
@@ -12,7 +12,7 @@ from bot.utils import has_lines
 log = logging.getLogger(__name__)
 
 BACKTICK = "`"
-PY_LANG_CODES = ("python", "pycon", "py")  # Order is important; "py" is last cause it's a subset.
+PY_LANG_CODES = ("python", "python-repl", "pycon", "py")  # Order is important; "py" is last cause it's a subset.
 _TICKS = {
     BACKTICK,
     "'",


### PR DESCRIPTION
Amend `codeblock._parsing.PY_LANG_CODES` to include valid `python-repl` lang code.