### PR TITLE
Detect codeblock language specifiers with special characters

### DIFF
--- a/bot/exts/info/codeblock/_parsing.py
+++ b/bot/exts/info/codeblock/_parsing.py
@@ -36,7 +36,7 @@ _RE_CODE_BLOCK = re.compile(
         (?P<tick>[{''.join(_TICKS)}]) # Put all ticks into a character class within a group.
         \2{{2}}                       # Match previous group 2 more times to ensure the same char.
     )
-    (?P<lang>[^\W_]+\n)?              # Optionally match a language specifier followed by a newline.
+    (?P<lang>[A-Za-z0-9\+\-\.]+\n)?   # Optionally match a language specifier followed by a newline.
     (?P<code>.+?)                     # Match the actual code within the block.
     \1                                # Match the same 3 ticks used at the start of the block.
     """,


### PR DESCRIPTION
The highlighting package Discord uses, `highlight.js`, has a couple of language specifiers that include the characters `-`, `+`, and `.`. One example is a Python-related language specifier: `python-repl`. However, the regex pattern we used to detect codeblocks did not account for these characters and, as such, did not detect that codeblocks using language specifiers that included these characters had a language specifier.

This PR changes the character set we use to match language specifiers to make sure we match all valid language specifiers (see [this overview](https://github.com/highlightjs/highlight.js/blob/master/SUPPORTED_LANGUAGES.md) of supported language specifiers in `highlight.js`).
