### PR TITLE
Internal API routing

### DIFF
--- a/bot/api.py
+++ b/bot/api.py
@@ -53,7 +53,7 @@ class APIClient:
 
     @staticmethod
     def _url_for(endpoint: str) -> str:
-        return f"{URLs.site_schema}{URLs.site_api}/{quote_url(endpoint)}"
+        return f"{URLs.site_api_schema}{URLs.site_api}/{quote_url(endpoint)}"
 
     async def close(self) -> None:
         """Close the aiohttp session."""

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -530,6 +530,7 @@ class URLs(metaclass=YAMLGetter):
     site: str
     site_api: str
     site_schema: str
+    site_api_schema: str
 
     # Site endpoints
     site_logs_view: str

--- a/bot/exts/utils/ping.py
+++ b/bot/exts/utils/ping.py
@@ -37,7 +37,7 @@ class Latency(commands.Cog):
         bot_ping = f"{bot_ping:.{ROUND_LATENCY}f} ms"
 
         try:
-            delay = await aioping.ping(URLs.site, family=socket.AddressFamily.AF_INET) * 1000
+            delay = await aioping.ping(URLs.site_api, family=socket.AddressFamily.AF_INET) * 1000
             site_ping = f"{delay:.{ROUND_LATENCY}f} ms"
 
         except TimeoutError:

--- a/config-default.yml
+++ b/config-default.yml
@@ -335,9 +335,10 @@ keys:
 urls:
     # PyDis site vars
     site:        &DOMAIN       "pythondiscord.com"
-    site_api:    &API    !JOIN ["api.", *DOMAIN]
+    site_api:    &API          "pydis-api.default.svc.cluster.local"
     site_paste:  &PASTE  !JOIN ["paste.", *DOMAIN]
     site_schema: &SCHEMA       "https://"
+    site_api_schema:           "http://"
     site_staff:  &STAFF  !JOIN ["staff.", *DOMAIN]
 
     paste_service:                      !JOIN [*SCHEMA, *PASTE, "/{key}"]

--- a/config-default.yml
+++ b/config-default.yml
@@ -336,9 +336,9 @@ urls:
     # PyDis site vars
     site:        &DOMAIN       "pythondiscord.com"
     site_api:    &API          "pydis-api.default.svc.cluster.local"
+    site_api_schema:           "http://"
     site_paste:  &PASTE  !JOIN ["paste.", *DOMAIN]
     site_schema: &SCHEMA       "https://"
-    site_api_schema:           "http://"
     site_staff:  &STAFF  !JOIN ["staff.", *DOMAIN]
 
     paste_service:                      !JOIN [*SCHEMA, *PASTE, "/{key}"]


### PR DESCRIPTION
Migrates away from the API fetching through Cloudflare to use cluster-local DNS and hit the Django service directly.

- Migrate API utilities to use internal DNS routing
- Migrate ping command to ping internal API
