### PR TITLE
Migrate talentpool to new API schema

### DIFF
--- a/bot/exts/moderation/watchchannels/_watchchannel.py
+++ b/bot/exts/moderation/watchchannels/_watchchannel.py
@@ -47,7 +47,9 @@ class WatchChannel(metaclass=CogABCMeta):
         webhook_id: int,
         api_endpoint: str,
         api_default_params: dict,
-        logger: logging.Logger
+        logger: logging.Logger,
+        *,
+        disable_header: bool = False
     ) -> None:
         self.bot = bot
 
@@ -66,6 +68,7 @@ class WatchChannel(metaclass=CogABCMeta):
         self.channel = None
         self.webhook = None
         self.message_history = MessageHistory()
+        self.disable_header = disable_header
 
         self._start = self.bot.loop.create_task(self.start_watchchannel())
 
@@ -267,6 +270,9 @@ class WatchChannel(metaclass=CogABCMeta):
 
     async def send_header(self, msg: Message) -> None:
         """Sends a header embed with information about the relayed messages to the watch channel."""
+        if self.disable_header:
+            return
+
         user_id = msg.author.id
 
         guild = self.bot.get_guild(GuildConfig.id)

--- a/bot/exts/moderation/watchchannels/talentpool.py
+++ b/bot/exts/moderation/watchchannels/talentpool.py
@@ -121,7 +121,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
         )
 
         if history:
-            msg += f"\n\n{len(history)} previous nominations in total"
+            msg += f"\n\n({len(history)} previous nominations in total)"
 
         await ctx.send(msg)
 

--- a/bot/exts/moderation/watchchannels/talentpool.py
+++ b/bot/exts/moderation/watchchannels/talentpool.py
@@ -14,6 +14,8 @@ from bot.exts.moderation.watchchannels._watchchannel import WatchChannel
 from bot.pagination import LinePaginator
 from bot.utils import time
 
+REASON_MAX_CHARS = 1000
+
 log = logging.getLogger(__name__)
 
 
@@ -82,6 +84,10 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
 
         if not await self.fetch_user_cache():
             await ctx.send(f":x: Failed to update the user cache; can't add {user}")
+            return
+
+        if len(reason) > REASON_MAX_CHARS:
+            await ctx.send(f":x: Maxiumum allowed characters for the reason is {REASON_MAX_CHARS}.")
             return
 
         # Manual request with `raise_for_status` as False because we want the actual response
