### PR TITLE
Relay the moderator's reason for `!superstarify` to the user

### DIFF
--- a/bot/exts/moderation/infraction/superstarify.py
+++ b/bot/exts/moderation/infraction/superstarify.py
@@ -157,32 +157,29 @@ class Superstarify(InfractionScheduler, Cog):
             New nickname: `{forced_nick}`
         """).strip()
 
-        formatted_reason = f'**Additional details:** {reason}\n\n' if reason else ''
-
-        embed_reason = (
+        user_message = (
             f"Your previous nickname, **{old_nick}**, "
-            f"didn't comply with our nickname policy. "
+            f"was so bad that we have decided to change it. "
             f"Your new nickname will be **{forced_nick}**.\n\n"
-            f"{formatted_reason}"
+            "{reason}"
             f"You will be unable to change your nickname until **{expiry_str}**. "
             "If you're confused by this, please read our "
             f"[official nickname policy]({NICKNAME_POLICY_URL})."
-        )
+        ).format
 
         successful = await self.apply_infraction(
             ctx, infraction, member, action(),
-            user_reason=embed_reason,
+            user_reason=user_message(reason=f'**Additional details:** {reason}\n\n' if reason else ''),
             additional_info=nickname_info
         )
 
-        # Send an embed with the infraction information to the invoking context if
-        # superstar was successful.
+        # Send an embed with to the invoking context if superstar was successful.
         if successful:
             log.trace(f"Sending superstar #{id_} embed.")
             embed = Embed(
-                title="Congratulations!",
+                title="Superstarified!",
                 colour=constants.Colours.soft_orange,
-                description=embed_reason
+                description=user_message(reason='')
             )
             await ctx.send(embed=embed)
 

--- a/bot/exts/moderation/infraction/superstarify.py
+++ b/bot/exts/moderation/infraction/superstarify.py
@@ -104,7 +104,7 @@ class Superstarify(InfractionScheduler, Cog):
 
             await self.reapply_infraction(infraction, action)
 
-    @command(name="superstarify", aliases=("force_nick", "star"))
+    @command(name="superstarify", aliases=("force_nick", "star", "starify"))
     async def superstarify(
         self,
         ctx: Context,
@@ -182,7 +182,7 @@ class Superstarify(InfractionScheduler, Cog):
             )
             await ctx.send(embed=embed)
 
-    @command(name="unsuperstarify", aliases=("release_nick", "unstar"))
+    @command(name="unsuperstarify", aliases=("release_nick", "unstar", "unstarify"))
     async def unsuperstarify(self, ctx: Context, member: Member) -> None:
         """Remove the superstarify infraction and allow the user to change their nickname."""
         await self.pardon_infraction(ctx, "superstar", member)

--- a/bot/exts/moderation/infraction/superstarify.py
+++ b/bot/exts/moderation/infraction/superstarify.py
@@ -111,7 +111,7 @@ class Superstarify(InfractionScheduler, Cog):
         member: Member,
         duration: Expiry,
         *,
-        reason: str = None,
+        reason: str = '',
     ) -> None:
         """
         Temporarily force a random superstar name (like Taylor Swift) to be the user's nickname.
@@ -128,15 +128,16 @@ class Superstarify(InfractionScheduler, Cog):
 
         Alternatively, an ISO 8601 timestamp can be provided for the duration.
 
-        An optional reason can be provided. If no reason is given, the original name will be shown
-        in a generated reason.
+        An optional reason can be provided, which would be added to a message stating their old nickname
+        and linking to the nickname policy.
         """
         if await _utils.get_active_infraction(ctx, member, "superstar"):
             return
 
         # Post the infraction to the API
         old_nick = member.display_name
-        reason = reason or f"old nick: {old_nick}"
+        reason = (f"Nickname '{old_nick}' does not comply with our [nickname policy]({NICKNAME_POLICY_URL}). "
+                  f"{reason}")
         infraction = await _utils.post_infraction(ctx, member, "superstar", reason, duration, active=True)
         id_ = infraction["id"]
 
@@ -152,7 +153,6 @@ class Superstarify(InfractionScheduler, Cog):
         old_nick = escape_markdown(old_nick)
         forced_nick = escape_markdown(forced_nick)
 
-        superstar_reason = f"Your nickname didn't comply with our [nickname policy]({NICKNAME_POLICY_URL})."
         nickname_info = textwrap.dedent(f"""
             Old nickname: `{old_nick}`
             New nickname: `{forced_nick}`
@@ -160,7 +160,7 @@ class Superstarify(InfractionScheduler, Cog):
 
         successful = await self.apply_infraction(
             ctx, infraction, member, action(),
-            user_reason=superstar_reason,
+            user_reason=reason,
             additional_info=nickname_info
         )
 

--- a/bot/exts/moderation/infraction/superstarify.py
+++ b/bot/exts/moderation/infraction/superstarify.py
@@ -136,9 +136,8 @@ class Superstarify(InfractionScheduler, Cog):
 
         # Post the infraction to the API
         old_nick = member.display_name
-        reason = (f"Nickname '{old_nick}' does not comply with our [nickname policy]({NICKNAME_POLICY_URL}). "
-                  f"{reason}")
-        infraction = await _utils.post_infraction(ctx, member, "superstar", reason, duration, active=True)
+        infraction_reason = f'Old nickname: {old_nick}. {reason}'
+        infraction = await _utils.post_infraction(ctx, member, "superstar", infraction_reason, duration, active=True)
         id_ = infraction["id"]
 
         forced_nick = self.get_nick(id_, member.id)
@@ -158,9 +157,21 @@ class Superstarify(InfractionScheduler, Cog):
             New nickname: `{forced_nick}`
         """).strip()
 
+        formatted_reason = f'**Additional details:** {reason}\n\n' if reason else ''
+
+        embed_reason = (
+            f"Your previous nickname, **{old_nick}**, "
+            f"didn't comply with our nickname policy. "
+            f"Your new nickname will be **{forced_nick}**.\n\n"
+            f"{formatted_reason}"
+            f"You will be unable to change your nickname until **{expiry_str}**. "
+            "If you're confused by this, please read our "
+            f"[official nickname policy]({NICKNAME_POLICY_URL})."
+        )
+
         successful = await self.apply_infraction(
             ctx, infraction, member, action(),
-            user_reason=reason,
+            user_reason=embed_reason,
             additional_info=nickname_info
         )
 
@@ -171,14 +182,7 @@ class Superstarify(InfractionScheduler, Cog):
             embed = Embed(
                 title="Congratulations!",
                 colour=constants.Colours.soft_orange,
-                description=(
-                    f"Your previous nickname, **{old_nick}**, "
-                    f"was so bad that we have decided to change it. "
-                    f"Your new nickname will be **{forced_nick}**.\n\n"
-                    f"You will be unable to change your nickname until **{expiry_str}**.\n\n"
-                    "If you're confused by this, please read our "
-                    f"[official nickname policy]({NICKNAME_POLICY_URL})."
-                )
+                description=embed_reason
             )
             await ctx.send(embed=embed)
 


### PR DESCRIPTION
This PR closes issue #1224.

Previously, when a moderator used the `!superstarify` command, the reason they gave only gets recorded in the user's infraction history and is not relayed to the user in the direct message sent by the bot. This PR changes the message the user is sent to fix this.

However, we're discussing if the special embed that gets posted in the channel where the command is issued is actually appropriate.

![image](https://user-images.githubusercontent.com/32915757/101285796-196b4200-37b5-11eb-9582-249c5c3117a1.png)
