### PR TITLE
Escaping markdown in the PyPi embed.

### DIFF
--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -7,6 +7,7 @@ from discord.ext.commands import Cog, Context, command
 
 from bot.bot import Bot
 from bot.constants import Colours, NEGATIVE_REPLIES
+from discord.utils import escape_markdown
 
 URL = "https://pypi.org/pypi/{package}/json"
 FIELDS = ("author", "requires_python", "summary", "license")
@@ -53,7 +54,7 @@ class PyPi(Cog):
 
                         embed.add_field(
                             name=field.replace("_", " ").title(),
-                            value=field_data,
+                            value=escape_markdown(field_data),
                             inline=False,
                         )
 

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -4,10 +4,10 @@ import random
 
 from discord import Embed
 from discord.ext.commands import Cog, Context, command
+from discord.utils import escape_markdown
 
 from bot.bot import Bot
 from bot.constants import Colours, NEGATIVE_REPLIES
-from discord.utils import escape_markdown
 
 URL = "https://pypi.org/pypi/{package}/json"
 FIELDS = ("author", "requires_python", "summary", "license")


### PR DESCRIPTION
Removes the possibility of markdown being rendered within an embed for the PyPi command.

Before:
![image](https://user-images.githubusercontent.com/15021300/107845672-29de0100-6d92-11eb-8ac2-bbf0e610f5ad.png)

After:
![image](https://user-images.githubusercontent.com/15021300/107845668-1894f480-6d92-11eb-9522-3f73323391a5.png)