### PR TITLE
Increase the total number of help channels to 42

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -481,7 +481,7 @@ help_channels:
 
     # Maximum number of channels across all 3 categories
     # Note Discord has a hard limit of 50 channels per category, so this shouldn't be > 50
-    max_total_channels: 32
+    max_total_channels: 42
 
     # Prefix for help channel names
     name_prefix: 'help-'


### PR DESCRIPTION
We've seen an increase in help channel activity and we're running out of help channels frequently. That's why we're increasing the number of help channels from 38 to 42.

Note that the old configuration said 32, but we had more channels in actual rotation due to a race condition we had in the past. The
system will never delete channels that were already in rotation, meaning that those that were added over the limit in the past still exist.