### PR TITLE
Code Snippets: Fix Error Handling for HTTP Request Errors

### DIFF
--- a/bot/exts/info/code_snippets.py
+++ b/bot/exts/info/code_snippets.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import textwrap
+from typing import Any
 from urllib.parse import quote_plus
 
 from aiohttp import ClientResponseError
@@ -43,7 +44,7 @@ class CodeSnippets(Cog):
     Matches each message against a regex and prints the contents of all matched snippets.
     """
 
-    async def _fetch_response(self, url: str, response_format: str, **kwargs) -> str:
+    async def _fetch_response(self, url: str, response_format: str, **kwargs) -> Any:
         """Makes http requests using aiohttp."""
         async with self.bot.http_session.get(url, raise_for_status=True, **kwargs) as response:
             if response_format == 'text':
@@ -61,7 +62,7 @@ class CodeSnippets(Cog):
                 ref = possible_ref['name']
                 file_path = path[len(ref) + 1:]
                 break
-        return (ref, file_path)
+        return ref, file_path
 
     async def _fetch_github_snippet(
         self,
@@ -145,8 +146,8 @@ class CodeSnippets(Cog):
         repo: str,
         ref: str,
         file_path: str,
-        start_line: int,
-        end_line: int
+        start_line: str,
+        end_line: str
     ) -> str:
         """Fetches a snippet from a BitBucket repo."""
         file_contents = await self._fetch_response(

--- a/bot/exts/info/code_snippets.py
+++ b/bot/exts/info/code_snippets.py
@@ -229,10 +229,11 @@ class CodeSnippets(Cog):
                         snippet = await handler(**match.groupdict())
                         all_snippets.append((match.start(), snippet))
                     except ClientResponseError as error:
+                        error_message = error.message  # noqa: B306
                         log.log(
                             logging.DEBUG if error.status == 404 else logging.ERROR,
-                            f'Failed to fetch code snippet from {error.request_info.real_url}. '
-                            f'Status: {error.status}. Message: {error}.'
+                            f'Failed to fetch code snippet from {match[0]!r}: {error.status} '
+                            f'{error_message} for GET {error.request_info.real_url.human_repr()}'
                         )
 
             # Sorts the list of snippets by their match index and joins them into a single message

--- a/bot/exts/info/code_snippets.py
+++ b/bot/exts/info/code_snippets.py
@@ -229,7 +229,8 @@ class CodeSnippets(Cog):
                         snippet = await handler(**match.groupdict())
                         all_snippets.append((match.start(), snippet))
                     except ClientResponseError as error:
-                        log.error(
+                        log.log(
+                            logging.DEBUG if error.status == 404 else logging.ERROR,
                             f'Failed to fetch code snippet from {error.request_info.real_url}. '
                             f'Status: {error.status}. Message: {error}.'
                         )


### PR DESCRIPTION
Fixes #1554 
Fixes #1553

Ignore 404s and avoid returning None as the response when there's an exception.