### PR TITLE
Purge ban now shows that user was purge banned within infraction message.

### DIFF
--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -173,6 +173,8 @@ class InfractionScheduler:
             total = len(infractions)
             end_msg = f" (#{id_} ; {total} infraction{ngettext('', 's', total)} total)"
 
+        purge = infraction['purge']
+
         # Execute the necessary actions to apply the infraction on Discord.
         if action_coro:
             log.trace(f"Awaiting the infraction #{id_} application action coroutine.")
@@ -210,7 +212,7 @@ class InfractionScheduler:
                 log.error(f"Deletion of {infr_type} infraction #{id_} failed with error code {e.status}.")
             infr_message = ""
         else:
-            infr_message = f" **{' '.join(infr_type.split('_'))}** to {user.mention}{expiry_msg}{end_msg}"
+            infr_message = f" **{purge}{' '.join(infr_type.split('_'))}** to {user.mention}{expiry_msg}{end_msg}"
 
         # Send a confirmation message to the invoking context.
         log.trace(f"Sending infraction #{id_} confirmation message.")
@@ -234,7 +236,7 @@ class InfractionScheduler:
             footer=f"ID {infraction['id']}"
         )
 
-        log.info(f"Applied {infr_type} infraction #{id_} to {user}.")
+        log.info(f"Applied {purge}{infr_type} infraction #{id_} to {user}.")
         return not failed
 
     async def pardon_infraction(

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -318,6 +318,8 @@ class Infractions(InfractionScheduler, commands.Cog):
         if infraction is None:
             return
 
+        infraction["purge"] = "purge " if purge_days else ""
+
         self.mod_log.ignore(Event.member_remove, user.id)
 
         if reason:

--- a/tests/bot/exts/moderation/infraction/test_infractions.py
+++ b/tests/bot/exts/moderation/infraction/test_infractions.py
@@ -39,7 +39,7 @@ class TruncationTests(unittest.IsolatedAsyncioTestCase):
             delete_message_days=0
         )
         self.cog.apply_infraction.assert_awaited_once_with(
-            self.ctx, {"foo": "bar"}, self.target, self.ctx.guild.ban.return_value
+            self.ctx, {"foo": "bar", "purge": ""}, self.target, self.ctx.guild.ban.return_value
         )
 
     @patch("bot.exts.moderation.infraction._utils.post_infraction")


### PR DESCRIPTION
Closes #1412 

Just a small QOL change. When a user is purge banned, the feedback message shows that the purge was applied.

The difference between a regular ban and a purge ban:
![image](https://user-images.githubusercontent.com/15021300/110314397-a2fcfc80-7fbc-11eb-8209-e9f085eed888.png)