@@ -162,6 +168,10 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
 
         Providing a `reason` is required.
         """
+        if len(reason) > REASON_MAX_CHARS:
+            await ctx.send(f":x: Maxiumum allowed characters for the end reason is {REASON_MAX_CHARS}.")
+            return
+
         if await self.unwatch(user.id, reason):
             await ctx.send(f":white_check_mark: Messages sent by {user} will no longer be relayed")
         else:
@@ -177,6 +187,10 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
     @has_any_role(*MODERATION_ROLES)
     async def edit_reason_command(self, ctx: Context, nomination_id: int, actor: FetchedMember, *, reason: str) -> None:
         """Edits the reason of a specific nominator in a specific active nomination."""
+        if len(reason) > REASON_MAX_CHARS:
+            await ctx.send(f":x: Maxiumum allowed characters for the reason is {REASON_MAX_CHARS}.")
+            return
+
         try:
             nomination = await self.bot.api_client.get(f"{self.api_endpoint}/{nomination_id}")
         except ResponseCodeError as e:
@@ -208,6 +222,10 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
     @has_any_role(*MODERATION_ROLES)
     async def edit_end_reason_command(self, ctx: Context, nomination_id: int, *, reason: str) -> None:
         """Edits the unnominate reason for the nomination with the given `id`."""
+        if len(reason) > REASON_MAX_CHARS:
+            await ctx.send(f":x: Maxiumum allowed characters for the end reason is {REASON_MAX_CHARS}.")
+            return
+
         try:
             nomination = await self.bot.api_client.get(f"{self.api_endpoint}/{nomination_id}")
         except ResponseCodeError as e:
@@ -269,7 +287,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
             actor_id = site_entry["actor"]
             actor = guild.get_member(actor_id)
 
-            reason = textwrap.shorten(site_entry["reason"], 1000, placeholder="...") or "*None*"
+            reason = site_entry["reason"] or "*None*"
             created = time.format_infraction(site_entry["inserted_at"])
             entries.append(
                 f"Actor: {actor.mention if actor else actor_id}\nCreated: {created}\nReason: {reason}"

--- a/bot/exts/moderation/watchchannels/talentpool.py
+++ b/bot/exts/moderation/watchchannels/talentpool.py
@@ -269,7 +269,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
             actor_id = site_entry["actor"]
             actor = guild.get_member(actor_id)
 
-            reason = site_entry["reason"] or "*None*"
+            reason = textwrap.shorten(site_entry["reason"], 1000, placeholder="...") or "*None*"
             created = time.format_infraction(site_entry["inserted_at"])
             entries.append(
                 f"Actor: {actor.mention if actor else actor_id}\nCreated: {created}\nReason: {reason}"

--- a/bot/exts/moderation/watchchannels/talentpool.py
+++ b/bot/exts/moderation/watchchannels/talentpool.py
@@ -109,7 +109,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
                 resp.raise_for_status()
 
         self.watched_users[user.id] = response_data
-        msg = f":white_check_mark: Messages sent by {user} will now be relayed to the talent pool channel"
+        msg = f":white_check_mark: The nomination for {user} has been added to the talent pool"
 
         history = await self.bot.api_client.get(
             self.api_endpoint,

--- a/bot/exts/moderation/watchchannels/talentpool.py
+++ b/bot/exts/moderation/watchchannels/talentpool.py
@@ -102,7 +102,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
                 if response_data.get('user', False):
                     await ctx.send(":x: The specified user can't be found in the database tables")
                 elif response_data.get('actor', False):
-                    await ctx.send(":x: You already have nominated this user")
+                    await ctx.send(":x: You have already nominated this user")
 
                 return
             else:
@@ -176,7 +176,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
     @nomination_edit_group.command(name='reason')
     @has_any_role(*MODERATION_ROLES)
     async def edit_reason_command(self, ctx: Context, nomination_id: int, actor: FetchedMember, *, reason: str) -> None:
-        """Edits the reason of `actor` entry for the nomination with the given `id`."""
+        """Edits the reason of a specific nominator in a specific active nomination."""
         try:
             nomination = await self.bot.api_client.get(f"{self.api_endpoint}/{nomination_id}")
         except ResponseCodeError as e:
@@ -188,21 +188,21 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
                 raise
 
         if not nomination["active"]:
-            await ctx.send(":x: Can't edit reason of ended nomination.")
+            await ctx.send(":x: Can't edit the reason of an inactive nomination.")
             return
 
         if not any(entry["actor"] == actor.id for entry in nomination["entries"]):
-            await ctx.send(f":x: {actor} don't have entry for this nomination.")
+            await ctx.send(f":x: {actor} doesn't have an entry in this nomination.")
             return
 
-        self.log.trace(f"Changing reason for nomination with id {nomination_id} of actor {actor} to {reason}")
+        self.log.trace(f"Changing reason for nomination with id {nomination_id} of actor {actor} to {repr(reason)}")
 
         await self.bot.api_client.patch(
             f"{self.api_endpoint}/{nomination_id}",
             json={"actor": actor.id, "reason": reason}
         )
         await self.fetch_user_cache()  # Update cache
-        await ctx.send(":white_check_mark: Successfully updates reason of nomination.")
+        await ctx.send(":white_check_mark: Successfully updated nomination reason.")
 
     @nomination_edit_group.command(name='end_reason')
     @has_any_role(*MODERATION_ROLES)
@@ -219,10 +219,10 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
                 raise
 
         if nomination["active"]:
-            await ctx.send(":x: Cannot edit end reason of active nomination.")
+            await ctx.send(":x: Can't edit the end reason of an active nomination.")
             return
 
-        self.log.trace(f"Changing end reason for nomination with id {nomination_id} to {reason}")
+        self.log.trace(f"Changing end reason for nomination with id {nomination_id} to {repr(reason)}")
 
         await self.bot.api_client.patch(
             f"{self.api_endpoint}/{nomination_id}",

--- a/bot/exts/moderation/watchchannels/talentpool.py
+++ b/bot/exts/moderation/watchchannels/talentpool.py
@@ -181,7 +181,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
             nomination = await self.bot.api_client.get(f"{self.api_endpoint}/{nomination_id}")
         except ResponseCodeError as e:
             if e.response.status == 404:
-                self.log.trace(f"Nomination API 404: Can't nomination with id {nomination_id}")
+                self.log.trace(f"Nomination API 404: Can't find a nomination with id {nomination_id}")
                 await ctx.send(f":x: Can't find a nomination with id `{nomination_id}`")
                 return
             else:
@@ -212,7 +212,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
             nomination = await self.bot.api_client.get(f"{self.api_endpoint}/{nomination_id}")
         except ResponseCodeError as e:
             if e.response.status == 404:
-                self.log.trace(f"Nomination API 404: Can't nomination with id {nomination_id}")
+                self.log.trace(f"Nomination API 404: Can't find a nomination with id {nomination_id}")
                 await ctx.send(f":x: Can't find a nomination with id `{nomination_id}`")
                 return
             else:

--- a/bot/exts/moderation/watchchannels/talentpool.py
+++ b/bot/exts/moderation/watchchannels/talentpool.py
@@ -271,7 +271,9 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
 
             reason = site_entry["reason"] or "*None*"
             created = time.format_infraction(site_entry["inserted_at"])
-            entries.append(f"Actor: {actor or actor_id}\nReason: {reason}\nCreated: {created}")
+            entries.append(
+                f"Actor: {actor.mention if actor else actor_id}\nReason: {reason}\nCreated: {created}"
+            )
 
         entries_string = "\n\n".join(entries)
 

--- a/bot/exts/moderation/watchchannels/talentpool.py
+++ b/bot/exts/moderation/watchchannels/talentpool.py
@@ -272,7 +272,7 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
             reason = site_entry["reason"] or "*None*"
             created = time.format_infraction(site_entry["inserted_at"])
             entries.append(
-                f"Actor: {actor.mention if actor else actor_id}\nReason: {reason}\nCreated: {created}"
+                f"Actor: {actor.mention if actor else actor_id}\nCreated: {created}\nReason: {reason}"
             )
 
         entries_string = "\n\n".join(entries)
@@ -299,12 +299,12 @@ class TalentPool(WatchChannel, Cog, name="Talentpool"):
                 ===============
                 Status: Inactive
                 Date: {start_date}
+                Nomination ID: `{nomination_object["id"]}`
 
                 {entries_string}
 
                 End date: {end_date}
                 Unwatch reason: {nomination_object["end_reason"]}
-                Nomination ID: `{nomination_object["id"]}`
                 ===============
                 """
             )


### PR DESCRIPTION
**Note: This has to be merged exactly same time than python-discord/site#447**

Migrates talent pool to the new system. More exact changes are in the commit message body.

Closes #1425 
