### PR TITLE
Make `defaultdict` tag

### DIFF
--- a/bot/resources/tags/defaultdict.md
+++ b/bot/resources/tags/defaultdict.md
@@ -1,6 +1,6 @@
 **[`collections.defaultdict`](https://docs.python.org/3/library/collections.html#collections.defaultdict)**
 
-The Python `defaultdict` type behaves almost exactly like a regular Python dictionary, but if you try to access or modify a missing key, the `defaultdict` will automatically create the key and generate a default value for it. 
+The Python `defaultdict` type behaves almost exactly like a regular Python dictionary, but if you try to access or modify a missing key, the `defaultdict` will automatically create the key and generate a default value for it.
 While instantiating a `defaultdict`, we pass in a function that tells it how to create a default value for missing keys.
 
 ```py

--- a/bot/resources/tags/defaultdict.md
+++ b/bot/resources/tags/defaultdict.md
@@ -1,20 +1,21 @@
 **[`collections.defaultdict`](https://docs.python.org/3/library/collections.html#collections.defaultdict)**
 
-The Python `defaultdict` type behaves almost exactly like a regular Python dictionary, but if you try to access or modify a missing key, the `defaultdict` will automatically create the key and generate a default value for it.
+The Python `defaultdict` type behaves almost exactly like a regular Python dictionary, but if you try to access or modify a missing key, the `defaultdict` will automatically insert the key and generate a default value for it.
 While instantiating a `defaultdict`, we pass in a function that tells it how to create a default value for missing keys.
 
 ```py
 >>> from collections import defaultdict
->>> my_dict = defaultdict(int, {"foo": 1, "bar": 2})
->>> print(my_dict)
-defaultdict(<class 'int'>, {'foo': 1, 'bar': 2})
+>>> my_dict = defaultdict(int)
+>>> my_dict
+defaultdict(<class 'int'>, {})
 ```
 
-In this example, we've used the `int` function - this means that if we try to access a non-existent key, it provides the default value of 0.
+In this example, we've used the `int` class which returns 0 when called like a function, so any missing key will get a default value of 0. You can also get an empty list by default with `list` or an empty string with `str`.
 
 ```py
->>> print(my_dict["foobar"])
+>>> my_dict["foo"]
 0
->>> print(my_dict)
-defaultdict(<class 'int'>, {'foo': 1, 'bar': 2, 'foobar': 0})
+>>> my_dict["bar"] += 5
+>>> my_dict
+defaultdict(<class 'int'>, {'foo': 0, 'bar': 5})
 ```

--- a/bot/resources/tags/defaultdict.md
+++ b/bot/resources/tags/defaultdict.md
@@ -1,0 +1,20 @@
+**[`collections.defaultdict`](https://docs.python.org/3/library/collections.html#collections.defaultdict)**
+
+The Python `defaultdict` type behaves almost exactly like a regular Python dictionary, but if you try to access or modify a missing key, the `defaultdict` will automatically create the key and generate a default value for it. 
+While instantiating a `defaultdict`, we pass in a function that tells it how to create a default value for missing keys.
+
+```py
+>>> from collections import defaultdict
+>>> my_dict = defaultdict(int, {"foo": 1, "bar": 2})
+>>> print(my_dict)
+defaultdict(<class 'int'>, {'foo': 1, 'bar': 2})
+```
+
+In this example, we've used the `int` function - this means that if we try to access a non-existent key, it provides the default value of 0.
+
+```py
+>>> print(my_dict["foobar"])
+0
+>>> print(my_dict)
+defaultdict(<class 'int'>, {'foo': 1, 'bar': 2, 'foobar': 0})
+```


### PR DESCRIPTION
Messed up and made a separate branch for this, my bad.
I've edited the `dict-get` tag to also refer to this.