### PR TITLE
Hopefully fix the API session being closed when populating the filter cache on startup

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -110,17 +110,3 @@ class APIClient:
 
             await self.maybe_raise_for_status(resp, raise_for_status)
             return await resp.json()
-
-
-def loop_is_running() -> bool:
-    """
-    Determine if there is a running asyncio event loop.
-
-    This helps enable "call this when event loop is running" logic (see: Twisted's `callWhenRunning`),
-    which is currently not provided by asyncio.
-    """
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return False
-    return True

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -32,7 +32,7 @@ class Bot(commands.Bot):
 
         self.http_session: Optional[aiohttp.ClientSession] = None
         self.redis_session = redis_session
-        self.api_client = None
+        self.api_client: Optional[api.APIClient] = None
         self.filter_list_cache = defaultdict(dict)
 
         self._connector = None
@@ -76,46 +76,6 @@ class Bot(commands.Bot):
 
         for item in full_cache:
             self.insert_item_into_filter_list_cache(item)
-
-    def _recreate(self) -> None:
-        """Re-create the connector, aiohttp session, the APIClient and the Redis session."""
-        # Use asyncio for DNS resolution instead of threads so threads aren't spammed.
-        # Doesn't seem to have any state with regards to being closed, so no need to worry?
-        self._resolver = aiohttp.AsyncResolver()
-
-        # Its __del__ does send a warning but it doesn't always show up for some reason.
-        if self._connector and not self._connector._closed:
-            log.warning(
-                "The previous connector was not closed; it will remain open and be overwritten"
-            )
-
-        if self.redis_session.closed:
-            # If the RedisSession was somehow closed, we try to reconnect it
-            # here. Normally, this shouldn't happen.
-            self.loop.create_task(self.redis_session.connect())
-
-        # Use AF_INET as its socket family to prevent HTTPS related problems both locally
-        # and in production.
-        self._connector = aiohttp.TCPConnector(
-            resolver=self._resolver,
-            family=socket.AF_INET,
-        )
-
-        # Client.login() will call HTTPClient.static_login() which will create a session using
-        # this connector attribute.
-        self.http.connector = self._connector
-
-        # Its __del__ does send a warning but it doesn't always show up for some reason.
-        if self.http_session and not self.http_session.closed:
-            log.warning(
-                "The previous session was not closed; it will remain open and be overwritten"
-            )
-
-        self.http_session = aiohttp.ClientSession(connector=self._connector)
-        self.api_client = api.APIClient(loop=self.loop, connector=self._connector)
-
-        # Build the FilterList cache
-        self.loop.create_task(self.cache_filter_list_data())
 
     @classmethod
     def create(cls) -> "Bot":
@@ -180,15 +140,8 @@ class Bot(commands.Bot):
         return command
 
     def clear(self) -> None:
-        """
-        Clears the internal state of the bot and recreates the connector and sessions.
-
-        Will cause a DeprecationWarning if called outside a coroutine.
-        """
-        # Because discord.py recreates the HTTPClient session, may as well follow suit and recreate
-        # our own stuff here too.
-        self._recreate()
-        super().clear()
+        """Not implemented! Re-instantiate the bot instead of attempting to re-use a closed one."""
+        raise NotImplementedError("Re-using a Bot object after closing it is not supported.")
 
     async def close(self) -> None:
         """Close the Discord connection and the aiohttp session, connector, statsd client, and resolver."""
@@ -230,7 +183,31 @@ class Bot(commands.Bot):
 
     async def login(self, *args, **kwargs) -> None:
         """Re-create the connector and set up sessions before logging into Discord."""
-        self._recreate()
+        # Use asyncio for DNS resolution instead of threads so threads aren't spammed.
+        self._resolver = aiohttp.AsyncResolver()
+
+        # Use AF_INET as its socket family to prevent HTTPS related problems both locally
+        # and in production.
+        self._connector = aiohttp.TCPConnector(
+            resolver=self._resolver,
+            family=socket.AF_INET,
+        )
+
+        # Client.login() will call HTTPClient.static_login() which will create a session using
+        # this connector attribute.
+        self.http.connector = self._connector
+
+        self.http_session = aiohttp.ClientSession(connector=self._connector)
+        self.api_client = api.APIClient(loop=self.loop, connector=self._connector)
+
+        if self.redis_session.closed:
+            # If the RedisSession was somehow closed, we try to reconnect it
+            # here. Normally, this shouldn't happen.
+            await self.redis_session.connect()
+
+        # Build the FilterList cache
+        await self.cache_filter_list_data()
+
         await self.stats.create_socket()
         await super().login(*args, **kwargs)
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -32,7 +32,7 @@ class Bot(commands.Bot):
 
         self.http_session: Optional[aiohttp.ClientSession] = None
         self.redis_session = redis_session
-        self.api_client = api.APIClient(loop=self.loop)
+        self.api_client = None
         self.filter_list_cache = defaultdict(dict)
 
         self._connector = None
@@ -112,7 +112,7 @@ class Bot(commands.Bot):
             )
 
         self.http_session = aiohttp.ClientSession(connector=self._connector)
-        self.api_client.recreate(force=True, connector=self._connector)
+        self.api_client = api.APIClient(loop=self.loop, connector=self._connector)
 
         # Build the FilterList cache
         self.loop.create_task(self.cache_filter_list_data())
@@ -194,7 +194,8 @@ class Bot(commands.Bot):
         """Close the Discord connection and the aiohttp session, connector, statsd client, and resolver."""
         await super().close()
 
-        await self.api_client.close()
+        if self.api_client:
+            await self.api_client.close()
 
         if self.http_session:
             await self.http_session.close()

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -198,7 +198,7 @@ class Bot(commands.Bot):
         self.http.connector = self._connector
 
         self.http_session = aiohttp.ClientSession(connector=self._connector)
-        self.api_client = api.APIClient(loop=self.loop, connector=self._connector)
+        self.api_client = api.APIClient(connector=self._connector)
 
         if self.redis_session.closed:
             # If the RedisSession was somehow closed, we try to reconnect it

--- a/tests/bot/test_api.py
+++ b/tests/bot/test_api.py
@@ -13,14 +13,6 @@ class APIClientTests(unittest.IsolatedAsyncioTestCase):
         cls.error_api_response = MagicMock()
         cls.error_api_response.status = 999
 
-    def test_loop_is_not_running_by_default(self):
-        """The event loop should not be running by default."""
-        self.assertFalse(api.loop_is_running())
-
-    async def test_loop_is_running_in_async_context(self):
-        """The event loop should be running in an async context."""
-        self.assertTrue(api.loop_is_running())
-
     def test_response_code_error_default_initialization(self):
         """Test the default initialization of `ResponseCodeError` without `text` or `json`"""
         error = api.ResponseCodeError(response=self.error_api_response)


### PR DESCRIPTION
Fixes [BOT-J8](https://sentry.io/organizations/python-discord/issues/2102206308/?project=2724195).

I've simplified the code for creation sessions upon startup. This was facilitated by dropping support for `Bot.clear()`, which we never relied on. I go into a bit more detail in the commit messages. I've ran the bot locally and don't have any issues with closed sessions upon startup.