### PR TITLE
Account for defcon threshold being None when displaying server info

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -64,7 +64,8 @@ class Information(Cog):
 
         defcon_info = ""
         if cog := self.bot.get_cog("Defcon"):
-            defcon_info = f"Defcon threshold: {humanize_delta(cog.threshold)}\n"
+            threshold = humanize_delta(cog.threshold) if cog.threshold else "-"
+            defcon_info = f"Defcon threshold: {threshold}\n"
 
         verification = f"Verification level: {ctx.guild.verification_level.name}\n"
 

--- a/bot/exts/moderation/defcon.py
+++ b/bot/exts/moderation/defcon.py
@@ -157,9 +157,9 @@ class Defcon(Cog):
 
         await ctx.send(embed=embed)
 
-    @defcon_group.command(aliases=('t', 'd'))
+    @defcon_group.command(name="threshold", aliases=('t', 'd'))
     @has_any_role(*MODERATION_ROLES)
-    async def threshold(
+    async def threshold_command(
         self, ctx: Context, threshold: Union[DurationDelta, int], expiry: Optional[Expiry] = None
     ) -> None:
         """


### PR DESCRIPTION
Fixes [BOT-XK](https://sentry.io/organizations/python-discord/issues/2264325856).