### PR TITLE
Dynamic available help channels message

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -406,6 +406,7 @@ class Channels(metaclass=YAMLGetter):
 
     meta: int
     python_general: int
+    how_to_get_help: int
 
     cooldown: int
 

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -495,18 +495,16 @@ class HelpChannels(commands.Cog):
                 c.id for c in available_channels_category.channels if 'help-' in c.name
             )
 
-        if self.how_to_get_help is None:
-            self.how_to_get_help = await channel_utils.try_get_channel(Channels.how_to_get_help)
-
-        if self.dynamic_message is None:
-            last_message = await self.how_to_get_help.history(limit=1)
-            self.dynamic_message = next(last_message)
-
         available_channels = AVAILABLE_HELP_CHANNELS.format(
             available=', '.join(f"<#{c}>" for c in self.available_help_channels)
         )
 
-        try:
-            await self.dynamic_message.edit(content=available_channels)
-        except discord.Forbidden:
-            self.dynamic_message = await self.how_to_get_help.send(available_channels)
+        if self.how_to_get_help is None:
+            self.how_to_get_help = await channel_utils.try_get_channel(Channels.how_to_get_help)
+
+        if self.dynamic_message is None:
+            try:
+                self.dynamic_message = await self.how_to_get_help.fetch_message(self.how_to_get_help.last_message_id)
+                await self.dynamic_message.edit(content=available_channels)
+            except discord.NotFound:
+                self.dynamic_message = await self.how_to_get_help.send(available_channels)

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -21,7 +21,7 @@ NAMESPACE = "help"
 HELP_CHANNEL_TOPIC = """
 This is a Python help channel. You can claim your own help channel in the Python Help: Available category.
 """
-AVAILABLE_HELP_CHANNELS = """**Currently available help channel(s):** {available}"""
+AVAILABLE_HELP_CHANNELS = "**Currently available help channel(s):** {available}"
 
 
 class HelpChannels(commands.Cog):
@@ -500,3 +500,4 @@ class HelpChannels(commands.Cog):
             await self.dynamic_message.edit(content=available_channels)
         except discord.NotFound:
             self.dynamic_message = await self.how_to_get_help.send(available_channels)
+            log.trace("A dynamic message was sent for later modification because one couldn't be found.")

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -123,12 +123,11 @@ class HelpChannels(commands.Cog):
 
         await _caches.unanswered.set(message.channel.id, True)
 
-        # Not awaited because it may indefinitely hold the lock while waiting for a channel.
-        scheduling.create_task(self.move_to_available(), name=f"help_claim_{message.id}")
-
         # Removing the help channel from the dynamic message, and editing/sending that message.
         self.available_help_channels.remove(message.channel.id)
-        await self.update_available_help_channels()
+
+        # Not awaited because it may indefinitely hold the lock while waiting for a channel.
+        scheduling.create_task(self.move_to_available(), name=f"help_claim_{message.id}")
 
     def create_channel_queue(self) -> asyncio.Queue:
         """

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -21,9 +21,7 @@ NAMESPACE = "help"
 HELP_CHANNEL_TOPIC = """
 This is a Python help channel. You can claim your own help channel in the Python Help: Available category.
 """
-AVAILABLE_HELP_CHANNELS = """
-**Currently available help channel(s):** {available}
-"""
+AVAILABLE_HELP_CHANNELS = """**Currently available help channel(s):** {available}"""
 
 
 class HelpChannels(commands.Cog):

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -11,7 +11,7 @@ from discord.ext import commands
 
 from bot import constants
 from bot.bot import Bot
-from bot.constants import Categories, Channels
+from bot.constants import Channels
 from bot.exts.help_channels import _caches, _channel, _cooldown, _message, _name, _stats
 from bot.utils import channel as channel_utils, lock, scheduling
 
@@ -490,9 +490,8 @@ class HelpChannels(commands.Cog):
     async def update_available_help_channels(self) -> None:
         """Updates the dynamic message within #how-to-get-help for available help channels."""
         if not self.available_help_channels:
