### PR TITLE
Use a specific error message when a warned user isn't in the guild

### DIFF
--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -54,8 +54,12 @@ class Infractions(InfractionScheduler, commands.Cog):
     # region: Permanent infractions
 
     @command()
-    async def warn(self, ctx: Context, user: Member, *, reason: t.Optional[str] = None) -> None:
+    async def warn(self, ctx: Context, user: FetchedMember, *, reason: t.Optional[str] = None) -> None:
         """Warn a user for the given reason."""
+        if not isinstance(user, Member):
+            await ctx.send(":x: The user doesn't appear to be on the server.")
+            return
+
         infraction = await _utils.post_infraction(ctx, user, "warning", reason, active=False)
         if infraction is None:
             return
@@ -63,8 +67,12 @@ class Infractions(InfractionScheduler, commands.Cog):
         await self.apply_infraction(ctx, infraction, user)
 
     @command()
-    async def kick(self, ctx: Context, user: Member, *, reason: t.Optional[str] = None) -> None:
+    async def kick(self, ctx: Context, user: FetchedMember, *, reason: t.Optional[str] = None) -> None:
         """Kick a user for the given reason."""
+        if not isinstance(user, Member):
+            await ctx.send(":x: The user doesn't appear to be on the server.")
+            return
+
         await self.apply_kick(ctx, user, reason)
 
     @command()
@@ -100,7 +108,7 @@ class Infractions(InfractionScheduler, commands.Cog):
     @command(aliases=["mute"])
     async def tempmute(
         self, ctx: Context,
-        user: Member,
+        user: FetchedMember,
         duration: t.Optional[Expiry] = None,
         *,
         reason: t.Optional[str] = None
@@ -122,6 +130,10 @@ class Infractions(InfractionScheduler, commands.Cog):
 
         If no duration is given, a one hour duration is used by default.
         """
+        if not isinstance(user, Member):
+            await ctx.send(":x: The user doesn't appear to be on the server.")
+            return
+
         if duration is None:
             duration = await Duration().convert(ctx, "1h")
         await self.apply_mute(ctx, user, reason, expires_at=duration)


### PR DESCRIPTION
This commit changes slightly how the warn, kick and mute commands to take a fetched member as their argument and to return a little error message if the user isn't in the guild rather than showing the whole help page.

**Previously:**
![image](https://user-images.githubusercontent.com/44778521/116263900-18de4280-a77a-11eb-8d50-dd47803ed0d0.png)
(note that help message of the mute command is way longer)

**Now:**
![image](https://user-images.githubusercontent.com/44778521/116263753-ec2a2b00-a779-11eb-8fe3-f5faf7477990.png)
