### PR TITLE
Creation of the PyPi command.

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -246,13 +246,16 @@ class Colours(metaclass=YAMLGetter):
     section = "style"
     subsection = "colours"
 
+    blue: int
     bright_green: int
-    soft_green: int
-    soft_orange: int
-    soft_red: int
     orange: int
     pink: int
     purple: int
+    soft_green: int
+    soft_orange: int
+    soft_red: int
+    white: int
+    yellow: int
 
 
 class DuckPond(metaclass=YAMLGetter):

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -1,5 +1,6 @@
+import itertools
 import logging
-from random import choice
+import random
 
 from discord import Embed
 from discord.ext.commands import Cog, Context, command
@@ -8,7 +9,9 @@ from bot.bot import Bot
 from bot.constants import Colours, NEGATIVE_REPLIES
 
 URL = "https://pypi.org/pypi/{package}/json"
-FIELDS = ["author", "requires_python", "summary", "license"]
+FIELDS = ("author", "requires_python", "summary", "license")
+PYPI_ICON = "https://cdn.discordapp.com/emojis/766274397257334814.png"
+PYPI_COLOURS = itertools.cycle((Colours.yellow, Colours.blue, Colours.white))
 
 log = logging.getLogger(__name__)
 
@@ -21,8 +24,12 @@ class PyPi(Cog):
 
     @command(name="pypi", aliases=("package", "pack"))
     async def get_package_info(self, ctx: Context, package: str) -> None:
-        """Getting information about a specific package."""
-        embed = Embed(title=choice(NEGATIVE_REPLIES), colour=Colours.soft_red)
+        """Provide information about a specific package from PyPI."""
+        embed = Embed(
+            title=random.choice(NEGATIVE_REPLIES),
+            colour=Colours.soft_red
+        )
+        embed.set_thumbnail(url=PYPI_ICON)
 
         async with self.bot.http_session.get(URL.format(package=package)) as response:
             if response.status == 404:
@@ -34,7 +41,7 @@ class PyPi(Cog):
 
                 embed.title = f"{info['name']} v{info['version']}"
                 embed.url = info['package_url']
-                embed.colour = Colours.soft_green
+                embed.colour = next(PYPI_COLOURS)
 
                 for field in FIELDS:
                     # Field could be completely empty, in some cases can be a string with whitespaces, or None.

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -32,9 +32,9 @@ class PyPi(Cog):
                 response_json = await response.json()
                 info = response_json["info"]
 
-                embed.title = "Python Package Index"
+                embed.title = f"{info['name']} v{info['version']}"
+                embed.url = info['package_url']
                 embed.colour = Colours.soft_green
-                embed.description = f"[{info['name']} v{info['version']}]({info['package_url']})\n"
 
                 for field in FIELDS:
                     # Field could be completely empty, in some cases can be a string with whitespaces, or None.

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -1,10 +1,16 @@
+import logging
+from random import choice
+
 from discord import Embed
 from discord.ext.commands import Cog, Context, command
 
 from bot.bot import Bot
-from bot.constants import NEGATIVE_REPLIES
+from bot.constants import NEGATIVE_REPLIES, Colours
 
 URL = "https://pypi.org/pypi/{package}/json"
+FIELDS = ["author", "requires_python", "description", "license"]
+
+log = logging.getLogger(__name__)
 
 
 class PyPi(Cog):
@@ -16,16 +22,30 @@ class PyPi(Cog):
     @command(name="pypi", aliases=("package", "pack"))
     async def get_package_info(self, ctx: Context, package: str) -> None:
         """Getting information about a specific package."""
-        embed = Embed(title="PyPi package information")
+        embed = Embed(title=choice(NEGATIVE_REPLIES), colour=Colours.soft_red)
 
-        async with self.bot.http_session.get(URL.format(package_name=package)) as response:
+        async with self.bot.http_session.get(URL.format(package=package)) as response:
             if response.status == 404:
-                return await ctx.send(f"Package with name '{package}' could not be found.")
+                embed.description = f"Package could not be found."
+
             elif response.status == 200 and response.content_type == "application/json":
                 response_json = await response.json()
                 info = response_json["info"]
+
+                embed.title = "Python Package Index"
+                embed.colour = Colours.soft_green
+                embed.description = f"[{info['name']} v{info['version']}]({info['download_url']})\n"
+
+                for field in FIELDS:
+                    embed.add_field(
+                        name=field.replace("_", " ").title(),
+                        value=info[field],
+                        inline=False,
+                    )
+
             else:
-                return await ctx.send("There was an error when fetching your PyPi package.")
+                embed.description = "There was an error when fetching your PyPi package."
+                log.trace(f"Error when fetching PyPi package: {response.status}.")
 
         await ctx.send(embed=embed)
 

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -37,11 +37,11 @@ class PyPi(Cog):
                 embed.description = f"[{info['name']} v{info['version']}]({info['package_url']})\n"
 
                 for field in FIELDS:
