### PR TITLE
Fix Race Conditions in Help Channels

### DIFF
--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -4,8 +4,10 @@ from datetime import datetime, timedelta
 
 import discord
 
+import bot
 from bot import constants
 from bot.exts.help_channels import _caches, _message
+from bot.utils.channel import try_get_channel
 
 log = logging.getLogger(__name__)
 
@@ -55,3 +57,43 @@ async def get_in_use_time(channel_id: int) -> t.Optional[timedelta]:
 def is_excluded_channel(channel: discord.abc.GuildChannel) -> bool:
     """Check if a channel should be excluded from the help channel system."""
     return not isinstance(channel, discord.TextChannel) or channel.id in EXCLUDED_CHANNELS
+
+
+async def move_to_bottom(channel: discord.TextChannel, category_id: int, **options) -> None:
+    """
+    Move the `channel` to the bottom position of `category` and edit channel attributes.
+
+    To ensure "stable sorting", we use the `bulk_channel_update` endpoint and provide the current
+    positions of the other channels in the category as-is. This should make sure that the channel
+    really ends up at the bottom of the category.
+
+    If `options` are provided, the channel will be edited after the move is completed. This is the
+    same order of operations that `discord.TextChannel.edit` uses. For information on available
+    options, see the documentation on `discord.TextChannel.edit`. While possible, position-related
+    options should be avoided, as it may interfere with the category move we perform.
+    """
+    # Get a fresh copy of the category from the bot to avoid the cache mismatch issue we had.
+    category = await try_get_channel(category_id)
+
+    payload = [{"id": c.id, "position": c.position} for c in category.channels]
+
+    # Calculate the bottom position based on the current highest position in the category. If the
+    # category is currently empty, we simply use the current position of the channel to avoid making
+    # unnecessary changes to positions in the guild.
+    bottom_position = payload[-1]["position"] + 1 if payload else channel.position
+
+    payload.append(
+        {
+            "id": channel.id,
+            "position": bottom_position,
+            "parent_id": category.id,
+            "lock_permissions": True,
+        }
+    )
+
+    # We use d.py's method to ensure our request is processed by d.py's rate limit manager
+    await bot.instance.http.bulk_channel_update(category.guild.id, payload)
+
+    # Now that the channel is moved, we can edit the other attributes
+    if options:
+        await channel.edit(**options)

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -89,6 +89,7 @@ class HelpChannels(commands.Cog):
         self.scheduler.cancel_all()
 
     @lock.lock_arg(NAMESPACE, "message", attrgetter("channel.id"))
+    @lock.lock_arg(NAMESPACE, "message", attrgetter("author.id"))
     async def claim_channel(self, message: discord.Message) -> None:
         """
         Claim the channel in which the question `message` was sent.

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -349,7 +349,6 @@ class HelpChannels(commands.Cog):
         await self.unclaim_channel(channel)
         await _stats.report_complete_session(channel.id, caller)
 
-        log.trace(f"Position of #{channel} ({channel.id}) is actually {channel.position}.")
         log.trace(f"Sending dormant message for #{channel} ({channel.id}).")
         embed = discord.Embed(description=_message.DORMANT_MSG)
         await channel.send(embed=embed)

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -384,10 +384,8 @@ class HelpChannels(commands.Cog):
         claimant = self.bot.get_guild(constants.Guild.id).get_member(claimant_id)
         if claimant is None:
             log.info(f"{claimant_id} left the guild during their help session; the cooldown role won't be removed")
-            return
-
-        # Remove the cooldown role if the claimant has no other channels left
-        if not any(claimant.id == user_id for _, user_id in await _caches.claimants.items()):
+        elif not any(claimant.id == user_id for _, user_id in await _caches.claimants.items()):
+            # Remove the cooldown role if the claimant has no other channels left
             await _cooldown.remove_cooldown_role(claimant)
 
         await _message.unpin(channel)

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -178,8 +178,7 @@ class HelpChannels(commands.Cog):
         """
         Make the current in-use help channel dormant.
 
