### PR TITLE
Migrate GHCR_TOKEN -> GITHUB_TOKEN in Docker build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN  }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
 
       # Build and push the container to the GitHub Container
       # Repository. The container will be tagged as "latest"


### PR DESCRIPTION
GITHUB_TOKEN has now enough permissions to be used for pushing to GHCR, so we don't need PAT anymore.