### PR TITLE
Use a paginated embed to output multiple snowflakes

### DIFF
--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -162,6 +162,9 @@ class Utils(Cog):
         if len(snowflakes) > 1 and await has_no_roles_check(ctx, *STAFF_ROLES):
             raise BadArgument("Cannot process more than one snowflake in one invocation.")
 
+        if not snowflakes:
+            raise BadArgument("At least one snowflake must be provided.")
+
         embed = Embed(
             colour=Colour.blue()
         )

--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -162,17 +162,26 @@ class Utils(Cog):
         if len(snowflakes) > 1 and await has_no_roles_check(ctx, *STAFF_ROLES):
             raise BadArgument("Cannot process more than one snowflake in one invocation.")
 
+        embed = Embed(
+            colour=Colour.blue()
+        )
+        embed.set_author(
+            name=f"Snowflake{'s'[:len(snowflakes)^1]}",  # Deals with pluralisation
+            icon_url="https://github.com/twitter/twemoji/blob/master/assets/72x72/2744.png?raw=true"
+        )
+
+        lines = []
         for snowflake in snowflakes:
             created_at = snowflake_time(snowflake)
-            embed = Embed(
-                description=f"**Created at {created_at}** ({time_since(created_at, max_units=3)}).",
-                colour=Colour.blue()
-            )
-            embed.set_author(
-                name=f"Snowflake: {snowflake}",
-                icon_url="https://github.com/twitter/twemoji/blob/master/assets/72x72/2744.png?raw=true"
-            )
-            await ctx.send(embed=embed)
+            lines.append(f"**{snowflake}**\nCreated at {created_at} ({time_since(created_at, max_units=3)}).")
+
+        await LinePaginator.paginate(
+            lines,
+            ctx=ctx,
+            embed=embed,
+            max_lines=5,
+            max_size=1000
+        )
 
     @command(aliases=("poll",))
     @has_any_role(*MODERATION_ROLES, Roles.project_leads, Roles.domain_leads)

--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -165,9 +165,7 @@ class Utils(Cog):
         if not snowflakes:
             raise BadArgument("At least one snowflake must be provided.")
 
-        embed = Embed(
-            colour=Colour.blue()
-        )
+        embed = Embed(colour=Colour.blue())
         embed.set_author(
             name=f"Snowflake{'s'[:len(snowflakes)^1]}",  # Deals with pluralisation
             icon_url="https://github.com/twitter/twemoji/blob/master/assets/72x72/2744.png?raw=true"


### PR DESCRIPTION
## Description
Previously each snowflake passed to the command would have their own embed, which may cause the bot to send many embeds if a staff unknowingly passed it a bunch of snowflakes. This change makes sure that we don't run into rate limits on the bot by sending all of the snowflakes in one embed.

## Screenshots
No Snowflake
![image](https://user-images.githubusercontent.com/9753350/114687039-40112a80-9d0b-11eb-9fde-727a566b94b4.png)

1 snowflake
![image](https://user-images.githubusercontent.com/9753350/114687072-499a9280-9d0b-11eb-9e57-99fd4df0a2bd.png)

3 snowflakes
![image](https://user-images.githubusercontent.com/9753350/114687121-53bc9100-9d0b-11eb-9fe1-b63a8eaf370e.png)

Many snowflakes
![image](https://user-images.githubusercontent.com/9753350/114687177-633bda00-9d0b-11eb-8c4e-b77278dd8105.png)