### PR TITLE
Add voice_ban to supported types of the infraction scheduler

### DIFF
--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -27,7 +27,7 @@ class Infractions(InfractionScheduler, commands.Cog):
     category_description = "Server moderation tools."
 
     def __init__(self, bot: Bot):
-        super().__init__(bot, supported_infractions={"ban", "kick", "mute", "note", "warning"})
+        super().__init__(bot, supported_infractions={"ban", "kick", "mute", "note", "warning", "voice_ban"})
 
         self.category = "Moderation"
         self._muted_role = discord.Object(constants.Roles.muted)


### PR DESCRIPTION
The `voice_ban` infraction was not listed as a supported type for the infraction scheduler. This meant that the scheduler did not schedule the expiry of `voice_ban` infractions after a restart. Those unlucky users were voice-banned "forever".