### PR TITLE
Fixes Error Handler Tag Dispatching

### DIFF
--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -181,6 +181,9 @@ class ErrorHandler(Cog):
             similar_command_name = similar_command_data[0]
             similar_command = self.bot.get_command(similar_command_name)
 
+            if not similar_command:
+                return
+
             log_msg = "Cancelling attempt to suggest a command due to failed checks."
             try:
                 if not await similar_command.can_run(ctx):

--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -155,7 +155,8 @@ class ErrorHandler(Cog):
             )
         else:
             with contextlib.suppress(ResponseCodeError):
-                await ctx.invoke(tags_get_command, tag_name=tag_name)
+                if await ctx.invoke(tags_get_command, tag_name=tag_name):
+                    return
 
         if not any(role.id in MODERATION_ROLES for role in ctx.author.roles):
             tags_cog = self.bot.get_cog("Tags")

--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -281,9 +281,13 @@ class Tags(Cog):
         return False
 
     @tags_group.command(name='get', aliases=('show', 'g'))
-    async def get_command(self, ctx: Context, *, tag_name: TagNameConverter = None) -> None:
-        """Get a specified tag, or a list of all tags if no tag is specified."""
-        await self.display_tag(ctx, tag_name)
+    async def get_command(self, ctx: Context, *, tag_name: TagNameConverter = None) -> bool:
+        """
+        Get a specified tag, or a list of all tags if no tag is specified.
+
+        Returns False if a tag is on cooldown, or if no matches are found.
+        """
+        return await self.display_tag(ctx, tag_name)
 
 
 def setup(bot: Bot) -> None:


### PR DESCRIPTION
With the introduction of the new command suggestions, some users noticed that suggested tags could be sent twice (or could cause an unhandled error on the bot). [Context here](https://discord.com/channels/267624335836053506/429409067623251969/800234101835563018).

This is due to the error handler not returning if it sent a tag match, and instead reinvoking the tag. The error is caused by not checking for none on the suggestion. This PR addresses both issues.