### PR TITLE
Fix zen's negative indexing

### DIFF
--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -109,7 +109,7 @@ class Utils(Cog):
         # handle if it's an index int
         if isinstance(search_value, int):
             upper_bound = len(zen_lines) - 1
-            lower_bound = -1 * upper_bound
+            lower_bound = -1 * len(zen_lines)
             if not (lower_bound <= search_value <= upper_bound):
                 raise BadArgument(f"Please provide an index between {lower_bound} and {upper_bound}.")
 


### PR DESCRIPTION
Negative indexing starts at -1, not 0, meaning lower bound should be -1 * len(zen_lines), not -1 * upper_bound.
The current implementation means !zen -18 would spit out line 2, and not line 1.