### PR TITLE
Update eval to use SIGTERM for killed processes

### DIFF
--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -43,7 +43,7 @@ EVAL_CHANNELS = (Channels.bot_commands, Channels.esoteric)
 EVAL_CATEGORIES = (Categories.help_available, Categories.help_in_use, Categories.voice)
 EVAL_ROLES = (Roles.helpers, Roles.moderators, Roles.admins, Roles.owners, Roles.python_community, Roles.partners)
 
-SIGKILL = 9
+SIGTERM = 15
 
 REEVAL_EMOJI = '\U0001f501'  # :repeat:
 REEVAL_TIMEOUT = 30
@@ -112,7 +112,7 @@ class Snekbox(Cog):
         if returncode is None:
             msg = "Your eval job has failed"
             error = stdout.strip()
-        elif returncode == 128 + SIGKILL:
+        elif returncode == 128 + SIGTERM:
             msg = "Your eval job timed out or ran out of memory"
         elif returncode == 255:
             msg = "Your eval job has failed"

--- a/tests/bot/exts/utils/test_snekbox.py
+++ b/tests/bot/exts/utils/test_snekbox.py
@@ -66,7 +66,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         """Return error and message according to the eval result."""
         cases = (
             ('ERROR', None, ('Your eval job has failed', 'ERROR')),
-            ('', 128 + snekbox.SIGKILL, ('Your eval job timed out or ran out of memory', '')),
+            ('', 128 + snekbox.SIGTERM, ('Your eval job timed out or ran out of memory', '')),
             ('', 255, ('Your eval job has failed', 'A fatal NsJail error occurred'))
         )
         for stdout, returncode, expected in cases:


### PR DESCRIPTION
Due to a recent change in snekbox (https://github.com/python-discord/snekbox/pull/96) processes killed by cgroup limits will use SIGTERM instead of SIGKILL. This commit account for this change by updating the numerical value to 15 (SIGTERM portable value).