### PR TITLE
Gracefully handle non-existing infractions

### DIFF
--- a/bot/converters.py
+++ b/bot/converters.py
@@ -575,10 +575,7 @@ class Infraction(Converter):
                 return infractions[0]
 
         else:
-            try:
-                return await ctx.bot.api_client.get(f"bot/infractions/{arg}")
-            except ResponseCodeError:
-                raise BadArgument("The provided infraction could not be found.")
+            return await ctx.bot.api_client.get(f"bot/infractions/{arg}")
 
 
 Expiry = t.Union[Duration, ISODateTime]

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -575,7 +575,10 @@ class Infraction(Converter):
                 return infractions[0]
 
         else:
-            return await ctx.bot.api_client.get(f"bot/infractions/{arg}")
+            try:
+                return await ctx.bot.api_client.get(f"bot/infractions/{arg}")
+            except ResponseCodeError:
+                raise BadArgument("The provided infraction could not be found.")
 
 
 Expiry = t.Union[Duration, ISODateTime]

--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -92,7 +92,7 @@ class ErrorHandler(Cog):
                 await self.handle_unexpected_error(ctx, e.original)
             return  # Exit early to avoid logging.
         elif not isinstance(e, errors.DisabledCommand):
-            # ConversionError, MaxConcurrencyReached, ExtensionError
+            # MaxConcurrencyReached, ExtensionError
             await self.handle_unexpected_error(ctx, e)
             return  # Exit early to avoid logging.
 

--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -85,6 +85,12 @@ class ErrorHandler(Cog):
             else:
                 await self.handle_unexpected_error(ctx, e.original)
             return  # Exit early to avoid logging.
+        elif isinstance(e, errors.ConversionError):
+            if isinstance(e.original, ResponseCodeError):
+                await self.handle_api_error(ctx, e.original)
+            else:
+                await self.handle_unexpected_error(ctx, e.original)
+            return  # Exit early to avoid logging.
         elif not isinstance(e, errors.DisabledCommand):
             # ConversionError, MaxConcurrencyReached, ExtensionError
             await self.handle_unexpected_error(ctx, e)


### PR DESCRIPTION
This closes #1375.

Catches the response code error and handles by raising a bad argument error