-        Make the channel dormant if the user passes the `close_check`,
-        delete the message that invoked this.
+        May only be invoked by the channel's claimant or by staff.
         """
         # Don't use a discord.py check because the check needs to fail silently.
         if await self.close_check(ctx):

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -351,6 +351,7 @@ class HelpChannels(commands.Cog):
 
         _stats.report_counts()
 
+    @lock.lock_arg(f"{NAMESPACE}.unclaim", "channel")
     async def unclaim_channel(self, channel: discord.TextChannel, *, is_auto: bool = True) -> None:
         """
         Unclaim an in-use help `channel` to make it dormant.

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -363,15 +363,15 @@ class HelpChannels(commands.Cog):
         Set `is_auto` to True if the channel was automatically closed or False if manually closed.
         """
         claimant_id = await _caches.claimants.get(channel.id)
-        coroutine = self._unclaim_channel(channel, claimant_id, is_auto)
+        _unclaim_channel = self._unclaim_channel
 
         # It could be possible that there is no claimant cached. In such case, it'd be useless and
         # possibly incorrect to lock on None. Therefore, the lock is applied conditionally.
         if claimant_id is not None:
             decorator = lock.lock_arg(f"{NAMESPACE}.unclaim", "claimant_id", wait=True)
-            coroutine = decorator(coroutine)
+            _unclaim_channel = decorator(_unclaim_channel)
 
-        return await coroutine
+        return await _unclaim_channel(channel, claimant_id, is_auto)
 
     async def _unclaim_channel(self, channel: discord.TextChannel, claimant_id: int, is_auto: bool) -> None:
         """Actual implementation of `unclaim_channel`. See that for full documentation."""

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -462,9 +462,10 @@ class HelpChannels(commands.Cog):
         if message.author.bot:
             return  # Ignore messages sent by bots.
 
+        await self.init_task
+
         if channel_utils.is_in_category(message.channel, constants.Categories.help_available):
             if not _channel.is_excluded_channel(message.channel):
-                await self.init_task
                 await self.claim_channel(message)
                 await self.move_to_available()  # Not in a lock because it may wait indefinitely.
         else:
@@ -477,14 +478,13 @@ class HelpChannels(commands.Cog):
 
         The new time for the dormant task is configured with `HelpChannels.deleted_idle_minutes`.
         """
+        await self.init_task
+
         if not channel_utils.is_in_category(msg.channel, constants.Categories.help_in_use):
             return
 
         if not await _message.is_empty(msg.channel):
             return
-
-        log.trace("Waiting for the cog to be ready before processing deleted messages.")
-        await self.init_task
 
         log.info(f"Claimant of #{msg.channel} ({msg.author}) deleted message, channel is empty now. Rescheduling task.")
 

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -325,45 +325,6 @@ class HelpChannels(commands.Cog):
 
             self.scheduler.schedule_later(delay, channel.id, self.move_idle_channel(channel))
 
-    async def move_to_bottom_position(self, channel: discord.TextChannel, category_id: int, **options) -> None:
-        """
-        Move the `channel` to the bottom position of `category` and edit channel attributes.
-
-        To ensure "stable sorting", we use the `bulk_channel_update` endpoint and provide the current
-        positions of the other channels in the category as-is. This should make sure that the channel
-        really ends up at the bottom of the category.
-
-        If `options` are provided, the channel will be edited after the move is completed. This is the
-        same order of operations that `discord.TextChannel.edit` uses. For information on available
-        options, see the documentation on `discord.TextChannel.edit`. While possible, position-related
-        options should be avoided, as it may interfere with the category move we perform.
-        """
-        # Get a fresh copy of the category from the bot to avoid the cache mismatch issue we had.
-        category = await channel_utils.try_get_channel(category_id)
-
-        payload = [{"id": c.id, "position": c.position} for c in category.channels]
-
-        # Calculate the bottom position based on the current highest position in the category. If the
-        # category is currently empty, we simply use the current position of the channel to avoid making
-        # unnecessary changes to positions in the guild.
-        bottom_position = payload[-1]["position"] + 1 if payload else channel.position
-
-        payload.append(
-            {
-                "id": channel.id,
-                "position": bottom_position,
-                "parent_id": category.id,
-                "lock_permissions": True,
-            }
-        )
-
-        # We use d.py's method to ensure our request is processed by d.py's rate limit manager
-        await self.bot.http.bulk_channel_update(category.guild.id, payload)
-
-        # Now that the channel is moved, we can edit the other attributes
-        if options:
-            await channel.edit(**options)
-
     async def move_to_available(self) -> None:
         """Make a channel available."""
         log.trace("Making a channel available.")
@@ -375,7 +336,7 @@ class HelpChannels(commands.Cog):
 
         log.trace(f"Moving #{channel} ({channel.id}) to the Available category.")
 
