### PR TITLE
Add a tag to explain a common error with substituting `=` and `==`.

### DIFF
--- a/bot/resources/tags/comparison.md
+++ b/bot/resources/tags/comparison.md
@@ -1,0 +1,12 @@
+**Assignment vs. Comparison**
+
+The assignment operator (`=`) is used to assign variables.
+```python
+x = 5
+print(x)  # Prints 5
+```
+The equality operator (`==`) is used to compare values.
+```python
+if x == 5:
+    print("The value of x is 5")
+```


### PR DESCRIPTION
Title is self explanatory, I think.