### PR TITLE
```py convention in code block instructions

### DIFF
--- a/bot/exts/info/codeblock/_instructions.py
+++ b/bot/exts/info/codeblock/_instructions.py
@@ -71,7 +71,7 @@ def _get_no_ticks_message(content: str) -> Optional[str]:
     log.trace("Creating instructions for a missing code block.")
 
     if _parsing.is_python_code(content):
-        example_blocks = _get_example("python")
+        example_blocks = _get_example("py")
         return (
             "It looks like you're trying to paste code into this channel.\n\n"
             "Discord has support for Markdown, which allows you to post code with full "

--- a/bot/exts/info/codeblock/_instructions.py
+++ b/bot/exts/info/codeblock/_instructions.py
@@ -133,7 +133,7 @@ def _get_no_lang_message(content: str) -> Optional[str]:
     log.trace("Creating instructions for a missing language.")
 
     if _parsing.is_python_code(content):
-        example_blocks = _get_example("python")
+        example_blocks = _get_example("py")
 
         # Note that _get_bad_ticks_message expects the first line to have two newlines.
         return (


### PR DESCRIPTION
PR #1257 implemented using \```py rather than \```python in the `!code` message. This PR extends that to the instruction message sent when someone sends incorrectly formatted code.