### PR TITLE
Make trace logging optional and allow selective enabling

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -199,6 +199,7 @@ class Bot(metaclass=YAMLGetter):
     prefix: str
     sentry_dsn: Optional[str]
     token: str
+    trace_loggers: Optional[str]
 
 
 class Redis(metaclass=YAMLGetter):

--- a/bot/log.py
+++ b/bot/log.py
@@ -87,10 +87,27 @@ def _monkeypatch_trace(self: logging.Logger, msg: str, *args, **kwargs) -> None:
 
 
 def _set_trace_loggers() -> None:
-    """Set loggers to the trace level according to the value from the BOT_TRACE_LOGGERS env var."""
-    if constants.Bot.trace_loggers:
-        if constants.Bot.trace_loggers in {"*", "ROOT"}:
+    """
+    Set loggers to the trace level according to the value from the BOT_TRACE_LOGGERS env var.
+
+    When the env var is a list of logger names delimited by a comma,
+    each of the listed loggers will be set to the trace level.
+
+    If this list is prefixed with a "!", all of the loggers except the listed ones will be set to the trace level.
+
+    Otherwise if the env var begins with a "*",
+    the root logger is set to the trace level and other contents are ignored.
+    """
+    level_filter = constants.Bot.trace_loggers
+    if level_filter:
+        if level_filter.startswith("*"):
             logging.getLogger().setLevel(logging.TRACE)
+
+        elif level_filter.startswith("!"):
+            logging.getLogger().setLevel(logging.TRACE)
+            for logger_name in level_filter.strip("!,").split(","):
+                logging.getLogger(logger_name).setLevel(logging.DEBUG)
+
         else:
-            for logger_name in constants.Bot.trace_loggers.split(","):
+            for logger_name in level_filter.strip(",").split(","):
                 logging.getLogger(logger_name).setLevel(logging.TRACE)

--- a/config-default.yml
+++ b/config-default.yml
@@ -1,7 +1,8 @@
 bot:
-    prefix:      "!"
-    sentry_dsn:  !ENV "BOT_SENTRY_DSN"
-    token:       !ENV "BOT_TOKEN"
+    prefix:         "!"
+    sentry_dsn:     !ENV "BOT_SENTRY_DSN"
+    token:          !ENV "BOT_TOKEN"
+    trace_loggers:  !ENV "BOT_TRACE_LOGGERS"
 
     clean:
         # Maximum number of messages to traverse for clean commands


### PR DESCRIPTION
closes: #1502

Implements the `BOT_TRACE_LOGGERS` env var that can be used to set which loggers should log trace logs instead of defaulting to logging them all in a development environment.

The env var follows the format of a comma delimited list prefixed with either a `*` or a `!`. 

- When neither of the prefixes are present, the listed loggers are set to the trace level. 
- If the `!` prefix is used, all of the loggers except the listed ones are set to the trace level.
- Otherwise if `*` is used, the root logger is set to the trace level.

I removed the option to use the `COLOREDLOGS_LOG_LEVEL` to change the coloredlogs level as I don't think it's something that was really used as the levels are controlled by our loggers instead of the different handlers needing to filter them, and it made the code a bit more complicated, but I'm open to changing it back if there are any opinions against it.

I left the `None` value (unset env var) to not enable any trace logs as it made sense with the `None`'s general purpose, although I'm not sure if it is a good default, thoughts?