### PR TITLE
General moderation improvements

### DIFF
--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -10,7 +10,7 @@ from discord.ext.commands import Context, command
 from bot import constants
 from bot.bot import Bot
 from bot.constants import Event
-from bot.converters import Expiry, FetchedMember
+from bot.converters import Duration, Expiry, FetchedMember
 from bot.decorators import respect_role_hierarchy
 from bot.exts.moderation.infraction import _utils
 from bot.exts.moderation.infraction._scheduler import InfractionScheduler
@@ -98,7 +98,13 @@ class Infractions(InfractionScheduler, commands.Cog):
     # region: Temporary infractions
 
     @command(aliases=["mute"])
-    async def tempmute(self, ctx: Context, user: Member, duration: Expiry, *, reason: t.Optional[str] = None) -> None:
+    async def tempmute(
+        self, ctx: Context,
+        user: Member,
+        duration: t.Optional[Expiry] = None,
+        *,
+        reason: t.Optional[str] = None
+    ) -> None:
         """
         Temporarily mute a user for the given reason and duration.
 
@@ -113,7 +119,11 @@ class Infractions(InfractionScheduler, commands.Cog):
         \u2003`s` - seconds
 
         Alternatively, an ISO 8601 timestamp can be provided for the duration.
+
+        If no duration is given, a one hour duration is used by default.
         """
+        if duration is None:
+            duration = await Duration().convert(ctx, "1h")
         await self.apply_mute(ctx, user, reason, expires_at=duration)
 
     @command()

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -180,11 +180,6 @@ class Infractions(InfractionScheduler, commands.Cog):
 
         await self.apply_infraction(ctx, infraction, user)
 
-    @command(hidden=True, aliases=['shadowkick', 'skick'])
-    async def shadow_kick(self, ctx: Context, user: Member, *, reason: t.Optional[str] = None) -> None:
-        """Kick a user for the given reason without notifying the user."""
-        await self.apply_kick(ctx, user, reason, hidden=True)
-
     @command(hidden=True, aliases=['shadowban', 'sban'])
     async def shadow_ban(self, ctx: Context, user: FetchedMember, *, reason: t.Optional[str] = None) -> None:
         """Permanently ban a user for the given reason without notifying the user."""
@@ -192,31 +187,6 @@ class Infractions(InfractionScheduler, commands.Cog):
 
     # endregion
     # region: Temporary shadow infractions
-
-    @command(hidden=True, aliases=["shadowtempmute, stempmute", "shadowmute", "smute"])
-    async def shadow_tempmute(
-        self, ctx: Context,
-        user: Member,
-        duration: Expiry,
-        *,
-        reason: t.Optional[str] = None
-    ) -> None:
-        """
-        Temporarily mute a user for the given reason and duration without notifying the user.
-
-        A unit of time should be appended to the duration.
-        Units (∗case-sensitive):
-        \u2003`y` - years
-        \u2003`m` - months∗
-        \u2003`w` - weeks
-        \u2003`d` - days
-        \u2003`h` - hours
-        \u2003`M` - minutes∗
-        \u2003`s` - seconds
-
-        Alternatively, an ISO 8601 timestamp can be provided for the duration.
-        """
-        await self.apply_mute(ctx, user, reason, expires_at=duration, hidden=True)
 
     @command(hidden=True, aliases=["shadowtempban, stempban"])
     async def shadow_tempban(

--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -40,12 +40,12 @@ class ModManagement(commands.Cog):
 
     # region: Edit infraction commands
 
-    @commands.group(name='infraction', aliases=('infr', 'infractions', 'inf'), invoke_without_command=True)
+    @commands.group(name='infraction', aliases=('infr', 'infractions', 'inf', 'i'), invoke_without_command=True)
     async def infraction_group(self, ctx: Context) -> None:
         """Infraction manipulation commands."""
         await ctx.send_help(ctx.command)
 
-    @infraction_group.command(name='edit')
+    @infraction_group.command(name='edit', aliases=('e',))
     async def infraction_edit(
         self,
         ctx: Context,


### PR DESCRIPTION
This PR implements some small but useful changes which were discussed internally:

* Removes the unnecessary and undesired `shadowkick` and `shadowmute` infractions.
* Gives mutes a one hour default duration.
* Adds the `i` alias to the infraction command group, and the `e` alias to the `edit` infraction subcommand, which closes #1278 