-        await self.move_to_bottom_position(
+        await _channel.move_to_bottom(
             channel=channel,
             category_id=constants.Categories.help_available,
         )
@@ -390,7 +351,7 @@ class HelpChannels(commands.Cog):
         """
         log.info(f"Moving #{channel} ({channel.id}) to the Dormant category.")
 
-        await self.move_to_bottom_position(
+        await _channel.move_to_bottom(
             channel=channel,
             category_id=constants.Categories.help_dormant,
         )
@@ -446,7 +407,7 @@ class HelpChannels(commands.Cog):
         """Make a channel in-use and schedule it to be made dormant."""
         log.info(f"Moving #{channel} ({channel.id}) to the In Use category.")
 
-        await self.move_to_bottom_position(
+        await _channel.move_to_bottom(
             channel=channel,
             category_id=constants.Categories.help_in_use,
         )

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -183,7 +183,7 @@ class HelpChannels(commands.Cog):
         # Don't use a discord.py check because the check needs to fail silently.
         if await self.close_check(ctx):
             log.info(f"Close command invoked by {ctx.author} in #{ctx.channel}.")
-            await self.unclaim_channel(ctx.channel, "command")
+            await self.unclaim_channel(ctx.channel, is_auto=False)
 
     async def get_available_candidate(self) -> discord.TextChannel:
         """
@@ -229,7 +229,7 @@ class HelpChannels(commands.Cog):
         elif missing < 0:
             log.trace(f"Moving {abs(missing)} superfluous available channels over to the Dormant category.")
             for channel in channels[:abs(missing)]:
-                await self.unclaim_channel(channel, "auto")
+                await self.unclaim_channel(channel)
 
     async def init_categories(self) -> None:
         """Get the help category objects. Remove the cog if retrieval fails."""
@@ -302,7 +302,7 @@ class HelpChannels(commands.Cog):
                 f"and will be made dormant."
             )
 
-            await self.unclaim_channel(channel, "auto")
+            await self.unclaim_channel(channel)
         else:
             # Cancel the existing task, if any.
             if has_task:
@@ -351,7 +351,7 @@ class HelpChannels(commands.Cog):
 
         _stats.report_counts()
 
-    async def unclaim_channel(self, channel: discord.TextChannel, caller: str) -> None:
+    async def unclaim_channel(self, channel: discord.TextChannel, *, is_auto: bool = True) -> None:
         """
         Unclaim an in-use help `channel` to make it dormant.
 
@@ -359,10 +359,10 @@ class HelpChannels(commands.Cog):
         Remove the cooldown role from the channel claimant if they have no other channels claimed.
         Cancel the scheduled cooldown role removal task.
 
-        `caller` is used to track stats on how `channel` was unclaimed (either 'auto' or 'command').
+        Set `is_auto` to True if the channel was automatically closed or False if manually closed.
         """
         claimant_id = await _caches.claimants.get(channel.id)
-        coroutine = self._unclaim_channel(channel, claimant_id, caller)
+        coroutine = self._unclaim_channel(channel, claimant_id, is_auto)
 
         # It could be possible that there is no claimant cached. In such case, it'd be useless and
         # possibly incorrect to lock on None. Therefore, the lock is applied conditionally.
@@ -372,7 +372,7 @@ class HelpChannels(commands.Cog):
 
         return await coroutine
 
-    async def _unclaim_channel(self, channel: discord.TextChannel, claimant_id: int, caller: str) -> None:
+    async def _unclaim_channel(self, channel: discord.TextChannel, claimant_id: int, is_auto: bool) -> None:
         """Actual implementation of `unclaim_channel`. See that for full documentation."""
         await _caches.claimants.delete(channel.id)
 
@@ -390,12 +390,12 @@ class HelpChannels(commands.Cog):
             await _cooldown.remove_cooldown_role(claimant)
 
         await _message.unpin(channel)
-        await _stats.report_complete_session(channel.id, caller)
+        await _stats.report_complete_session(channel.id, is_auto)
         await self.move_to_dormant(channel)
 
         # Cancel the task that makes the channel dormant only if called by the close command.
         # In other cases, the task is either already done or not-existent.
-        if caller == "command":
+        if not is_auto:
             self.scheduler.cancel(channel.id)
 
     async def move_to_in_use(self, channel: discord.TextChannel) -> None:

