### PR TITLE
Voice Gate: notify new unverified users in the verification channel

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -600,6 +600,7 @@ class VoiceGate(metaclass=YAMLGetter):
     minimum_days_verified: int
     minimum_messages: int
     bot_message_delete_delay: int
+    voice_ping_delete_delay: int
 
 
 class Event(Enum):

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -361,6 +361,7 @@ class CleanMessages(metaclass=YAMLGetter):
 
     message_limit: int
 
+
 class Stats(metaclass=YAMLGetter):
     section = "bot"
     subsection = "stats"
@@ -602,6 +603,7 @@ class VoiceGate(metaclass=YAMLGetter):
     bot_message_delete_delay: int
     minimum_activity_blocks: int
     voice_ping_delete_delay: int
+
 
 class Event(Enum):
     """

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -246,7 +246,7 @@ class Filtering(Cog):
                             filter_triggered = True
 
                         stats = self._add_stats(filter_name, match, result)
-                        await self._send_log(filter_name, _filter["type"], msg, stats, is_eval=True)
+                        await self._send_log(filter_name, _filter, msg, stats, is_eval=True)
 
                         break  # We don't want multiple filters to trigger
 

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 
 import discord
 from dateutil import parser
-from discord import Colour
+from discord import Colour, Member, VoiceState
 from discord.ext.commands import Cog, Context, command
 
 from bot.api import ResponseCodeError
@@ -156,6 +156,10 @@ class VoiceGate(Cog):
 
         with suppress(discord.NotFound):
             await message.delete()
+
+    @Cog.listener()
+    async def on_voice_state_update(self, member: Member, before: VoiceState, after: VoiceState):
+        pass
 
     async def cog_command_error(self, ctx: Context, error: Exception) -> None:
         """Check for & ignore any InWhitelistCheckFailure."""

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -48,8 +48,6 @@ class VoiceGate(Cog):
 
     def __init__(self, bot: Bot) -> None:
         self.bot = bot
-        # voice_verification_channel set to None so that we have a placeholder to get it later in the cog
-        self.voice_verification_channel = None
 
     @property
     def mod_log(self) -> ModLog:
@@ -71,9 +69,9 @@ class VoiceGate(Cog):
         """
         # If user has received a ping in voice_verification, delete the message
         if message_id := await self.redis_cache.get(ctx.author.id, NO_MSG):
+            log.trace(f"Removing voice gate reminder message for user: {ctx.author.id}")
             with suppress(discord.NotFound):
-                self.voice_verification_channel = self.bot.get_channel(Channels.voice_gate)
-                await self.bot.http.delete_message(self.voice_verification_channel, message_id)
+                await self.bot.http.delete_message(Channels.voice_gate, message_id)
             await self.redis_cache.set(ctx.author.id, NO_MSG)
 
         try:

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -199,8 +199,7 @@ class VoiceGate(Cog):
             log.trace("User not in a voice channel. Ignore.")
             return
 
-        in_cache = await self.redis_cache.get(member.id, NO_MSG)
-        if in_cache:
+        if await self.redis_cache.contains(member.id):
             log.trace("User already in cache. Ignore.")
             return
 

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -29,7 +29,7 @@ MESSAGE_FIELD_MAP = {
 }
 
 VOICE_PING = (
-    "Hello, {}! Wondering why you can't talk in the voice channels? "
+    "Hello, {0}! Wondering why you can't talk in the voice channels? "
     "Use the `!voiceverify` command in here to verify. "
     "If you don't yet qualify, you'll be told why!"
 )
