### PR TITLE
List non staff with stream perms

### DIFF
--- a/bot/exts/moderation/stream.py
+++ b/bot/exts/moderation/stream.py
@@ -208,7 +208,7 @@ class Stream(commands.Cog):
             # Only output the message in the pagination
             lines = [line[1] for line in streamer_info]
             embed = discord.Embed(
-                title=f"Members who can stream (`{len(lines)}` total)",
+                title=f"Members with streaming permission (`{len(lines)}` total)",
                 colour=Colours.soft_green
             )
             await LinePaginator.paginate(lines, ctx, embed, max_size=400, empty=False)

--- a/bot/exts/moderation/stream.py
+++ b/bot/exts/moderation/stream.py
@@ -186,7 +186,7 @@ class Stream(commands.Cog):
         ]
 
         # List of tuples (UtcPosixTimestamp, str)
-        # This is so that output can be sorted on [0] before passed it's to the paginator
+        # So that the list can be sorted on the UtcPosixTimestamp before the message is passed to the paginator.
         streamer_info = []
         for member in non_staff_members_with_stream:
             if revoke_time := await self.task_cache.get(member.id):

--- a/bot/exts/moderation/stream.py
+++ b/bot/exts/moderation/stream.py
@@ -186,7 +186,7 @@ class Stream(commands.Cog):
         ]
 
         # List of tuples (UtcPosixTimestamp, str)
-        # This is so that we can sort before outputting to the paginator
+        # This is so that output can be sorted on [0] before passed it's to the paginator
         streamer_info = []
         for member in non_staff_members_with_stream:
             if revoke_time := await self.task_cache.get(member.id):

--- a/bot/exts/moderation/stream.py
+++ b/bot/exts/moderation/stream.py
@@ -180,9 +180,9 @@ class Stream(commands.Cog):
     async def liststream(self, ctx: commands.Context) -> None:
         """Lists all non-staff users who have permission to stream."""
         non_staff_members_with_stream = [
-            _member
-            for _member in ctx.guild.get_role(Roles.video).members
-            if not any(role.id in STAFF_ROLES for role in _member.roles)
+            member
+            for member in ctx.guild.get_role(Roles.video).members
+            if not any(role.id in STAFF_ROLES for role in member.roles)
         ]
 
         # List of tuples (UtcPosixTimestamp, str)

--- a/bot/exts/moderation/stream.py
+++ b/bot/exts/moderation/stream.py
@@ -8,7 +8,7 @@ from async_rediscache import RedisCache
 from discord.ext import commands
 
 from bot.bot import Bot
-from bot.constants import Colours, Emojis, Guild, Roles, STAFF_ROLES, VideoPermission
+from bot.constants import Colours, Emojis, Guild, MODERATION_ROLES, Roles, VideoPermission
 from bot.converters import Expiry
 from bot.utils.scheduling import Scheduler
 from bot.utils.time import format_infraction_with_duration
@@ -69,7 +69,7 @@ class Stream(commands.Cog):
             )
 
     @commands.command(aliases=("streaming",))
-    @commands.has_any_role(*STAFF_ROLES)
+    @commands.has_any_role(*MODERATION_ROLES)
     async def stream(self, ctx: commands.Context, member: discord.Member, duration: Expiry = None) -> None:
         """
         Temporarily grant streaming permissions to a member for a given duration.
@@ -126,7 +126,7 @@ class Stream(commands.Cog):
         log.debug(f"Successfully gave {member} ({member.id}) permission to stream until {revoke_time}.")
 
     @commands.command(aliases=("pstream",))
-    @commands.has_any_role(*STAFF_ROLES)
+    @commands.has_any_role(*MODERATION_ROLES)
     async def permanentstream(self, ctx: commands.Context, member: discord.Member) -> None:
         """Permanently grants the given member the permission to stream."""
         log.trace(f"Attempting to give permanent streaming permission to {member} ({member.id}).")
@@ -153,7 +153,7 @@ class Stream(commands.Cog):
         log.debug(f"Successfully gave {member} ({member.id}) permanent streaming permission.")
 
     @commands.command(aliases=("unstream", "rstream"))
-    @commands.has_any_role(*STAFF_ROLES)
+    @commands.has_any_role(*MODERATION_ROLES)
     async def revokestream(self, ctx: commands.Context, member: discord.Member) -> None:
         """Revoke the permission to stream from the given member."""
         log.trace(f"Attempting to remove streaming permission from {member} ({member.id}).")


### PR DESCRIPTION
This command is useful to audit users who still have the permission to stream.

I have chosen to also sort and paginate the embed to make it easier to read.
The sorting is based on how long until the user's streaming permissions are revoked, with permanent streamers at the end.

Example output:
![image](https://user-images.githubusercontent.com/9753350/115278720-b1067700-a13d-11eb-9d6d-9124883729ad.png)
