### PR TITLE
DM on open help channel

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -326,6 +326,7 @@ class Icons(metaclass=YAMLGetter):
     filtering: str
 
     green_checkmark: str
+    green_questionmark: str
     guild_update: str
 
     hash_blurple: str

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -102,6 +102,7 @@ class HelpChannels(commands.Cog):
         await _cooldown.revoke_send_permissions(message.author, self.scheduler)
 
         await _message.pin(message)
+        await _message.dm_on_open(message)
 
         # Add user with channel for dormant check.
         await _caches.claimants.set(message.channel.id, message.author.id)

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -111,7 +111,7 @@ async def dm_on_open(message: discord.Message) -> None:
         name="Your message", value=truncate_message(message, limit=100), inline=False
     )
     embed.add_field(
-        name="Want to go there?",
+        name="Conversation",
         value=f"[Jump to message!]({message.jump_url})",
         inline=False,
     )

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -8,6 +8,7 @@ import bot
 from bot import constants
 from bot.exts.help_channels import _caches
 from bot.utils.channel import is_in_category
+from bot.utils.messages import truncate_message
 
 log = logging.getLogger(__name__)
 
@@ -90,6 +91,38 @@ async def is_empty(channel: discord.TextChannel) -> bool:
             return True
 
     return False
+
+
+async def dm_on_open(message: discord.Message) -> None:
+    """
+    DM claimant with a link to the claimed channel's first message, with a 100 letter preview of the message.
+
+    Does nothing if the user has DMs disabled.
+    """
+    embed = discord.Embed(
+        title="Help channel opened",
+        description=f"You claimed {message.channel.mention}.",
+        colour=bot.constants.Colours.bright_green,
+        timestamp=message.created_at,
+    )
+
+    embed.set_thumbnail(url=constants.Icons.green_questionmark)
+    embed.add_field(
+        name="Your message", value=truncate_message(message, limit=100), inline=False
+    )
+    embed.add_field(
+        name="Want to go there?",
+        value=f"[Jump to message!]({message.jump_url})",
+        inline=False,
+    )
+
+    try:
+        await message.author.send(embed=embed)
+        log.trace(f"Sent DM to {message.author.id} after claiming help channel.")
+    except discord.errors.Forbidden:
+        log.trace(
+            f"Ignoring to send DM to {message.author.id} after claiming help channel: DMs disabled."
+        )
 
 
 async def notify(channel: discord.TextChannel, last_notification: t.Optional[datetime]) -> t.Optional[datetime]:

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -1,4 +1,5 @@
 import logging
+import textwrap
 import typing as t
 from datetime import datetime
 
@@ -8,7 +9,6 @@ import bot
 from bot import constants
 from bot.exts.help_channels import _caches
 from bot.utils.channel import is_in_category
-from bot.utils.messages import truncate_message
 
 log = logging.getLogger(__name__)
 
@@ -108,7 +108,9 @@ async def dm_on_open(message: discord.Message) -> None:
 
     embed.set_thumbnail(url=constants.Icons.green_questionmark)
     embed.add_field(
-        name="Your message", value=truncate_message(message, limit=100), inline=False
+        name="Your message",
+        value=textwrap.shorten(message.content, width=100, placeholder="..."),
+        inline=False,
     )
     embed.add_field(
         name="Conversation",

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -154,12 +154,3 @@ async def send_denial(ctx: Context, reason: str) -> None:
 def format_user(user: discord.abc.User) -> str:
     """Return a string for `user` which has their mention and ID."""
     return f"{user.mention} (`{user.id}`)"
-
-
-def truncate_message(message: discord.Message, limit: int) -> str:
-    """Returns a truncated version of the message content, up to the specified limit."""
-    text = message.content
-    if len(text) > limit:
-        return text[:limit-3] + "..."
-    else:
-        return text

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -154,3 +154,12 @@ async def send_denial(ctx: Context, reason: str) -> None:
 def format_user(user: discord.abc.User) -> str:
     """Return a string for `user` which has their mention and ID."""
     return f"{user.mention} (`{user.id}`)"
+
+
+def truncate_message(message: discord.Message, limit: int) -> str:
+    """Returns a truncated version of the message content, up to the specified limit."""
+    text = message.content
+    if len(text) > limit:
+        return text[:limit-3] + "..."
+    else:
+        return text

--- a/config-default.yml
+++ b/config-default.yml
@@ -90,6 +90,7 @@ style:
         filtering: "https://cdn.discordapp.com/emojis/472472638594482195.png"
 
         green_checkmark: "https://raw.githubusercontent.com/python-discord/branding/master/icons/checkmark/green-checkmark-dist.png"
+        green_questionmark: "https://raw.githubusercontent.com/python-discord/branding/master/icons/checkmark/green-question-mark-dist.png"
         guild_update: "https://cdn.discordapp.com/emojis/469954765141442561.png"
 
         hash_blurple: "https://cdn.discordapp.com/emojis/469950142942806017.png"


### PR DESCRIPTION
Closes #1174.

This PR introduces a feature that will DM users when they claim help channels, with links to the original message and more. It looks like this:
<img width="590" alt="Screenshot 2021-02-23 at 04 14 17" src="https://user-images.githubusercontent.com/65498475/108798228-9aa0cc80-758d-11eb-9fc6-3341bb5f61f3.png">

This also introduces a new message truncation feature, that we can use whenever the content of a message needs to be truncated to a certain length. The bot simply ignores to send a DM if the claimant's DMs aren't open.

## Before merging
The thumbnail icon is currently waiting to get merged into master on the branding repo. Please have a look at python-discord/branding#121 and merge it as soon as possible. That PR needs to be merged in order for the icon to be accessed by the bot.