### PR TITLE
Close voice channels with defcon shutdown

### DIFF
--- a/bot/exts/moderation/defcon.py
+++ b/bot/exts/moderation/defcon.py
@@ -181,7 +181,7 @@ class Defcon(Cog):
         role = ctx.guild.default_role
         permissions = role.permissions
 
-        permissions.update(send_messages=False, add_reactions=False)
+        permissions.update(send_messages=False, add_reactions=False, connect=False)
         await role.edit(reason="DEFCON shutdown", permissions=permissions)
         await ctx.send(f"{Action.SERVER_SHUTDOWN.value.emoji} Server shut down.")
 
@@ -192,7 +192,7 @@ class Defcon(Cog):
         role = ctx.guild.default_role
         permissions = role.permissions
 
-        permissions.update(send_messages=True, add_reactions=True)
+        permissions.update(send_messages=True, add_reactions=True, connect=True)
         await role.edit(reason="DEFCON unshutdown", permissions=permissions)
         await ctx.send(f"{Action.SERVER_OPEN.value.emoji} Server reopened.")
 


### PR DESCRIPTION
## Description
<!-- Describe how you've implemented your changes. -->
Simple addition to remove the connect permission from the everyone role and restore it when done.

## Reasoning
<!-- Outline the reasoning for how it's been implemented. -->
Keep people from joining voice channels during a raid, making the entire server as read only as it can get.

## Did you:
<!-- These are required when contributing. -->
<!-- Replace [ ] with [x] to mark items as done. -->

- [x] Join the [**Python Discord Community**](https://discord.gg/python)?
- [x] If dependencies have been added or updated, run `pipenv lock`?
- [x] **Lint your code** (`pipenv run lint`)?
- [x] Set the PR to **allow edits from contributors**?