### PR TITLE
Don't fuzzy search for tags when tag is on cooldown

### DIFF
--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -285,7 +285,7 @@ class Tags(Cog):
         """
         Get a specified tag, or a list of all tags if no tag is specified.
 
-        Returns True if something can be send, or the tag is on cooldown
+        Returns True if something can be sent, or if the tag is on cooldown.
         Returns False if no matches are found.
         """
         return await self.display_tag(ctx, tag_name)

--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -189,7 +189,7 @@ class Tags(Cog):
         If a tag is not specified, display a paginated embed of all tags.
 
         Tags are on cooldowns on a per-tag, per-channel basis. If a tag is on cooldown, display
-        nothing and return False.
+        nothing and return True.
         """
         def _command_on_cooldown(tag_name: str) -> bool:
             """
@@ -217,7 +217,7 @@ class Tags(Cog):
                 f"{ctx.author} tried to get the '{tag_name}' tag, but the tag is on cooldown. "
                 f"Cooldown ends in {time_left:.1f} seconds."
             )
-            return False
+            return True
 
         if tag_name is not None:
             temp_founds = self._get_tag(tag_name)
@@ -285,7 +285,8 @@ class Tags(Cog):
         """
         Get a specified tag, or a list of all tags if no tag is specified.
 
-        Returns False if a tag is on cooldown, or if no matches are found.
+        Returns True if something can be send, or the tag is on cooldown
+        Returns False if no matches are found.
         """
         return await self.display_tag(ctx, tag_name)
 


### PR DESCRIPTION
Closes #1373.

By returning True within this command, the fuzzy search in [error_handler.py](https://github.com/python-discord/bot/blob/ced0af2b2936b1fab4f5601bd7b1c00bbbd9130a/bot/exts/backend/error_handler.py#L169) is not hit.
As the tag_get function deals with cooldowns internally, we can reserve False for when a tag is not found.

See https://discord.com/channels/267624335836053506/635950537262759947/805458232943837194 for a discussion on this.
