### PR TITLE
Add the Moderators role to moderation_roles in config

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -275,6 +275,7 @@ guild:
     moderation_roles:
         - *ADMINS_ROLE
         - *MOD_TEAM_ROLE
+        - *MODS_ROLE
         - *OWNERS_ROLE
 
     staff_roles:


### PR DESCRIPTION
This allows mod alert pings to go through in #mod-alerts, the allowed mentions only included the mods team role which is not pinged on mod alerts.