### PR TITLE
Allow eval almost everywhere

### DIFF
--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -11,7 +11,7 @@ from discord.ext.commands import Cog, Context
 
 from bot.constants import Channels, DEBUG_MODE, RedirectOutput
 from bot.utils import function
-from bot.utils.checks import InWhitelistCheckFailure, in_whitelist_check
+from bot.utils.checks import ContextCheckFailure, in_whitelist_check
 from bot.utils.function import command_wraps
 
 log = logging.getLogger(__name__)
@@ -43,6 +43,10 @@ def in_whitelist(
         return in_whitelist_check(ctx, channels, categories, roles, redirect, fail_silently)
 
     return commands.check(predicate)
+
+
+class NotInBlacklistCheckFailure(ContextCheckFailure):
+    """Raised when the 'not_in_blacklist' check fails."""
 
 
 def not_in_blacklist(
@@ -77,7 +81,7 @@ def not_in_blacklist(
         success = not_blacklisted or overridden
 
         if not success and not fail_silently:
-            raise InWhitelistCheckFailure(redirect)
+            raise NotInBlacklistCheckFailure(redirect)
 
         return success
 

--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -12,7 +12,7 @@ from bot.bot import Bot
 from bot.constants import Colours, Icons, MODERATION_ROLES
 from bot.converters import TagNameConverter
 from bot.errors import InvalidInfractedUser, LockedResourceError
-from bot.utils.checks import InWhitelistCheckFailure
+from bot.utils.checks import ContextCheckFailure
 
 log = logging.getLogger(__name__)
 
@@ -274,7 +274,7 @@ class ErrorHandler(Cog):
             await ctx.send(
                 "Sorry, it looks like I don't have the permissions or roles I need to do that."
             )
-        elif isinstance(e, (InWhitelistCheckFailure, errors.NoPrivateMessage)):
+        elif isinstance(e, (ContextCheckFailure, errors.NoPrivateMessage)):
             ctx.bot.stats.incr("errors.wrong_channel_or_dm_error")
             await ctx.send(e)
 

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -13,7 +13,7 @@ from discord.ext.commands import Cog, Context, command, guild_only
 
 from bot.bot import Bot
 from bot.constants import Categories, Channels, Roles, URLs
-from bot.decorators import in_whitelist
+from bot.decorators import not_in_blacklist
 from bot.utils import send_to_paste_service
 from bot.utils.messages import wait_for_deletion
 
@@ -39,8 +39,8 @@ RAW_CODE_REGEX = re.compile(
 MAX_PASTE_LEN = 10000
 
 # `!eval` command whitelists
-EVAL_CHANNELS = (Channels.bot_commands, Channels.esoteric)
-EVAL_CATEGORIES = (Categories.help_available, Categories.help_in_use, Categories.voice)
+NO_EVAL_CHANNELS = (Channels.python_general,)
+NO_EVAL_CATEGORIES = ()
 EVAL_ROLES = (Roles.helpers, Roles.moderators, Roles.admins, Roles.owners, Roles.python_community, Roles.partners)
 
 SIGKILL = 9
@@ -280,7 +280,7 @@ class Snekbox(Cog):
 
     @command(name="eval", aliases=("e",))
     @guild_only()
-    @in_whitelist(channels=EVAL_CHANNELS, categories=EVAL_CATEGORIES, roles=EVAL_ROLES)
+    @not_in_blacklist(channels=NO_EVAL_CHANNELS, categories=NO_EVAL_CATEGORIES, override_roles=EVAL_ROLES)
     async def eval_command(self, ctx: Context, *, code: str = None) -> None:
         """
         Run Python code and get the results.

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -38,7 +38,7 @@ RAW_CODE_REGEX = re.compile(
 
 MAX_PASTE_LEN = 10000
 
-# `!eval` command whitelists
+# `!eval` command whitelists and blacklists.
 NO_EVAL_CHANNELS = (Channels.python_general,)
 NO_EVAL_CATEGORIES = ()
 EVAL_ROLES = (Roles.helpers, Roles.moderators, Roles.admins, Roles.owners, Roles.python_community, Roles.partners)

--- a/bot/utils/checks.py
+++ b/bot/utils/checks.py
@@ -20,8 +20,8 @@ from bot import constants
 log = logging.getLogger(__name__)
 
 
-class InWhitelistCheckFailure(CheckFailure):
-    """Raised when the `in_whitelist` check fails."""
+class ContextCheckFailure(CheckFailure):
+    """Raised when a context-specific check fails."""
 
     def __init__(self, redirect_channel: Optional[int]) -> None:
         self.redirect_channel = redirect_channel
@@ -34,6 +34,10 @@ class InWhitelistCheckFailure(CheckFailure):
         error_message = f"You are not allowed to use that command{redirect_message}."
 
         super().__init__(error_message)
+
+
+class InWhitelistCheckFailure(ContextCheckFailure):
+    """Raised when the `in_whitelist` check fails."""
 
 
 def in_whitelist_check(


### PR DESCRIPTION
## Description
Adds a check to blacklist a command only in a specific context, with an option for a role override. The check is applied to the eval command to blacklist it only from python-general.

## Questionable choices
* The check uses the in_whitelist_check check internally. It's possible that it's better to manually handle the logic of the predicate.
* This still uses the InWhiteListCheckFailure exception, even though it explicitly states in its docstring that it's raised for the in_whitelist_check. I wasn't sure if it's better to do this, or to duplicate the class's code with a different name. There might be a third solution I'm not seeing.

