### PR TITLE
Remove selenium from the element list

### DIFF
--- a/bot/resources/elements.json
+++ b/bot/resources/elements.json
@@ -32,7 +32,6 @@
     "gallium",
     "germanium",
     "arsenic",
-    "selenium",
     "bromine",
     "krypton",
     "rubidium",


### PR DESCRIPTION
This could lead to some confusion with the users believing that this channel is reserved to help related to the selenium tool.

I’ve gone through the list, there don’t seem to be any other problematic element, although it would be nice if someone could give it a quick second look. 