### PR TITLE
Redirect output to bot-commands channel for the !eval command

### DIFF
--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -111,12 +111,15 @@ def redirect_output(
     destination_channel: int,
     bypass_roles: t.Optional[t.Container[int]] = None,
     channels: t.Optional[t.Container[int]] = None,
-    categories: t.Optional[t.Container[int]] = None
+    categories: t.Optional[t.Container[int]] = None,
+    ping_user: bool = True
 ) -> t.Callable:
     """
     Changes the channel in the context of the command to redirect the output to a certain channel.
 
     Redirect is bypassed if the author has a bypass role or if it is in a channel that can bypass redirection.
+
+    If ping_user is False, it will not send a message in the destination channel.
 
     This decorator must go before (below) the `command` decorator.
     """
@@ -147,7 +150,9 @@ def redirect_output(
 
             log.trace(f"Redirecting output of {ctx.author}'s command '{ctx.command.name}' to {redirect_channel.name}")
             ctx.channel = redirect_channel
-            await ctx.channel.send(f"Here's the output of your command, {ctx.author.mention}")
+
+            if ping_user:
+                await ctx.send(f"Here's the output of your command, {ctx.author.mention}")
             asyncio.create_task(func(self, ctx, *args, **kwargs))
 
             message = await old_channel.send(

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -107,11 +107,16 @@ def has_no_roles(*roles: t.Union[str, int]) -> t.Callable:
     return commands.check(predicate)
 
 
-def redirect_output(destination_channel: int, bypass_roles: t.Container[int] = None) -> t.Callable:
+def redirect_output(
+    destination_channel: int,
+    bypass_roles: t.Optional[t.Container[int]] = None,
+    channels: t.Optional[t.Container[int]] = None,
+    categories: t.Optional[t.Container[int]] = None
+) -> t.Callable:
     """
     Changes the channel in the context of the command to redirect the output to a certain channel.
 
-    Redirect is bypassed if the author has a role to bypass redirection.
+    Redirect is bypassed if the author has a bypass role or if it is in a channel that can bypass redirection.
 
     This decorator must go before (below) the `command` decorator.
     """
@@ -119,7 +124,7 @@ def redirect_output(destination_channel: int, bypass_roles: t.Container[int] = N
         @command_wraps(func)
         async def inner(self: Cog, ctx: Context, *args, **kwargs) -> None:
             if ctx.channel.id == destination_channel:
-                log.trace(f"Command {ctx.command.name} was invoked in destination_channel, not redirecting")
+                log.trace(f"Command {ctx.command} was invoked in destination_channel, not redirecting")
                 await func(self, ctx, *args, **kwargs)
                 return
 
@@ -127,6 +132,15 @@ def redirect_output(destination_channel: int, bypass_roles: t.Container[int] = N
                 log.trace(f"{ctx.author} has role to bypass output redirection")
                 await func(self, ctx, *args, **kwargs)
                 return
+
+            elif channels and ctx.channel.id not in channels:
+                log.trace(f"{ctx.author} used {ctx.command} in a channel that can bypass output redirection")
+                await func(self, ctx, *args, **kwargs)
+                return
+
+            elif categories and ctx.channel.category.id not in categories:
+                log.trace(f"{ctx.author} used {ctx.command} in a category that can bypass output redirection")
+                await func(self, ctx, *args, **kwargs)
 
             redirect_channel = ctx.guild.get_channel(destination_channel)
             old_channel = ctx.channel

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -13,7 +13,7 @@ from discord.ext.commands import Cog, Context, command, guild_only
 
 from bot.bot import Bot
 from bot.constants import Categories, Channels, Roles, URLs
-from bot.decorators import not_in_blacklist
+from bot.decorators import redirect_output
 from bot.utils import send_to_paste_service
 from bot.utils.messages import wait_for_deletion
 
@@ -280,7 +280,12 @@ class Snekbox(Cog):
 
     @command(name="eval", aliases=("e",))
     @guild_only()
-    @not_in_blacklist(channels=NO_EVAL_CHANNELS, categories=NO_EVAL_CATEGORIES, override_roles=EVAL_ROLES)
+    @redirect_output(
+        destination_channel=Channels.bot_commands,
+        bypass_roles=EVAL_ROLES,
+        categories=NO_EVAL_CATEGORIES,
+        channels=NO_EVAL_CHANNELS
+    )
     async def eval_command(self, ctx: Context, *, code: str = None) -> None:
         """
         Run Python code and get the results.

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -284,7 +284,8 @@ class Snekbox(Cog):
         destination_channel=Channels.bot_commands,
         bypass_roles=EVAL_ROLES,
         categories=NO_EVAL_CATEGORIES,
-        channels=NO_EVAL_CHANNELS
+        channels=NO_EVAL_CHANNELS,
+        ping_user=False
     )
     async def eval_command(self, ctx: Context, *, code: str = None) -> None:
         """


### PR DESCRIPTION
## Relevant Issues
Closes #1498

## Description
This PR makes it so that if you do the `!e` command, and you use it in a blacklisted channel (i.e `#python-general`), if you don't have a bypassing role, then the output will be redirected.

## Screenshots
![image](https://user-images.githubusercontent.com/78174417/115120590-44904a00-9f7c-11eb-95bd-ae75e73a0fec.png)