-                    # Field could be completely empty, in some cases can be a string with whitespaces.
-                    if field_value := info[field].strip():
+                    # Field could be completely empty, in some cases can be a string with whitespaces, or None.
+                    if info[field] and not info[field].isspace():
                         embed.add_field(
                             name=field.replace("_", " ").title(),
-                            value=field_value,
+                            value=info[field],
                             inline=False,
                         )
 

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -1,0 +1,35 @@
+from discord import Embed
+from discord.ext.commands import Cog, Context, command
+
+from bot.bot import Bot
+from bot.constants import NEGATIVE_REPLIES
+
+URL = "https://pypi.org/pypi/{package}/json"
+
+
+class PyPi(Cog):
+    """Cog for getting information about PyPi packages."""
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @command(name="pypi", aliases=("package", "pack"))
+    async def get_package_info(self, ctx: Context, package: str) -> None:
+        """Getting information about a specific package."""
+        embed = Embed(title="PyPi package information")
+
+        async with self.bot.http_session.get(URL.format(package_name=package)) as response:
+            if response.status == 404:
+                return await ctx.send(f"Package with name '{package}' could not be found.")
+            elif response.status == 200 and response.content_type == "application/json":
+                response_json = await response.json()
+                info = response_json["info"]
+            else:
+                return await ctx.send("There was an error when fetching your PyPi package.")
+
+        await ctx.send(embed=embed)
+
+
+def setup(bot: Bot) -> None:
+    """Load the PyPi cog."""
+    bot.add_cog(PyPi(bot))

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -8,7 +8,7 @@ from bot.bot import Bot
 from bot.constants import Colours, NEGATIVE_REPLIES
 
 URL = "https://pypi.org/pypi/{package}/json"
-FIELDS = ["author", "requires_python", "description", "license"]
+FIELDS = ["author", "requires_python", "summary", "license"]
 
 log = logging.getLogger(__name__)
 
@@ -34,14 +34,15 @@ class PyPi(Cog):
 
                 embed.title = "Python Package Index"
                 embed.colour = Colours.soft_green
-                embed.description = f"[{info['name']} v{info['version']}]({info['download_url']})\n"
+                embed.description = f"[{info['name']} v{info['version']}]({info['package_url']})\n"
 
                 for field in FIELDS:
-                    embed.add_field(
-                        name=field.replace("_", " ").title(),
-                        value=info[field],
-                        inline=False,
-                    )
+                    if field_value := info[field]:
+                        embed.add_field(
+                            name=field.replace("_", " ").title(),
+                            value=field_value,
+                            inline=False,
+                        )
 
             else:
                 embed.description = "There was an error when fetching your PyPi package."

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -37,7 +37,8 @@ class PyPi(Cog):
                 embed.description = f"[{info['name']} v{info['version']}]({info['package_url']})\n"
 
                 for field in FIELDS:
-                    if field_value := info[field]:
+                    # Field could be completely empty, in some cases can be a string with whitespaces.
+                    if field_value := info[field].strip():
                         embed.add_field(
                             name=field.replace("_", " ").title(),
                             value=field_value,

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -5,7 +5,7 @@ from discord import Embed
 from discord.ext.commands import Cog, Context, command
 
 from bot.bot import Bot
-from bot.constants import NEGATIVE_REPLIES, Colours
+from bot.constants import Colours, NEGATIVE_REPLIES
 
 URL = "https://pypi.org/pypi/{package}/json"
 FIELDS = ["author", "requires_python", "description", "license"]
@@ -26,7 +26,7 @@ class PyPi(Cog):
 
         async with self.bot.http_session.get(URL.format(package=package)) as response:
             if response.status == 404:
-                embed.description = f"Package could not be found."
+                embed.description = "Package could not be found."
 
             elif response.status == 200 and response.content_type == "application/json":
                 response_json = await response.json()

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -44,11 +44,16 @@ class PyPi(Cog):
                 embed.colour = next(PYPI_COLOURS)
 
                 for field in FIELDS:
+                    field_data = info[field]
+
                     # Field could be completely empty, in some cases can be a string with whitespaces, or None.
-                    if info[field] and not info[field].isspace():
+                    if field_data and not field_data.isspace():
+                        if '\n' in field_data and field == "license":
+                            field_data = field_data.split('\n')[0]
+
                         embed.add_field(
                             name=field.replace("_", " ").title(),
-                            value=info[field],
+                            value=field_data,
                             inline=False,
                         )
 

--- a/config-default.yml
+++ b/config-default.yml
@@ -24,13 +24,16 @@ bot:
 
 style:
     colours:
+        blue: 0x3775a8
         bright_green: 0x01d277
-        soft_green: 0x68c290
-        soft_orange: 0xf9cb54
-        soft_red: 0xcd6d6d
         orange: 0xe67e22
         pink: 0xcf84e0
         purple: 0xb734eb
+        soft_green: 0x68c290
+        soft_orange: 0xf9cb54
+        soft_red: 0xcd6d6d
+        white: 0xfffffe
+        yellow: 0xffd241
 
     emojis:
         badge_bug_hunter: "<:bug_hunter_lvl1:743882896372269137>"


### PR DESCRIPTION
Closes #796, rewrite of #1237.

Fetches information of PyPi packages and displays said information to the user in a neat embed.

Embed color rotates through yellow, blue, and white. 

Finding a package:
![image](https://user-images.githubusercontent.com/15021300/107823675-00db5300-6d35-11eb-9d94-7626c9903de5.png)

Attempting to find something that doesn't exist:
![image](https://user-images.githubusercontent.com/15021300/107823710-0df84200-6d35-11eb-93fb-b8080e5e1bd2.png)