### PR TITLE
Fix ZeroDivisionError In Error Handler

### DIFF
--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -159,12 +159,7 @@ class ErrorHandler(Cog):
                     return
 
         if not any(role.id in MODERATION_ROLES for role in ctx.author.roles):
-            tags_cog = self.bot.get_cog("Tags")
-            command_name = ctx.invoked_with
-            sent = await tags_cog.display_tag(ctx, command_name)
-
-            if not sent:
-                await self.send_command_suggestion(ctx, command_name)
+            await self.send_command_suggestion(ctx, ctx.invoked_with)
 
         # Return to not raise the exception
         return


### PR DESCRIPTION
Closes #1362.

An error occurs in the error handler when trying to find suggestions for tags. This is due to the way the tag search command is invoked directly through `ctx.invoke`, which bypasses converter checks ([reference](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.Context.invoke)), which allows the suggestor to pass in an invalid argument such as `!!` to the get tag function.

This functionality is redundant, as the code right before the suggestor is already responsible for suggesting a tag. Full discussion on the reasoning behind this solution [starts here](https://discord.com/channels/267624335836053506/635950537262759947/800276211171328000).