### PR TITLE
Update badges on the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 [![Build][3]][4]
 [![Deploy][5]][6]
 [![Coverage Status](https://coveralls.io/repos/github/python-discord/bot/badge.svg)](https://coveralls.io/github/python-discord/bot)
-[![License](https://img.shields.io/github/license/python-discord/bot)](LICENSE)
-[![Website](https://img.shields.io/badge/website-visit-brightgreen)](https://pythondiscord.com)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 This project is a Discord bot specifically for use with the Python Discord server. It provides numerous utilities
 and other tools to help keep the server running like a well-oiled machine.
@@ -19,5 +18,5 @@ Read the [Contributing Guide](https://pythondiscord.com/pages/contributing/bot/)
 [4]: https://github.com/python-discord/bot/actions?query=workflow%3ABuild+branch%3Amaster
 [5]: https://github.com/python-discord/bot/workflows/Deploy/badge.svg?branch=master
 [6]: https://github.com/python-discord/bot/actions?query=workflow%3ADeploy+branch%3Amaster
-[7]: https://img.shields.io/static/v1?label=Python%20Discord&logo=discord&message=%3E100k%20members&color=%237289DA&logoColor=white
-[8]: https://discord.gg/2B963hn
+[7]: https://raw.githubusercontent.com/python-discord/branding/master/logos/badge/badge_github.png
+[8]: https://discord.gg/python

--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ Read the [Contributing Guide](https://pythondiscord.com/pages/contributing/bot/)
 [4]: https://github.com/python-discord/bot/actions?query=workflow%3ABuild+branch%3Amaster
 [5]: https://github.com/python-discord/bot/workflows/Deploy/badge.svg?branch=master
 [6]: https://github.com/python-discord/bot/actions?query=workflow%3ADeploy+branch%3Amaster
-[7]: https://raw.githubusercontent.com/python-discord/branding/master/logos/badge/badge_github.png
+[7]: https://raw.githubusercontent.com/python-discord/branding/master/logos/badge/badge_github.svg
 [8]: https://discord.gg/python


### PR DESCRIPTION
Some small changes with the README badges:
* Use the new Python Discord badge
* Use the vanity URL
* Use a static license badge as the current one is broken
* Remove the site badge