### PR TITLE
Use .gitattributes to normalise line endings on check-in

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,6 @@ repos:
       - id: check-yaml
         args: [--unsafe] # Required due to custom constructors (e.g. !ENV)
       - id: end-of-file-fixer
-      - id: mixed-line-ending
-        args: [--fix=lf]
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
   - repo: https://github.com/pre-commit/pygrep-hooks


### PR DESCRIPTION
Remove the mixed line endings pre-commit hook because it is obsolete.

Relying on git to handle line endings means contributors have more flexibility with which line endings they want to use on check-out. The settings in `.gitattributes` only impose which line endings will be used upon check-in (`LF`), which should not impact local development; git will still respect the `core.eol` and `core.autocrlf` settings.