### PR TITLE
Branding: correct broken timestamp persistence & improve cosmetics

### DIFF
--- a/bot/exts/backend/branding/_cog.py
+++ b/bot/exts/backend/branding/_cog.py
@@ -58,6 +58,8 @@ def extract_event_duration(event: Event) -> str:
     Extract a human-readable, year-agnostic duration string from `event`.
 
     In the case that `event` is a fallback event, resolves to 'Fallback'.
+
+    For 1-day events, only the single date is shown, instead of a period.
     """
     if event.meta.is_fallback:
         return "Fallback"
@@ -65,6 +67,9 @@ def extract_event_duration(event: Event) -> str:
     fmt = "%B %d"  # Ex: August 23
     start_date = event.meta.start_date.strftime(fmt)
     end_date = event.meta.end_date.strftime(fmt)
+
+    if start_date == end_date:
+        return start_date
 
     return f"{start_date} - {end_date}"
 


### PR DESCRIPTION
So when Phil Karlton said ~

> There are only two hard things in Computer Science: cache invalidation and naming things.

~ I think he forgot about timezones.

# Branding

The new branding manager [#1463] is storing UTC timestamps incorrectly, and this PR amends that. The bug isn't critical, in fact it doesn't even do anything, as I'll explain shortly, but it is still a bug. Additionally this PR adds a small cosmetic fix for 1 day events.

## 1. Datetime sucks

The branding manager persists the last date & time it rotated icons, represented as a POSIX UTC timestamp, in Redis.

The timestamp is generated in the following way:

```python
timestamp = datetime.utcnow().timestamp()
```

This is completely wrong.

Calling `utcnow` will produce a *tz-naive* representation; this means that the instance is not aware of being in UTC. The `datetime` module understands naive timestamps to be in local time, and since POSIX timestamps should be UTC, calling `timestamp` on a naive instance will convert it to UTC (as if the instance represented local time).

To demonstrate, I currently reside in `UTC+2`:

```python
>>> datetime.now()
datetime.datetime(2021, 4, 13, 22, 10, 13, 661321)  # 22:10 ~ true local time
>>> datetime.utcnow()
datetime.datetime(2021, 4, 13, 20, 10, 17, 590921)  # 20:10 ~ true UTC time
>>> datetime.utcnow().timestamp()
1618337421.918989  # 18:10 ~ wtf?
```

When calling `utcnow`, the produced instance corresponds to my time `-2`. This is correct, but the instance isn't aware of being in UTC. When we call `timestamp` on it, it offsets by `-2` **again**. To confirm, you can use an [online tool like this](https://www.unixtimestamp.com).

The reason why I didn't catch this bug in testing is because a) the timestamp is human-unreadable, and more importantly b) there is also a supercool bug on the way out of Redis:

```python
last_rotation = datetime.fromtimestamp(last_rotation_timestamp)
```

This is wrong again ~ `fromtimestamp` will read *a UTC timestamp* and *convert it to local time*. Because of this, the error cancels out. In my timezone, we subtract 2 hours initially, and then correct the error by (incorrectly) adding 2 hours. The bug is nefarious because by the time you have the `datetime` instance (which has a reasonable str repr), it's too late to observe it. Furthermore, I believe it's probably not an issue at all in production since I assume server time to be UTC anyway, so there should be no shifting. However, it's still incorrect.

I believe the best way to avoid such problems is to use tz-aware instances. Since #1470 started using `arrow` instead of the stdlib `datetime`, I decided to follow suit. Arrow generally mimics the `datetime` API, but with the important difference that objects are tz-aware by default. For this reason, we get the following:

```python
>>> datetime.utcnow()
datetime.datetime(2021, 4, 13, 20, 23, 26, 699655)  # 20:23 ~ correct UTC time
>>> datetime.utcnow().timestamp()
1618338208.493884  # 18:23
>>> Arrow.utcnow().timestamp()
1618345409.64813  # 20:23
```

On the way out, I'm then using `utcfromtimestamp` to read the timestamp into a *tz-aware* UTC object for further use.

For the record, using `datetime.utcfromtimestamp` is possible and correct, but it again produces a *tz-naive* object. :roll_eyes: 

It's also worth noting that this behaviour is documented throughout the datetime docs, e.g. [the note here](https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp).

Finally, I didn't migrate the repository part of the branding manager to `arrow`. We do use `datetime.utcnow` there, but I believe it's the rare case where it makes sense ~ we only grab the current UTC month and day from it, but don't use the instance any further.

## 2. Event cosmetics

Since I was already working on the cog, I decided to add something that I forgot about last time. Event duration strings are ~

* either `'Fallback'`
* or `'<start_date> - <end_date>'`

~ when formatted for the frontend.

For 1-day events, we get this:

![image](https://user-images.githubusercontent.com/44734341/114617912-03ace280-9ca9-11eb-9749-f0547edc64ff.png)

In d29e98b, I add a check for this case to produce just the single date instead:

![image](https://user-images.githubusercontent.com/44734341/114617941-0c9db400-9ca9-11eb-91f4-0b5aaa83d4e7.png)

Please note that this change will also propagate to the calendar view.

Sorry for writing a book.