### PR TITLE
Make "event" plural in socketstats embed

### DIFF
--- a/bot/exts/utils/internal.py
+++ b/bot/exts/utils/internal.py
@@ -240,7 +240,7 @@ async def func():  # (None,) -> Any
 
         stats_embed = discord.Embed(
             title="WebSocket statistics",
-            description=f"Receiving {per_s:0.2f} event per second.",
+            description=f"Receiving {per_s:0.2f} events per second.",
             color=discord.Color.blurple()
         )
 


### PR DESCRIPTION
This is how the socketstats embed previously looked:
<img width="225" alt="Screenshot 2021-02-26 at 22 25 04" src="https://user-images.githubusercontent.com/65498475/109356776-7a208d00-7881-11eb-9c89-fde0e6e70c8a.png">

This is how it looks now:
<img width="223" alt="Screenshot 2021-02-26 at 22 26 55" src="https://user-images.githubusercontent.com/65498475/109356973-bce26500-7881-11eb-9bc6-89f1d706b5b4.png">

Notice the new "s"? Yep, events is now plural.