### PR TITLE
Code block: remove null bytes before parsing AST

### DIFF
--- a/bot/exts/info/codeblock/_parsing.py
+++ b/bot/exts/info/codeblock/_parsing.py
@@ -103,6 +103,9 @@ def _is_python_code(content: str) -> bool:
     """Return True if `content` is valid Python consisting of more than just expressions."""
     log.trace("Checking if content is Python code.")
     try:
+        # Remove null bytes because they cause ast.parse to raise a ValueError.
+        content = content.replace("\x00", "")
+
         # Attempt to parse the message into an AST node.
         # Invalid Python code will raise a SyntaxError.
         tree = ast.parse(content)


### PR DESCRIPTION
`ast.parse` raises a ValueError complaining that source code strings cannot contain null bytes. It seems like they may accidentally get pasted into Discord by users sometimes. I couldn't manage to paste a null byte myself.

Fixes [BOT-XR](https://sentry.io/organizations/python-discord/issues/2273274549/)