### PR TITLE
Protect against overflows caused by large expirations

### DIFF
--- a/bot/converters.py
+++ b/bot/converters.py
@@ -350,7 +350,7 @@ class Duration(DurationDelta):
 
         try:
             return now + delta
-        except ValueError:
+        except (ValueError, OverflowError):
             raise BadArgument(f"`{duration}` results in a datetime outside the supported range.")
 
 


### PR DESCRIPTION
Closes #1225 and #1369.

Excepting `ValueError` catches dates that would go above the year 9999, but very large numbers can cause an `OverflowError` to be thrown instead. This deals with both in the same way.

ValueError (Current behaviour)
![image](https://user-images.githubusercontent.com/9753350/106369533-4a499c80-634a-11eb-87d3-3976d5e4d49e.png)

OverflowError (New behaviour)

![image](https://user-images.githubusercontent.com/9753350/106369541-5a617c00-634a-11eb-8ab5-60ec1aa3fc04.png)