### PR TITLE
Fix backtick escapes in the codeblock tag

### DIFF
--- a/bot/resources/tags/codeblock.md
+++ b/bot/resources/tags/codeblock.md
@@ -1,7 +1,7 @@
 Here's how to format Python code on Discord:
 
-\```py
+\`\`\`py
 print('Hello world!')
-\```
+\`\`\`
 
 **These are backticks, not quotes.** Check [this](https://superuser.com/questions/254076/how-do-i-type-the-tick-and-backtick-characters-on-windows/254077#254077) out if you can't find the backtick key.


### PR DESCRIPTION
On some devices the previous escaping didn't work properly, escaping
all backticks will make sure none of them get registered as Markdown

<img src=https://i.imgur.com/p3kNzhO.jpg width="210" height="468">