### PR TITLE
Allow the sf command to take more than one snowflake at the time

### DIFF
--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -2,7 +2,7 @@ import difflib
 import logging
 import re
 import unicodedata
-from typing import Tuple, Union, List
+from typing import Tuple, Union
 
 from discord import Colour, Embed, utils
 from discord.ext.commands import BadArgument, Cog, Context, clean_content, command, has_any_role
@@ -14,6 +14,7 @@ from bot.converters import Snowflake
 from bot.decorators import in_whitelist
 from bot.pagination import LinePaginator
 from bot.utils import messages
+from bot.utils.checks import has_no_roles_check
 from bot.utils.time import time_since
 
 log = logging.getLogger(__name__)
@@ -158,6 +159,9 @@ class Utils(Cog):
     @in_whitelist(channels=(Channels.bot_commands,), roles=STAFF_ROLES)
     async def snowflake(self, ctx: Context, *snowflakes: Snowflake) -> None:
         """Get Discord snowflake creation time."""
+        if len(snowflakes) > 1 and await has_no_roles_check(ctx, *STAFF_ROLES):
+            raise BadArgument("Cannot process more than one snowflake in one invocation.")
+
         for snowflake in snowflakes:
             created_at = snowflake_time(snowflake)
             embed = Embed(

--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -2,7 +2,7 @@ import difflib
 import logging
 import re
 import unicodedata
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 
 from discord import Colour, Embed, utils
 from discord.ext.commands import BadArgument, Cog, Context, clean_content, command, has_any_role
@@ -156,18 +156,19 @@ class Utils(Cog):
 
     @command(aliases=("snf", "snfl", "sf"))
     @in_whitelist(channels=(Channels.bot_commands,), roles=STAFF_ROLES)
-    async def snowflake(self, ctx: Context, snowflake: Snowflake) -> None:
+    async def snowflake(self, ctx: Context, *snowflakes: Snowflake) -> None:
         """Get Discord snowflake creation time."""
-        created_at = snowflake_time(snowflake)
-        embed = Embed(
-            description=f"**Created at {created_at}** ({time_since(created_at, max_units=3)}).",
-            colour=Colour.blue()
-        )
-        embed.set_author(
-            name=f"Snowflake: {snowflake}",
-            icon_url="https://github.com/twitter/twemoji/blob/master/assets/72x72/2744.png?raw=true"
-        )
-        await ctx.send(embed=embed)
+        for snowflake in snowflakes:
+            created_at = snowflake_time(snowflake)
+            embed = Embed(
+                description=f"**Created at {created_at}** ({time_since(created_at, max_units=3)}).",
+                colour=Colour.blue()
+            )
+            embed.set_author(
+                name=f"Snowflake: {snowflake}",
+                icon_url="https://github.com/twitter/twemoji/blob/master/assets/72x72/2744.png?raw=true"
+            )
+            await ctx.send(embed=embed)
 
     @command(aliases=("poll",))
     @has_any_role(*MODERATION_ROLES)


### PR DESCRIPTION
Here is how it looks with many snowflakes:

![image](https://user-images.githubusercontent.com/44778521/110350578-27d72d00-8034-11eb-94f5-0b16d193b9b8.png)

To avoid users making the bot hit ratelimits, it is still limited to one snowflake per invocation for non-staffers

![image](https://user-images.githubusercontent.com/44778521/110350770-56550800-8034-11eb-8104-88c425259c03.png)