@@ -66,7 +66,6 @@ class VoiceGate(Cog):
         - You must have accepted our rules over a certain number of days ago
         - You must not be actively banned from using our voice channels
         """
-
         # If user has received a ping in voice_verification, delete the message
         if message_id := await self.redis_cache.get(ctx.author.id, None):
             with suppress(discord.NotFound):
@@ -186,7 +185,7 @@ class VoiceGate(Cog):
 
     @Cog.listener()
     async def on_voice_state_update(self, member: Member, *_) -> None:
-        """Pings a user if they've never joined the voice chat before and aren't verified"""
+        """Pings a user if they've never joined the voice chat before and aren't verified."""
         if member.bot:
             log.trace("User is a bot. Ignore.")
             return

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -217,7 +217,7 @@ class VoiceGate(Cog):
         message = await voice_verification_channel.send(f"Hello, {member.mention}! {VOICE_PING}")
         await self.redis_cache.set(member.id, message.id)
 
-        await asyncio.sleep(60)
+        await asyncio.sleep(GateConf.voice_ping_delete_delay)
         if message := await self.redis_cache.get(member.id):
             await message.delete()
             await self.redis_cache.set(member.id, NO_MSG)

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 import discord
 from async_rediscache import RedisCache
 from dateutil import parser
-from discord import Colour, Member
+from discord import Colour, Member, VoiceState
 from discord.ext.commands import Cog, Context, command
 
 from bot.api import ResponseCodeError
@@ -188,12 +188,7 @@ class VoiceGate(Cog):
             await message.delete()
 
     @Cog.listener()
-    async def on_voice_state_update(
-            self,
-            member: Member,
-            before: discord.VoiceState,
-            after: discord.VoiceState
-    ) -> None:
+    async def on_voice_state_update(self, member: Member, before: VoiceState, after: VoiceState) -> None:
         """Pings a user if they've never joined the voice chat before and aren't voice verified."""
         if member.bot:
             log.trace("User is a bot. Ignore.")

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -18,6 +18,10 @@ from bot.utils.checks import InWhitelistCheckFailure
 
 log = logging.getLogger(__name__)
 
+# Flag written to the cog's RedisCache as a value when the Member's (key) notification
+# was already removed ~ this signals both that no further notifications should be sent,
+# and that the notification does not need to be removed. The implementation relies on
+# this being falsey!
 NO_MSG = 0
 
 FAILED_MESSAGE = (

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -216,8 +216,11 @@ class VoiceGate(Cog):
         await self.redis_cache.set(member.id, message.id)
 
         await asyncio.sleep(GateConf.voice_ping_delete_delay)
-        if message := await self.redis_cache.get(member.id):
-            await message.delete()
+
+        if message_id := await self.redis_cache.get(member.id):
+            log.trace(f"Removing voice gate reminder message for user: {member.id}")
+            with suppress(discord.NotFound):
+                await self.bot.http.delete_message(Channels.voice_gate, message_id)
             await self.redis_cache.set(member.id, NO_MSG)
 
     async def cog_command_error(self, ctx: Context, error: Exception) -> None:

--- a/config-default.yml
+++ b/config-default.yml
@@ -521,6 +521,7 @@ voice_gate:
     minimum_days_verified: 3  # How many days the user must have been verified for
     minimum_messages: 50  # How many messages a user must have to be eligible for voice
     bot_message_delete_delay: 10  # Seconds before deleting bot's response in Voice Gate
+    voice_ping_delete_delay: 60 # Seconds before deleting the bot's ping to user in Voice Gate
 
 
 config:

--- a/config-default.yml
+++ b/config-default.yml
@@ -522,7 +522,7 @@ voice_gate:
     minimum_messages: 50  # How many messages a user must have to be eligible for voice
     bot_message_delete_delay: 10  # Seconds before deleting bot's response in Voice Gate
     minimum_activity_blocks: 3  # Number of 10 minute blocks during which a user must have been active
-    voice_ping_delete_delay: 60 # Seconds before deleting the bot's ping to user in Voice Gate
+    voice_ping_delete_delay: 60  # Seconds before deleting the bot's ping to user in Voice Gate
 
 config:
     required_keys: ['bot.token']

--- a/config-default.yml
+++ b/config-default.yml
@@ -524,5 +524,6 @@ voice_gate:
     minimum_activity_blocks: 3  # Number of 10 minute blocks during which a user must have been active
     voice_ping_delete_delay: 60  # Seconds before deleting the bot's ping to user in Voice Gate
 
+
 config:
     required_keys: ['bot.token']


### PR DESCRIPTION
This PR's purpose is to ping new users in the voice_verification channel so that they can figure out why they aren't able to talk.  Currently, we have a lot of people confused about the new system. There are multiple people popping in and out of the voice channel thinking that there's something wrong with their connection or thinking they got specifically suppressed.  

By pinging the user in the voice_verification channel (along with a little explanation on how to use it), this should reduce the number of folks asking.

The reason that this is only sending a ping in the channel and not a direct DM is that a fair number of people may have their DMs turned off.  Another reason is that if they are joining a voice channel, they'll already be looking in that section of the channels, and a ping that's right in front of their eyes should get them looking in the right place.

Closes #1261 