### PR TITLE
Reduce default duration of stream permission from 30m to 5m

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -548,4 +548,4 @@ config:
 
 
 video_permission:
-    default_permission_duration: 30  # Default duration for stream command in minutes
+    default_permission_duration: 5  # Default duration for stream command in minutes


### PR DESCRIPTION
At the request of Mr Hemlock (@MrHemlock)