### PR TITLE
Add tag that explains discord.py local file uploading as attachment

### DIFF
--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -1,4 +1,4 @@
-Thanks to discord.py, sending local files as embed images is simple. You have to create an instance of `discord.File` class:
+Thanks to discord.py, sending local files as embed images is simple. You have to create an instance of [`discord.File`](https://discordpy.readthedocs.io/en/latest/api.html#discord.File) class:
 ```py
 # When you know the file exact path, you can pass it.
 file = discord.File("/this/is/path/to/my/file.png", filename="file.png")
@@ -10,14 +10,14 @@ with open("/this/is/path/to/my/file.png", "rb") as f:
 When using the file-like object, you have to open it in `rb` mode. Also, in this case, passing filename to it is not necessary.
 Please note that `filename` can't contain underscores. This is Discord limitation.
 
-`discord.Embed` instance has method `set_image` what can be used to set attachment as image:
+[`discord.Embed`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed) instance has method [`set_image`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed.set_image) what can be used to set attachment as image:
 ```py
 embed = discord.Embed()
 # Set other fields
-embed.set_image("attachment://file.png")  # Filename here must be exactly same as attachment filename.
+embed.set_image(url="attachment://file.png")  # Filename here must be exactly same as attachment filename.
 ```
 After this, you can send embed and attachment to Discord:
 ```py
 await channel.send(file=file, embed=embed)
 ```
-This example uses `discord.TextChannel` for sending, but any instance of `discord.abc.Messageable` can be used for sending.
+This example uses [`discord.TextChannel`](https://discordpy.readthedocs.io/en/latest/api.html#discord.TextChannel) for sending, but any instance of [`discord.abc.Messageable`](https://discordpy.readthedocs.io/en/latest/api.html#discord.abc.Messageable) can be used for sending.

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -16,7 +16,7 @@ embed = discord.Embed()
 # Set other fields
 embed.set_image(url="attachment://file.png")  # Filename here must be exactly same as attachment filename.
 ```
-After this, you send an embed with an attachment to Discord:
+After this, you can send an embed with an attachment to Discord:
 ```py
 await channel.send(file=file, embed=embed)
 ```

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -20,5 +20,5 @@ After this, you can send embed and attachment to Discord:
 ```py
 await channel.send(file=file, embed=embed)
 ```
-This example uses `discord.TextChannel` for sending, but any `discord.Messageable` can be used for sending.
+This example uses `discord.TextChannel` for sending, but any `discord.abc.Messageable` can be used for sending.
 

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -8,7 +8,7 @@ with open("/this/is/path/to/my/file.png", "rb") as f:
     file = discord.File(f)
 ```
 When using the file-like object, you have to open it in `rb` mode. Also, in this case, passing filename to it is not necessary.
-Please note that `filename` can't contain underscores. This is Discord limitation.
+Please note that `filename` can't contain underscores. This is a Discord limitation..
 
 [`discord.Embed`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed) instances have a [`set_image`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed.set_image) method which can be used to set an attachment as an image:
 ```py

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -1,0 +1,24 @@
+Thanks to discord.py, sending local files as embed images is simple. You have to create an instance of `discord.File` class:
+```py
+# When you know the file exact path, you can pass it.
+file = discord.File("/this/is/path/to/my/file.png", filename="file.png")
+
+# When you have the file-like object, then you can pass this instead path.
+with open("/this/is/path/to/my/file.png", "rb") as f:
+    file = discord.File(f)
+```
+When using the file-like object, you have to open it in `rb` mode. Also, in this case, passing filename to it is not necessary.
+Please note that `filename` can't contain underscores. This is Discord limitation.
+
+`discord.Embed` instance has method `set_image` what can be used to set attachment as image:
+```py
+embed = discord.Embed()
+# Set other fields
+embed.set_image("attachment://file.png")  # Filename here must be exactly same as attachment filename.
+```
+After this, you can send embed and attachment to Discord:
+```py
+await channel.send(file=file, embed=embed)
+```
+This example uses `discord.Channel` for sending, but any `discord.Messageable` can be used for sending.
+

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -8,7 +8,7 @@ with open("/this/is/path/to/my/file.png", "rb") as f:
     file = discord.File(f)
 ```
 When using the file-like object, you have to open it in `rb` mode. Also, in this case, passing filename to it is not necessary.
-Please note that `filename` can't contain underscores. This is a Discord limitation..
+Please note that `filename` can't contain underscores. This is a Discord limitation.
 
 [`discord.Embed`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed) instances have a [`set_image`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed.set_image) method which can be used to set an attachment as an image:
 ```py

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -20,5 +20,5 @@ After this, you can send embed and attachment to Discord:
 ```py
 await channel.send(file=file, embed=embed)
 ```
-This example uses `discord.Channel` for sending, but any `discord.Messageable` can be used for sending.
+This example uses `discord.TextChannel` for sending, but any `discord.Messageable` can be used for sending.
 

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -20,4 +20,4 @@ After this, you can send embed and attachment to Discord:
 ```py
 await channel.send(file=file, embed=embed)
 ```
-This example uses `discord.TextChannel` for sending, but any `discord.abc.Messageable` can be used for sending.
+This example uses `discord.TextChannel` for sending, but any instance of `discord.abc.Messageable` can be used for sending.

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -21,4 +21,3 @@ After this, you can send embed and attachment to Discord:
 await channel.send(file=file, embed=embed)
 ```
 This example uses `discord.TextChannel` for sending, but any `discord.abc.Messageable` can be used for sending.
-

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -7,7 +7,7 @@ file = discord.File("/this/is/path/to/my/file.png", filename="file.png")
 with open("/this/is/path/to/my/file.png", "rb") as f:
     file = discord.File(f)
 ```
-When using the file-like object, you have to open it in `rb` mode. Also, in this case, passing filename to it is not necessary.
+When using the file-like object, you have to open it in `rb` mode. Also, in this case, passing `filename` to it is not necessary.
 Please note that `filename` can't contain underscores. This is a Discord limitation.
 
 [`discord.Embed`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed) instances have a [`set_image`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed.set_image) method which can be used to set an attachment as an image:

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -10,13 +10,13 @@ with open("/this/is/path/to/my/file.png", "rb") as f:
 When using the file-like object, you have to open it in `rb` mode. Also, in this case, passing filename to it is not necessary.
 Please note that `filename` can't contain underscores. This is Discord limitation.
 
-[`discord.Embed`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed) instance has method [`set_image`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed.set_image) what can be used to set attachment as image:
+[`discord.Embed`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed) instances have a [`set_image`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed.set_image) method which can be used to set an attachment as an image:
 ```py
 embed = discord.Embed()
 # Set other fields
 embed.set_image(url="attachment://file.png")  # Filename here must be exactly same as attachment filename.
 ```
-After this, you can send embed and attachment to Discord:
+After this, you send an embed with an attachment to Discord:
 ```py
 await channel.send(file=file, embed=embed)
 ```


### PR DESCRIPTION
![Screenshot 2021-02-06 at 12 59 21](https://user-images.githubusercontent.com/45097959/107116362-3d153c00-687b-11eb-962c-2e805b0f9c4c.png)

I think codeblocks should be like they are not one big. This helps explaining it.
Closes #1389 