### PR TITLE
Helpful Startup Errors

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -15,7 +15,7 @@ try:
     bot.instance.run(constants.Bot.token)
 except StartupError as e:
     message = "Unknown Startup Error Occurred."
-    if isinstance(e.exception, aiohttp.ClientConnectorError):
+    if type(e.exception) in [aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError]:
         message = "Could not connect to site API. Is it running?"
     elif isinstance(e.exception, OSError):
         message = "Could not connect to Redis. Is it running?"

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -15,7 +15,7 @@ try:
     bot.instance.run(constants.Bot.token)
 except StartupError as e:
     message = "Unknown Startup Error Occurred."
-    if type(e.exception) in [aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError]:
+    if isinstance(e.exception, (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError)):
         message = "Could not connect to site API. Is it running?"
     elif isinstance(e.exception, OSError):
         message = "Could not connect to Redis. Is it running?"
@@ -24,3 +24,5 @@ except StartupError as e:
     log = logging.getLogger("bot")
     log.fatal("", exc_info=e.exception)
     log.fatal(message)
+
+    exit(69)

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,10 +1,26 @@
+import logging
+
+import aiohttp
+
 import bot
 from bot import constants
-from bot.bot import Bot
+from bot.bot import Bot, StartupError
 from bot.log import setup_sentry
 
 setup_sentry()
 
-bot.instance = Bot.create()
-bot.instance.load_extensions()
-bot.instance.run(constants.Bot.token)
+try:
+    bot.instance = Bot.create()
+    bot.instance.load_extensions()
+    bot.instance.run(constants.Bot.token)
+except StartupError as e:
+    message = "Unknown Startup Error Occurred."
+    if isinstance(e.exception, aiohttp.ClientConnectorError):
+        message = "Could not connect to site API. Is it running?"
+    elif isinstance(e.exception, OSError):
+        message = "Could not connect to Redis. Is it running?"
+
+    # The exception is logged with an empty message so the actual message is visible at the bottom
+    log = logging.getLogger("bot")
+    log.fatal("", exc_info=e.exception)
+    log.fatal(message)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -23,7 +23,7 @@ class StartupError(Exception):
     """Exception class for startup errors."""
 
     def __init__(self, base: Exception):
-        super()
+        super().__init__()
         self.exception = base
 
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -102,7 +102,7 @@ class Bot(commands.Bot):
             except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError) as e:
                 attempts += 1
                 if attempts == constants.URLs.connect_max_retries:
-                    raise e
+                    raise
                 await asyncio.sleep(constants.URLs.connect_cooldown)
 
     @classmethod

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -99,7 +99,7 @@ class Bot(commands.Bot):
                 await self.api_client.get("healthcheck")
                 break
 
-            except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError) as e:
+            except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError):
                 attempts += 1
                 if attempts == constants.URLs.connect_max_retries:
                     raise

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -99,7 +99,7 @@ class Bot(commands.Bot):
                 await self.api_client.get("healthcheck")
                 break
 
-            except aiohttp.ClientConnectorError as e:
+            except (aiohttp.ClientConnectorError, aiohttp.ServerDisconnectedError) as e:
                 attempts += 1
                 if attempts == constants.URLs.connect_max_retries:
                     raise e

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -19,6 +19,14 @@ log = logging.getLogger('bot')
 LOCALHOST = "127.0.0.1"
 
 
+class StartupError(Exception):
+    """Exception class for startup errors."""
+
+    def __init__(self, base: Exception):
+        super()
+        self.exception = base
+
+
 class Bot(commands.Bot):
     """A subclass of `discord.ext.commands.Bot` with an aiohttp session and an API client."""
 
@@ -318,5 +326,8 @@ def _create_redis_session(loop: asyncio.AbstractEventLoop) -> RedisSession:
         use_fakeredis=constants.Redis.use_fakeredis,
         global_namespace="bot",
     )
-    loop.run_until_complete(redis_session.connect())
+    try:
+        loop.run_until_complete(redis_session.connect())
+    except OSError as e:
+        raise StartupError(e)
     return redis_session

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -531,6 +531,8 @@ class URLs(metaclass=YAMLGetter):
     github_bot_repo: str
 
     # Base site vars
+    connect_max_retries: int
+    connect_cooldown: int
     site: str
     site_api: str
     site_schema: str

--- a/config-default.yml
+++ b/config-default.yml
@@ -338,6 +338,8 @@ keys:
 
 urls:
     # PyDis site vars
+    connect_max_retries:       3
+    connect_cooldown:          5
     site:        &DOMAIN       "pythondiscord.com"
     site_api:    &API          "pydis-api.default.svc.cluster.local"
     site_api_schema:           "http://"


### PR DESCRIPTION
# Description
One of the biggest hurdles that people face when setting up the bot, is the lack of helpful information when things go wrong. From redis, to the API, plenty can go wrong, and it requires experience to read the traceback and figure out why.

Closes #1349.

# Inspiration
This PR aims to take a step in fixing that, by offering more descriptive errors on startup. This is inspired by #1385, but only covers a portion of the proposed changes.

# Implementation
This PR does two things:
1. It logs a message for redis and API errors, so we don't keep getting confused people asking why they got a 100 line traceback when they hit run.
2. It adds retries to site connection, so it solves the problem of the bot trying to connect to the site before it warms up in docker. (Right now that is at 3 attempts with 5 seconds between each).
