### PR TITLE
Ignore attachment-only messages for duplicates antispam rule

### DIFF
--- a/bot/rules/duplicates.py
+++ b/bot/rules/duplicates.py
@@ -13,7 +13,7 @@ async def apply(
         if (
             msg.author == last_message.author
             and msg.content == last_message.content
-            and (msg.content and not msg.attachments)
+            and msg.content
         )
     )
 

--- a/bot/rules/duplicates.py
+++ b/bot/rules/duplicates.py
@@ -13,6 +13,7 @@ async def apply(
         if (
             msg.author == last_message.author
             and msg.content == last_message.content
+            and (msg.content and not msg.attachments)
         )
     )
 

--- a/config-default.yml
+++ b/config-default.yml
@@ -367,7 +367,7 @@ anti_spam:
     rules:
         attachments:
             interval: 10
-            max: 3
+            max: 6
 
         burst:
             interval: 10

--- a/config-default.yml
+++ b/config-default.yml
@@ -367,7 +367,7 @@ anti_spam:
     rules:
         attachments:
             interval: 10
-            max: 9
+            max: 3
 
         burst:
             interval: 10


### PR DESCRIPTION
Closes #1356 because we already have attachments rule, but this still should ignore attachment-only messages in duplicates.