### PR TITLE
Remove invoked command and message after failure.

### DIFF
--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -8,7 +8,7 @@ from discord.ext.commands import Cog, Context, command
 from discord.utils import escape_markdown
 
 from bot.bot import Bot
-from bot.constants import Colours, NEGATIVE_REPLIES
+from bot.constants import Colours, NEGATIVE_REPLIES, RedirectOutput
 
 URL = "https://pypi.org/pypi/{package}/json"
 FIELDS = ("author", "requires_python", "summary", "license")
@@ -17,6 +17,7 @@ PYPI_ICON = "https://cdn.discordapp.com/emojis/766274397257334814.png"
 PYPI_COLOURS = itertools.cycle((Colours.yellow, Colours.blue, Colours.white))
 
 ILLEGAL_CHARACTERS = re.compile(r"[^a-zA-Z0-9-.]+")
+INVALID_INPUT_DELETE_DELAY = RedirectOutput.delete_delay
 
 log = logging.getLogger(__name__)
 
@@ -36,42 +37,49 @@ class PyPi(Cog):
         )
         embed.set_thumbnail(url=PYPI_ICON)
 
+        error = True
+
         if (character := re.search(ILLEGAL_CHARACTERS, package)) is not None:
             embed.description = f"Illegal character passed into command: '{escape_markdown(character.group(0))}'"
+
+        else:
+            async with self.bot.http_session.get(URL.format(package=package)) as response:
+                if response.status == 404:
+                    embed.description = "Package could not be found."
+
+                elif response.status == 200 and response.content_type == "application/json":
+                    response_json = await response.json()
+                    info = response_json["info"]
+
+                    embed.title = f"{info['name']} v{info['version']}"
+                    embed.url = info['package_url']
+                    embed.colour = next(PYPI_COLOURS)
+
+                    for field in FIELDS:
+                        field_data = info[field]
+
+                        # Field could be completely empty, in some cases can be a string with whitespaces, or None.
+                        if field_data and not field_data.isspace():
+                            if '\n' in field_data and field == "license":
+                                field_data = field_data.split('\n')[0]
+
+                            embed.add_field(
+                                name=field.replace("_", " ").title(),
+                                value=escape_markdown(field_data),
+                                inline=False,
+                            )
+
+                    error = False
+
+                else:
+                    embed.description = "There was an error when fetching your PyPi package."
+                    log.trace(f"Error when fetching PyPi package: {response.status}.")
+
+        if error:
+            await ctx.send(embed=embed, delete_after=INVALID_INPUT_DELETE_DELAY)
+            await ctx.message.delete(delay=INVALID_INPUT_DELETE_DELAY)
+        else:
             await ctx.send(embed=embed)
-            return
-
-        async with self.bot.http_session.get(URL.format(package=package)) as response:
-            if response.status == 404:
-                embed.description = "Package could not be found."
-
-            elif response.status == 200 and response.content_type == "application/json":
-                response_json = await response.json()
-                info = response_json["info"]
-
-                embed.title = f"{info['name']} v{info['version']}"
-                embed.url = info['package_url']
-                embed.colour = next(PYPI_COLOURS)
-
-                for field in FIELDS:
-                    field_data = info[field]
-
-                    # Field could be completely empty, in some cases can be a string with whitespaces, or None.
-                    if field_data and not field_data.isspace():
-                        if '\n' in field_data and field == "license":
-                            field_data = field_data.split('\n')[0]
-
-                        embed.add_field(
-                            name=field.replace("_", " ").title(),
-                            value=escape_markdown(field_data),
-                            inline=False,
-                        )
-
-            else:
-                embed.description = "There was an error when fetching your PyPi package."
-                log.trace(f"Error when fetching PyPi package: {response.status}.")
-
-        await ctx.send(embed=embed)
 
 
 def setup(bot: Bot) -> None:


### PR DESCRIPTION
Closes #1443.

Removes the invoked command and any error embed the bot sent (from the `pypi` cog) after a constant amount of time that's set in the config.