### PR TITLE
Send command help for BadUnionArgument errors

### DIFF
--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -244,6 +244,7 @@ class ErrorHandler(Cog):
         elif isinstance(e, errors.ArgumentParsingError):
             embed = self._get_error_embed("Argument parsing error", str(e))
             await ctx.send(embed=embed)
+            prepared_help_command.close()
             self.bot.stats.incr("errors.argument_parsing_error")
         else:
             embed = self._get_error_embed(

--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -239,6 +239,7 @@ class ErrorHandler(Cog):
         elif isinstance(e, errors.BadUnionArgument):
             embed = self._get_error_embed("Bad argument", f"{e}\n{e.errors[-1]}")
             await ctx.send(embed=embed)
+            await prepared_help_command
             self.bot.stats.incr("errors.bad_union_argument")
         elif isinstance(e, errors.ArgumentParsingError):
             embed = self._get_error_embed("Argument parsing error", str(e))


### PR DESCRIPTION
Currently the bot only sends the error embed when a BadUnionArgument or ArgumentParsingError occurs, unlike all the other handled exceptions which send the help for the command. 
The PR adds sending the help under the BadUnionArgument error. 
For ArgumentParsingError I've decided to only close the coroutine, as the error fails on the user's formatting and occurs regardless of the user passing in the expected args or not