### PR TITLE
pep 8 and inline-codeblock tag updates

### DIFF
--- a/bot/resources/tags/inline.md
+++ b/bot/resources/tags/inline.md
@@ -1,16 +1,7 @@
 **Inline codeblocks**
 
-In addition to multi-line codeblocks, discord has support for inline codeblocks as well. These are small codeblocks that are usually a single line, that can fit between non-codeblocks on the same line.
+Inline codeblocks look `like this`. To create them you surround text with single backticks, so \`hello\` would become `hello`.
 
-The following is an example of how it's done:
+Note that backticks are not quotes, see [this](https://superuser.com/questions/254076/how-do-i-type-the-tick-and-backtick-characters-on-windows/254077#254077) if you are struggling to find the backtick key.
 
-The \`\_\_init\_\_\` method customizes the newly created instance.
-
-And results in the following:
-
-The `__init__` method customizes the newly created instance.
-
-**Note:**  
-• These are **backticks** not quotes  
-• Avoid using them for multiple lines  
-• Useful for negating formatting you don't want
+For how to make multiline codeblocks see the `!codeblock` tag.

--- a/bot/resources/tags/pep8.md
+++ b/bot/resources/tags/pep8.md
@@ -1,3 +1,5 @@
-**PEP 8** is the official style guide for Python. It includes comprehensive guidelines for code formatting, variable naming, and making your code easy to read. Professional Python developers are usually required to follow the guidelines, and will often use code-linters like `flake8` to verify that the code they\'re writing complies with the style guide.
+**PEP 8** is the official style guide for Python. It includes comprehensive guidelines for code formatting, variable naming, and making your code easy to read. Professional Python developers are usually required to follow the guidelines, and will often use code-linters like flake8 to verify that the code they're writing complies with the style guide.
 
-You can find the PEP 8 document [here](https://www.python.org/dev/peps/pep-0008).
+More information:
+• [PEP 8 document](https://www.python.org/dev/peps/pep-0008)
+• [Our PEP 8 song!](https://www.youtube.com/watch?v=hgI0p1zf31k) :notes:


### PR DESCRIPTION
Rewrote the inline tag as it was unnecessarily long, and added the pep 8 song to the pep 8 tag.
Inline tag now looks like this:
![image](https://user-images.githubusercontent.com/22353562/108703661-d04ca380-7502-11eb-838a-afe951cc0906.png)

Pep 8 tag now looks like this:
![image](https://user-images.githubusercontent.com/22353562/108703764-f83c0700-7502-11eb-98c6-bb223df3532e.png)
