### PR TITLE
Formats Per-Command Help Output

### DIFF
--- a/bot/exts/info/help.py
+++ b/bot/exts/info/help.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import re
 from collections import namedtuple
 from contextlib import suppress
 from typing import List, Union
@@ -177,7 +178,9 @@ class CustomHelpCommand(HelpCommand):
         if not await command.can_run(self.context):
             command_details += "***You cannot run this command.***\n\n"
 
-        command_details += f"*{command.help or 'No details provided.'}*\n"
+        # Remove line breaks from docstrings, if not used to separate paragraphs
+        formatted_doc = re.sub("(?<!\n)\n(?!\n)", " ", command.help)
+        command_details += f"*{formatted_doc or 'No details provided.'}*\n"
         embed.description = command_details
 
         return embed


### PR DESCRIPTION
Closes #1232

### Description
Modifies the docstring sent for per-command help to remove weird formatting issues mentioned in #1232. Removes newlines that are not used for paragraph breaks, after retrieving the docstring, and lets the embed handle it on the discord side.

### The Old and Updated Output for Reference 
![Old](https://user-images.githubusercontent.com/47495861/99131463-41d3a680-2624-11eb-992f-db9b5825f5f2.png)
![Updated](https://user-images.githubusercontent.com/47495861/99131563-90814080-2624-11eb-8a79-8b4acfd061df.png)
