### PR TITLE
Ignore colourless roles for the `!user` embed color

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -284,7 +284,9 @@ class Information(Cog):
             embed.add_field(name=field_name, value=field_content, inline=False)
 
         embed.set_thumbnail(url=user.avatar_url_as(static_format="png"))
-        embed.colour = user.top_role.colour if roles else Colour.blurple()
+
+        role_colours = [role.colour for role in user.roles[1:] if role.colour != Colour.default()]
+        embed.colour = role_colours[-1] if role_colours else Colour.blurple()
 
         return embed
 

--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -284,9 +284,7 @@ class Information(Cog):
             embed.add_field(name=field_name, value=field_content, inline=False)
 
         embed.set_thumbnail(url=user.avatar_url_as(static_format="png"))
-
-        role_colours = [role.colour for role in user.roles[1:] if role.colour != Colour.default()]
-        embed.colour = role_colours[-1] if role_colours else Colour.blurple()
+        embed.colour = user.colour if user.colour != Colour.default() else Colour.blurple()
 
         return embed
 

--- a/tests/bot/exts/info/test_information.py
+++ b/tests/bot/exts/info/test_information.py
@@ -283,6 +283,7 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         user = helpers.MockMember()
         user.nick = None
         user.__str__ = unittest.mock.Mock(return_value="Mr. Hemlock")
+        user.colour = 0
 
         embed = await self.cog.create_user_embed(ctx, user)
 
@@ -298,6 +299,7 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         user = helpers.MockMember()
         user.nick = "Cat lover"
         user.__str__ = unittest.mock.Mock(return_value="Mr. Hemlock")
+        user.colour = 0
 
         embed = await self.cog.create_user_embed(ctx, user)
 
@@ -314,7 +316,7 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         admins_role.colour = 100
 
         # A `MockMember` has the @Everyone role by default; we add the Admins to that.
-        user = helpers.MockMember(roles=[admins_role], top_role=admins_role)
+        user = helpers.MockMember(roles=[admins_role], top_role=admins_role, colour=100)
 
         embed = await self.cog.create_user_embed(ctx, user)
 
@@ -337,7 +339,7 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         infraction_counts.return_value = ("Infractions", "expanded infractions info")
         nomination_counts.return_value = ("Nominations", "nomination info")
 
-        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role)
+        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role, colour=100)
         embed = await self.cog.create_user_embed(ctx, user)
 
         infraction_counts.assert_called_once_with(user)
@@ -371,7 +373,7 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
 
         infraction_counts.return_value = ("Infractions", "basic infractions info")
 
-        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role)
+        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role, colour=100)
         embed = await self.cog.create_user_embed(ctx, user)
 
         infraction_counts.assert_called_once_with(user)
@@ -409,7 +411,7 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         moderators_role = helpers.MockRole(name='Moderators')
         moderators_role.colour = 100
 
-        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role)
+        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role, colour=100)
         embed = await self.cog.create_user_embed(ctx, user)
 
         self.assertEqual(embed.colour, discord.Colour(moderators_role.colour))
@@ -422,7 +424,7 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         """The embed should be created with a blurple colour if the user has no assigned roles."""
         ctx = helpers.MockContext()
 
-        user = helpers.MockMember(id=217)
+        user = helpers.MockMember(id=217, colour=discord.Colour.blurple())
         embed = await self.cog.create_user_embed(ctx, user)
 
         self.assertEqual(embed.colour, discord.Colour.blurple())
@@ -435,7 +437,7 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         """The embed thumbnail should be set to the user's avatar in `png` format."""
         ctx = helpers.MockContext()
 
-        user = helpers.MockMember(id=217)
+        user = helpers.MockMember(id=217, colour=0)
         user.avatar_url_as.return_value = "avatar url"
         embed = await self.cog.create_user_embed(ctx, user)
 

--- a/tests/bot/exts/info/test_information.py
+++ b/tests/bot/exts/info/test_information.py
@@ -313,10 +313,9 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         """Created `!user` embeds should not contain mention of the @everyone-role."""
         ctx = helpers.MockContext(channel=helpers.MockTextChannel(id=1))
         admins_role = helpers.MockRole(name='Admins')
-        admins_role.colour = 100
 
         # A `MockMember` has the @Everyone role by default; we add the Admins to that.
-        user = helpers.MockMember(roles=[admins_role], top_role=admins_role, colour=100)
+        user = helpers.MockMember(roles=[admins_role], colour=100)
 
         embed = await self.cog.create_user_embed(ctx, user)
 
@@ -334,12 +333,11 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         ctx = helpers.MockContext(channel=helpers.MockTextChannel(id=50))
 
         moderators_role = helpers.MockRole(name='Moderators')
-        moderators_role.colour = 100
 
         infraction_counts.return_value = ("Infractions", "expanded infractions info")
         nomination_counts.return_value = ("Nominations", "nomination info")
 
-        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role, colour=100)
+        user = helpers.MockMember(id=314, roles=[moderators_role], colour=100)
         embed = await self.cog.create_user_embed(ctx, user)
 
         infraction_counts.assert_called_once_with(user)
@@ -369,11 +367,10 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         ctx = helpers.MockContext(channel=helpers.MockTextChannel(id=100))
 
         moderators_role = helpers.MockRole(name='Moderators')
-        moderators_role.colour = 100
 
         infraction_counts.return_value = ("Infractions", "basic infractions info")
 
-        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role, colour=100)
+        user = helpers.MockMember(id=314, roles=[moderators_role], colour=100)
         embed = await self.cog.create_user_embed(ctx, user)
 
         infraction_counts.assert_called_once_with(user)
@@ -409,12 +406,11 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         ctx = helpers.MockContext()
 
         moderators_role = helpers.MockRole(name='Moderators')
-        moderators_role.colour = 100
 
-        user = helpers.MockMember(id=314, roles=[moderators_role], top_role=moderators_role, colour=100)
+        user = helpers.MockMember(id=314, roles=[moderators_role], colour=100)
         embed = await self.cog.create_user_embed(ctx, user)
 
-        self.assertEqual(embed.colour, discord.Colour(moderators_role.colour))
+        self.assertEqual(embed.colour, discord.Colour(100))
 
     @unittest.mock.patch(
         f"{COG_PATH}.basic_user_infraction_counts",
@@ -424,7 +420,7 @@ class UserEmbedTests(unittest.IsolatedAsyncioTestCase):
         """The embed should be created with a blurple colour if the user has no assigned roles."""
         ctx = helpers.MockContext()
 
-        user = helpers.MockMember(id=217, colour=discord.Colour.blurple())
+        user = helpers.MockMember(id=217, colour=discord.Colour.default())
         embed = await self.cog.create_user_embed(ctx, user)
 
         self.assertEqual(embed.colour, discord.Colour.blurple())


### PR DESCRIPTION
Fixes #1496 with a simple list comprehension to determine the user's top **_colored_** role.

CC: @Akarys42