### PR TITLE
Handle tags on cooldown

### DIFF
--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -189,7 +189,7 @@ class Tags(Cog):
         If a tag is not specified, display a paginated embed of all tags.
 
         Tags are on cooldowns on a per-tag, per-channel basis. If a tag is on cooldown, display
-        nothing and return False.
+        nothing and return True.
         """
         def _command_on_cooldown(tag_name: str) -> bool:
             """
@@ -217,7 +217,7 @@ class Tags(Cog):
                 f"{ctx.author} tried to get the '{tag_name}' tag, but the tag is on cooldown. "
                 f"Cooldown ends in {time_left:.1f} seconds."
             )
-            return False
+            return True
 
         if tag_name is not None:
             temp_founds = self._get_tag(tag_name)
@@ -285,7 +285,7 @@ class Tags(Cog):
         """
         Get a specified tag, or a list of all tags if no tag is specified.
 
-        Returns False if a tag is on cooldown, or if no matches are found.
+        Returns True if a tag is on cooldown, False if no matches are found.
         """
         return await self.display_tag(ctx, tag_name)
 


### PR DESCRIPTION
Closes #1373.

By changing this to True the if statement in [bot.error_handler.py:163]([https://github.com/python-discord/bot/blob/2a31892f2339848e13f3e04fce37e64f5242ab84/bot/exts/backend/error_handler.py#L163) passes, and we don't suggest a similar tag.

I couldn't find anywhere in the code base that relies on this function returning False in the case of a cooldown, so I don't think this will have any side effects.

If we need to differentiate between not found, on cooldown and success for tags, then I think possibly an enum should be used?