-            available_channels_category = await channel_utils.try_get_channel(Categories.help_available)
             self.available_help_channels = set(
-                c.id for c in available_channels_category.channels if 'help-' in c.name
+                c.id for c in self.available_category.channels if 'help-' in c.name
             )
 
         available_channels = AVAILABLE_HELP_CHANNELS.format(

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -22,7 +22,7 @@ HELP_CHANNEL_TOPIC = """
 This is a Python help channel. You can claim your own help channel in the Python Help: Available category.
 """
 AVAILABLE_HELP_CHANNELS = """
-Currently available help channel(s): {available}
+**Currently available help channel(s):** {available}
 """
 
 

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -286,13 +286,8 @@ class HelpChannels(commands.Cog):
         self.close_command.enabled = True
 
         # Getting channels that need to be included in the dynamic message.
-        task = asyncio.create_task(self.update_available_help_channels())
-        self.queue_tasks.append(task)
-
-        await task
-
+        await self.update_available_help_channels()
         log.trace("Dynamic available help message updated.")
-        self.queue_tasks.remove(task)
 
         await self.init_available()
         _stats.report_counts()

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -11,6 +11,7 @@ from discord.ext import commands
 
 from bot import constants
 from bot.bot import Bot
+from bot.constants import Channels, Categories
 from bot.exts.help_channels import _caches, _channel, _cooldown, _message, _name, _stats
 from bot.utils import channel as channel_utils, lock, scheduling
 
@@ -19,6 +20,9 @@ log = logging.getLogger(__name__)
 NAMESPACE = "help"
 HELP_CHANNEL_TOPIC = """
 This is a Python help channel. You can claim your own help channel in the Python Help: Available category.
+"""
+AVAILABLE_HELP_CHANNELS = """
+Currently available help channel(s): {available}
 """
 
 
@@ -72,6 +76,11 @@ class HelpChannels(commands.Cog):
 
         self.last_notification: t.Optional[datetime] = None
 
+        # Acquiring and modifying the channel to dynamically update the available help channels message.
+        self.how_to_get_help: discord.TextChannel = None
+        self.available_help_channels: t.Set[int] = set()
+        self.dynamic_message: discord.Message = None
+
         # Asyncio stuff
         self.queue_tasks: t.List[asyncio.Task] = []
         self.init_task = self.bot.loop.create_task(self.init_cog())
@@ -113,6 +122,9 @@ class HelpChannels(commands.Cog):
         await _caches.claim_times.set(message.channel.id, timestamp)
 
         await _caches.unanswered.set(message.channel.id, True)
+
+        self.available_help_channels.remove(message.channel.id)
+        await self.update_available_help_channels()
 
         # Not awaited because it may indefinitely hold the lock while waiting for a channel.
         scheduling.create_task(self.move_to_available(), name=f"help_claim_{message.id}")
@@ -275,6 +287,15 @@ class HelpChannels(commands.Cog):
         # This may confuse users. So would potentially long delays for the cog to become ready.
         self.close_command.enabled = True
 
+        # Getting channels that need to be included in the dynamic message.
+        task = asyncio.create_task(self.update_available_help_channels())
+        self.queue_tasks.append(task)
+
+        await task
+
+        log.trace(f"Dynamic available help message updated.")
+        self.queue_tasks.remove(task)
+
         await self.init_available()
         _stats.report_counts()
 
@@ -331,6 +352,10 @@ class HelpChannels(commands.Cog):
             channel=channel,
             category_id=constants.Categories.help_available,
         )
+
+        # Adding the help channel to the dynamic message, and editing/sending that message.
+        self.available_help_channels.add(channel.id)
+        await self.update_available_help_channels()
 
         _stats.report_counts()
 
@@ -461,3 +486,26 @@ class HelpChannels(commands.Cog):
         self.queue_tasks.remove(task)
 
         return channel
+
+    async def update_available_help_channels(self) -> None:
+        """Updates the dynamic message within #how-to-get-help for available help channels."""
+        if not self.available_help_channels:
+            available_channels_category = await channel_utils.try_get_channel(Categories.help_available)
+            self.available_help_channels = set(
+                c.id for c in available_channels_category.channels if 'help-' in c.name
+            )
+
+        if self.how_to_get_help is None:
+            self.how_to_get_help = await channel_utils.try_get_channel(Channels.how_to_get_help)
+
+        if self.dynamic_message is None:
+            self.dynamic_message = await self.how_to_get_help.history(limit=1).next()
+
+        available_channels = AVAILABLE_HELP_CHANNELS.format(
+            available=', '.join(f"<#{c}>" for c in self.available_help_channels)
+        )
+
+        try:
+            await self.dynamic_message.edit(content=available_channels)
+        except discord.Forbidden:
+            self.dynamic_message = await self.how_to_get_help.send(available_channels)

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -11,7 +11,7 @@ from discord.ext import commands
 
 from bot import constants
 from bot.bot import Bot
-from bot.constants import Channels, Categories
+from bot.constants import Categories, Channels
 from bot.exts.help_channels import _caches, _channel, _cooldown, _message, _name, _stats
 from bot.utils import channel as channel_utils, lock, scheduling
 
@@ -293,7 +293,7 @@ class HelpChannels(commands.Cog):
 
         await task
 
-        log.trace(f"Dynamic available help message updated.")
+        log.trace("Dynamic available help message updated.")
         self.queue_tasks.remove(task)
 
         await self.init_available()
@@ -499,7 +499,8 @@ class HelpChannels(commands.Cog):
             self.how_to_get_help = await channel_utils.try_get_channel(Channels.how_to_get_help)
 
         if self.dynamic_message is None:
-            self.dynamic_message = await self.how_to_get_help.history(limit=1).next()
+            last_message = await self.how_to_get_help.history(limit=1)
+            self.dynamic_message = next(last_message)
 
         available_channels = AVAILABLE_HELP_CHANNELS.format(
             available=', '.join(f"<#{c}>" for c in self.available_help_channels)

--- a/config-default.yml
+++ b/config-default.yml
@@ -158,6 +158,7 @@ guild:
         python_general:     &PY_GENERAL     267624335836053506
 
         # Python Help: Available
+        how_to_get_help:    704250143020417084
         cooldown:           720603994149486673
 
         # Topical

--- a/config-default.yml
+++ b/config-default.yml
@@ -158,8 +158,8 @@ guild:
         python_general:     &PY_GENERAL     267624335836053506
 
         # Python Help: Available
-        how_to_get_help:    704250143020417084
         cooldown:           720603994149486673
+        how_to_get_help:    704250143020417084
 
         # Topical
         discord_py:         343944376055103488


### PR DESCRIPTION
Closes #1320
Rewrite of #1325

Users sometimes get confused on which channels are available for them to claim.

With this PR, a message in the #how-to-get-help channel will be edited to reflect which channels are currently available.

If the bot cannot edit the most recent message in the #how-to-get-help channel, then it knows it's trying to edit the webhook message that contains the guide for claiming a channel. It will send the dynamic message if this occurs.

If we do decide to remove or add more channels in the `help: available` category, then the bot will be able to pick up on them.

![image](https://user-images.githubusercontent.com/15021300/107025299-144b5480-675e-11eb-93e3-52c6723762f8.png)