### PR TITLE
`!user` command says if a user is "Verified", rather than "Pending"

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -229,9 +229,9 @@ class Information(Cog):
         if on_server:
             joined = time_since(user.joined_at, max_units=3)
             roles = ", ".join(role.mention for role in user.roles[1:])
-            membership = {"Joined": joined, "Pending": user.pending, "Roles": roles or None}
+            membership = {"Joined": joined, "Verified": not user.pending, "Roles": roles or None}
             if not is_mod_channel(ctx.channel):
-                membership.pop("Pending")
+                membership.pop("Verified")
 
             membership = textwrap.dedent("\n".join([f"{key}: {value}" for key, value in membership.items()]))
         else:

--- a/tests/bot/exts/info/test_information.py
+++ b/tests/bot/exts/info/test_information.py
@@ -355,7 +355,7 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             textwrap.dedent(f"""
                 Joined: {"1 year ago"}
-                Pending: {"False"}
+                Verified: {"True"}
                 Roles: &Moderators
             """).strip(),
             embed.fields[1].value


### PR DESCRIPTION
Previously, the `!user` command would tell mods if a user is "Pending", which is True before they are verified and False thereafter. I think most of us are interested in whether or not they are "Verified", which is False when they are pending and True otherwise. This PR aligns the message in the embed with the expected semantics.