--- a/bot/exts/help_channels/_stats.py
+++ b/bot/exts/help_channels/_stats.py
@@ -22,12 +22,13 @@ def report_counts() -> None:
             log.warning(f"Couldn't find category {name!r} to track channel count stats.")
 
 
-async def report_complete_session(channel_id: int, caller: str) -> None:
+async def report_complete_session(channel_id: int, is_auto: bool) -> None:
     """
     Report stats for a completed help session channel `channel_id`.
 
-    `caller` is used to track stats on how `channel_id` was unclaimed (either 'auto' or 'command').
+    Set `is_auto` to True if the channel was automatically closed or False if manually closed.
     """
+    caller = "auto" if is_auto else "command"
     bot.instance.stats.incr(f"help.dormant_calls.{caller}")
 
     in_use_time = await _channel.get_in_use_time(channel_id)

--- a/bot/exts/help_channels/_stats.py
+++ b/bot/exts/help_channels/_stats.py
@@ -1,0 +1,41 @@
+import logging
+
+from more_itertools import ilen
+
+import bot
+from bot import constants
+from bot.exts.help_channels import _caches, _channel
+
+log = logging.getLogger(__name__)
+
+
+def report_counts() -> None:
+    """Report channel count stats of each help category."""
+    for name in ("in_use", "available", "dormant"):
+        id_ = getattr(constants.Categories, f"help_{name}")
+        category = bot.instance.get_channel(id_)
+
+        if category:
+            total = ilen(_channel.get_category_channels(category))
+            bot.instance.stats.gauge(f"help.total.{name}", total)
+        else:
+            log.warning(f"Couldn't find category {name!r} to track channel count stats.")
+
+
+async def report_complete_session(channel_id: int, caller: str) -> None:
+    """
+    Report stats for a completed help session channel `channel_id`.
+
+    `caller` is used to track stats on how `channel_id` was unclaimed (either 'auto' or 'command').
+    """
+    bot.instance.stats.incr(f"help.dormant_calls.{caller}")
+
+    in_use_time = await _channel.get_in_use_time(channel_id)
+    if in_use_time:
+        bot.instance.stats.timing("help.in_use_time", in_use_time)
+
+    unanswered = await _caches.unanswered.get(channel_id)
+    if unanswered:
+        bot.instance.stats.incr("help.sessions.unanswered")
+    elif unanswered is not None:
+        bot.instance.stats.incr("help.sessions.answered")

--- a/bot/log.py
+++ b/bot/log.py
@@ -54,6 +54,9 @@ def setup() -> None:
     logging.getLogger("chardet").setLevel(logging.WARNING)
     logging.getLogger("async_rediscache").setLevel(logging.WARNING)
 
+    # Set back to the default of INFO even if asyncio's debug mode is enabled.
+    logging.getLogger("asyncio").setLevel(logging.INFO)
+
 
 def setup_sentry() -> None:
     """Set up the Sentry logging integrations."""

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -155,3 +155,20 @@ class Scheduler:
             # Log the exception if one exists.
             if exception:
                 self._log.error(f"Error in task #{task_id} {id(done_task)}!", exc_info=exception)
+
+
+def create_task(*args, **kwargs) -> asyncio.Task:
+    """Wrapper for `asyncio.create_task` which logs exceptions raised in the task."""
+    task = asyncio.create_task(*args, **kwargs)
+    task.add_done_callback(_log_task_exception)
+    return task
+
+
+def _log_task_exception(task: asyncio.Task) -> None:
+    """Retrieve and log the exception raised in `task` if one exists."""
+    with contextlib.suppress(asyncio.CancelledError):
+        exception = task.exception()
+        # Log the exception if one exists.
+        if exception:
+            log = logging.getLogger(__name__)
+            log.error(f"Error in task {task.get_name()} {id(task)}!", exc_info=exception)


### PR DESCRIPTION
The following race conditions were fixed:

* User claiming a second channel while their first channel is in the middle of being claimed.
* Multiple people claiming the same channel (this was accounted for before, but now each channel has its own lock).
* User's channel being unclaimed while they're in the middle of claiming a new channel. This would cause their cooldown role to get incorrectly removed.
* Multiple unclaims on the same channel either from multiple `!close` invocations or `!close` being called while the channel is automatically being unclaimed. Fixes #1341.

To facilitate these fixes, some refactoring had to be done. The lock decorator also had to be updated to support waiting for an `asyncio.Lock` instead of always aborting if the lock is unavailable. There was also some other refactoring sprinkled throughout the help channel modules.