### PR TITLE
Fix webhook message publishing

### DIFF
--- a/bot/exts/info/python_news.py
+++ b/bot/exts/info/python_news.py
@@ -109,13 +109,16 @@ class PythonNews(Cog):
                 colour=constants.Colours.soft_green
             )
             embed.set_footer(text=data["feed"]["title"], icon_url=AVATAR_URL)
-            msg = await send_webhook(
+
+            webhook_msg = await send_webhook(
                 webhook=self.webhook,
                 username=data["feed"]["title"],
                 embed=embed,
                 avatar_url=AVATAR_URL,
                 wait=True,
             )
+            msg = await self.webhook.channel.fetch_message(webhook_msg.id)
+
             payload["data"]["pep"].append(pep_nr)
 
             # Increase overall PEP new stat
@@ -186,13 +189,16 @@ class PythonNews(Cog):
                     text=f"Posted to {self.webhook_names[maillist]}",
                     icon_url=AVATAR_URL,
                 )
-                msg = await send_webhook(
+
+                webhook_msg = await send_webhook(
                     webhook=self.webhook,
                     username=self.webhook_names[maillist],
                     embed=embed,
                     avatar_url=AVATAR_URL,
                     wait=True,
                 )
+                msg = await self.webhook.channel.fetch_message(webhook_msg.id)
+
                 payload["data"][maillist].append(thread_information["thread_id"])
 
                 # Increase this specific maillist counter in stats

--- a/bot/exts/info/python_news.py
+++ b/bot/exts/info/python_news.py
@@ -110,14 +110,13 @@ class PythonNews(Cog):
             )
             embed.set_footer(text=data["feed"]["title"], icon_url=AVATAR_URL)
 
-            webhook_msg = await send_webhook(
+            msg = await send_webhook(
                 webhook=self.webhook,
                 username=data["feed"]["title"],
                 embed=embed,
                 avatar_url=AVATAR_URL,
                 wait=True,
             )
-            msg = await self.webhook.channel.fetch_message(webhook_msg.id)
 
             payload["data"]["pep"].append(pep_nr)
 
@@ -126,7 +125,7 @@ class PythonNews(Cog):
 
             if msg.channel.is_news():
                 log.trace("Publishing PEP annnouncement because it was in a news channel")
-                await msg.publish()
+                await self.bot.http.publish_message(msg.channel.id, msg.id)
 
         # Apply new sent news to DB to avoid duplicate sending
         await self.bot.api_client.put("bot/bot-settings/news", json=payload)
@@ -190,14 +189,13 @@ class PythonNews(Cog):
                     icon_url=AVATAR_URL,
                 )
 
-                webhook_msg = await send_webhook(
+                msg = await send_webhook(
                     webhook=self.webhook,
                     username=self.webhook_names[maillist],
                     embed=embed,
                     avatar_url=AVATAR_URL,
                     wait=True,
                 )
-                msg = await self.webhook.channel.fetch_message(webhook_msg.id)
 
                 payload["data"][maillist].append(thread_information["thread_id"])
 
@@ -206,7 +204,7 @@ class PythonNews(Cog):
 
                 if msg.channel.is_news():
                     log.trace("Publishing mailing list message because it was in a news channel")
-                    await msg.publish()
+                    await self.bot.http.publish_message(msg.channel.id, msg.id)
 
         await self.bot.api_client.put("bot/bot-settings/news", json=payload)
 

--- a/bot/exts/info/reddit.py
+++ b/bot/exts/info/reddit.py
@@ -224,11 +224,10 @@ class Reddit(Cog):
         for subreddit in RedditConfig.subreddits:
             top_posts = await self.get_top_posts(subreddit=subreddit, time="day")
             username = sub_clyde(f"{subreddit} Top Daily Posts")
-            webhook_message = await self.webhook.send(username=username, embed=top_posts, wait=True)
-            message = await self.webhook.channel.fetch_message(webhook_message.id)
+            message = await self.webhook.send(username=username, embed=top_posts, wait=True)
 
             if message.channel.is_news():
-                await message.publish()
+                await self.bot.http.publish_message(message.channel.id, message.id)
 
     async def top_weekly_posts(self) -> None:
         """Post a summary of the top posts."""

--- a/bot/exts/info/reddit.py
+++ b/bot/exts/info/reddit.py
@@ -224,7 +224,8 @@ class Reddit(Cog):
         for subreddit in RedditConfig.subreddits:
             top_posts = await self.get_top_posts(subreddit=subreddit, time="day")
             username = sub_clyde(f"{subreddit} Top Daily Posts")
-            message = await self.webhook.send(username=username, embed=top_posts, wait=True)
+            webhook_message = await self.webhook.send(username=username, embed=top_posts, wait=True)
+            message = await self.webhook.channel.fetch_message(webhook_message.id)
 
             if message.channel.is_news():
                 await message.publish()


### PR DESCRIPTION
Discord.py now uses the webhook HTTP state when operating on the return of `discord.Webhook.send`, this means that methods like `publish` on `discord.Message` objects no longer work.

This PR corrects places where the bot automatically publishes announcements by sending with the webhook and then fetching the message from the channel using the bot context and `discord.TextChannel.fetch_message`.

Once we have that object we are back to using the bot HTTP state again so we can use the publish methods.