### PR TITLE
Move Git SHA defining at end of Dockerfile to re-enable caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,10 @@
 FROM python:3.8-slim
 
-# Define Git SHA build argument
-ARG git_sha="development"
-
 # Set pip to have cleaner logs and no saved cache
 ENV PIP_NO_CACHE_DIR=false \
     PIPENV_HIDE_EMOJIS=1 \
     PIPENV_IGNORE_VIRTUALENVS=1 \
-    PIPENV_NOSPIN=1 \
-    GIT_SHA=$git_sha
+    PIPENV_NOSPIN=1
 
 RUN apt-get -y update \
     && apt-get install -y \
@@ -24,6 +20,12 @@ WORKDIR /bot
 # Install project dependencies
 COPY Pipfile* ./
 RUN pipenv install --system --deploy
+
+# Define Git SHA build argument
+ARG git_sha="development"
+
+# Set Git SHA environment variable here to enable caching
+ENV GIT_SHA=$git_sha
 
 # Copy the source code in last to optimize rebuilding the image
 COPY . .


### PR DESCRIPTION
Defining SHA at the beginning of build breaks caching, so this should be avoided.