### PR TITLE
Added slowmode statistic for python-general

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -429,7 +429,7 @@ class Channels(metaclass=YAMLGetter):
     off_topic_1: int
     off_topic_2: int
     organisation: int
-    python_discussion: int
+    python_general: int
     python_events: int
     python_news: int
     reddit: int

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -408,6 +408,7 @@ class Channels(metaclass=YAMLGetter):
     code_help_voice_2: int
     cooldown: int
     defcon: int
+    discord_py: int
     dev_contrib: int
     dev_core: int
     dev_log: int

--- a/bot/exts/moderation/slowmode.py
+++ b/bot/exts/moderation/slowmode.py
@@ -7,7 +7,7 @@ from discord import TextChannel
 from discord.ext.commands import Cog, Context, group, has_any_role
 
 from bot.bot import Bot
-from bot.constants import Emojis, MODERATION_ROLES
+from bot.constants import Channels, Emojis, MODERATION_ROLES
 from bot.converters import DurationDelta
 from bot.utils import time
 
@@ -58,6 +58,10 @@ class Slowmode(Cog):
             log.info(f'{ctx.author} set the slowmode delay for #{channel} to {humanized_delay}.')
 
             await channel.edit(slowmode_delay=slowmode_delay)
+            if channel.id == Channels.python_general:
+                log.info(f'Recording slowmode change in stats for {channel.name}.')
+                self.bot.stats.gauge(f"slowmode.{channel.name}", slowmode_delay)
+
             await ctx.send(
                 f'{Emojis.check_mark} The slowmode delay for {channel.mention} is now {humanized_delay}.'
             )

--- a/bot/exts/moderation/slowmode.py
+++ b/bot/exts/moderation/slowmode.py
@@ -75,16 +75,7 @@ class Slowmode(Cog):
     @slowmode_group.command(name='reset', aliases=['r'])
     async def reset_slowmode(self, ctx: Context, channel: Optional[TextChannel]) -> None:
         """Reset the slowmode delay for a text channel to 0 seconds."""
-        # Use the channel this command was invoked in if one was not given
-        if channel is None:
-            channel = ctx.channel
-
-        log.info(f'{ctx.author} reset the slowmode delay for #{channel} to 0 seconds.')
-
-        await channel.edit(slowmode_delay=0)
-        await ctx.send(
-            f'{Emojis.check_mark} The slowmode delay for {channel.mention} has been reset to 0 seconds.'
-        )
+        await self.set_slowmode(ctx, channel, relativedelta(seconds=0))
 
     async def cog_check(self, ctx: Context) -> bool:
         """Only allow moderators to invoke the commands in this cog."""

--- a/bot/exts/moderation/slowmode.py
+++ b/bot/exts/moderation/slowmode.py
@@ -15,6 +15,12 @@ log = logging.getLogger(__name__)
 
 SLOWMODE_MAX_DELAY = 21600  # seconds
 
+COMMONLY_SLOWMODED_CHANNELS = {
+    Channels.python_general: "python_general",
+    Channels.discord_py: "discordpy",
+    Channels.off_topic_0: "ot0",
+}
+
 
 class Slowmode(Cog):
     """Commands for getting and setting slowmode delays of text channels."""
@@ -58,9 +64,9 @@ class Slowmode(Cog):
             log.info(f'{ctx.author} set the slowmode delay for #{channel} to {humanized_delay}.')
 
             await channel.edit(slowmode_delay=slowmode_delay)
-            if channel.id == Channels.python_general:
+            if channel.id in COMMONLY_SLOWMODED_CHANNELS:
                 log.info(f'Recording slowmode change in stats for {channel.name}.')
-                self.bot.stats.gauge(f"slowmode.{channel.name}", slowmode_delay)
+                self.bot.stats.gauge(f"slowmode.{COMMONLY_SLOWMODED_CHANNELS[channel.id]}", slowmode_delay)
 
             await ctx.send(
                 f'{Emojis.check_mark} The slowmode delay for {channel.mention} is now {humanized_delay}.'

--- a/config-default.yml
+++ b/config-default.yml
@@ -157,7 +157,7 @@ guild:
 
         # Discussion
         meta:                               429409067623251969
-        python_discussion:  &PY_DISCUSSION  267624335836053506
+        python_general:     &PY_GENERAL     267624335836053506
 
         # Python Help: Available
         cooldown:           720603994149486673
@@ -430,7 +430,7 @@ code_block:
 
     # The channels which will be affected by a cooldown. These channels are also whitelisted.
     cooldown_channels:
-        - *PY_DISCUSSION
+        - *PY_GENERAL
 
     # Sending instructions triggers a cooldown on a per-channel basis.
     # More instruction messages will not be sent in the same channel until the cooldown has elapsed.

--- a/config-default.yml
+++ b/config-default.yml
@@ -162,6 +162,9 @@ guild:
         # Python Help: Available
         cooldown:           720603994149486673
 
+        # Topical
+        discord_py:         343944376055103488
+
         # Logs
         attachment_log:     &ATTACH_LOG     649243850006855680
         message_log:        &MESSAGE_LOG    467752170159079424

--- a/tests/bot/exts/moderation/test_slowmode.py
+++ b/tests/bot/exts/moderation/test_slowmode.py
@@ -85,22 +85,14 @@ class SlowmodeTests(unittest.IsolatedAsyncioTestCase):
 
             self.ctx.reset_mock()
 
-    async def test_reset_slowmode_no_channel(self) -> None:
-        """Reset slowmode without a given channel."""
-        self.ctx.channel = MockTextChannel(name='careers', slowmode_delay=6)
-
-        await self.cog.reset_slowmode(self.cog, self.ctx, None)
-        self.ctx.send.assert_called_once_with(
-            f'{Emojis.check_mark} The slowmode delay for #careers has been reset to 0 seconds.'
-        )
-
-    async def test_reset_slowmode_with_channel(self) -> None:
+    async def test_reset_slowmode_sets_delay_to_zero(self) -> None:
         """Reset slowmode with a given channel."""
         text_channel = MockTextChannel(name='meta', slowmode_delay=1)
+        self.cog.set_slowmode = mock.AsyncMock()
 
         await self.cog.reset_slowmode(self.cog, self.ctx, text_channel)
-        self.ctx.send.assert_called_once_with(
-            f'{Emojis.check_mark} The slowmode delay for #meta has been reset to 0 seconds.'
+        self.cog.set_slowmode.assert_awaited_once_with(
+            self.ctx, text_channel, relativedelta(seconds=0)
         )
 
     @mock.patch("bot.exts.moderation.slowmode.has_any_role")


### PR DESCRIPTION
Added a statistic for advanced monitoring of the cooldown in python-general. Also made the slowmode reset command use the slowmode setting command under the hood to avoid repetition.