### PR TITLE
Filter codeblock escapes and allow no mentions for !raw command

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from typing import Any, DefaultDict, Dict, Mapping, Optional, Tuple, Union
 
 import fuzzywuzzy
-from discord import Colour, Embed, Guild, Message, Role
+from discord import AllowedMentions, Colour, Embed, Guild, Message, Role
 from discord.ext.commands import BucketType, Cog, Context, Paginator, command, group, has_any_role
 
 from bot import constants
@@ -447,9 +447,9 @@ class Information(Cog):
 
         def add_content(title: str, content: str) -> None:
             paginator.add_line(f'== {title} ==\n')
-            # replace backticks as it breaks out of code blocks. Spaces seemed to be the most reasonable solution.
-            # we hope it's not close to 2000
-            paginator.add_line(content.replace('```', '`` `'))
+            # Replace backticks as it breaks out of code blocks.
+            # An invisble character seemed to be the most reasonable solution. We hope it's not close to 2000.
+            paginator.add_line(content.replace('`', '`\u200b'))
             paginator.close_page()
 
         if message.content:
@@ -468,7 +468,7 @@ class Information(Cog):
                 add_content(title, transformer(item))
 
         for page in paginator.pages:
-            await ctx.send(page)
+            await ctx.send(page, allowed_mentions=AllowedMentions.none())
 
     @raw.command()
     async def json(self, ctx: Context, message: Message) -> None:

--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -448,7 +448,7 @@ class Information(Cog):
         def add_content(title: str, content: str) -> None:
             paginator.add_line(f'== {title} ==\n')
             # Replace backticks as it breaks out of code blocks.
-            # An invisble character seemed to be the most reasonable solution. We hope it's not close to 2000.
+            # An invisible character seemed to be the most reasonable solution. We hope it's not close to 2000.
             paginator.add_line(content.replace('`', '`\u200b'))
             paginator.close_page()
 


### PR DESCRIPTION
## Changes
1. Instead of adding a space between ``` (this was easily bypassed), replace each backtick with "`\u200b".
2. If someone (somehow) bypasses the codeblocks, they cannot mention everyone because the message will use [`AllowedMentions.none`](https://discordpy.readthedocs.io/en/latest/api.html#discord.AllowedMentions.none)

## Relevant Issues
Closes #1485