### PR TITLE
feat: Use embed timestamp in modpings off

### DIFF
--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -105,7 +105,7 @@ class ModPings(Cog):
         self._role_scheduler.schedule_at(duration, mod.id, self.reapply_role(mod))
 
         embed = Embed(timestamp=duration, colour=Colours.bright_green)
-        embed.set_footer(text="Moderators role has been removed", icon_url=Icons.green_checkmark)
+        embed.set_footer(text="Moderators role has been removed until", icon_url=Icons.green_checkmark)
         await ctx.send(embed=embed)
 
     @modpings_group.command(name='on')

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -3,11 +3,11 @@ import logging
 
 from async_rediscache import RedisCache
 from dateutil.parser import isoparse
-from discord import Member
+from discord import Embed, Member
 from discord.ext.commands import Cog, Context, group, has_any_role
 
 from bot.bot import Bot
-from bot.constants import Emojis, Guild, MODERATION_ROLES, Roles
+from bot.constants import Colours, Emojis, Guild, Icons, MODERATION_ROLES, Roles
 from bot.converters import Expiry
 from bot.utils.scheduling import Scheduler
 
@@ -104,7 +104,9 @@ class ModPings(Cog):
             self._role_scheduler.cancel(mod.id)
         self._role_scheduler.schedule_at(duration, mod.id, self.reapply_role(mod))
 
-        await ctx.send(f"{Emojis.check_mark} Moderators role has been removed until {until_date}.")
+        embed = Embed(timestamp=duration, colour=Colours.bright_green)
+        embed.set_footer(text="Moderators role has been removed", icon_url=Icons.green_checkmark)
+        await ctx.send(embed=embed)
 
     @modpings_group.command(name='on')
     @has_any_role(*MODERATION_ROLES)


### PR DESCRIPTION
## Relevant Issues
Closes #1547 

## Description
This PR makes it so that when the bot sends the mod pings off embed, it uses and embed timestamp to show when the role will be given back, so that it can be converted to local readable time, instead of using an ISO format.
## Screenshots
![](https://user-images.githubusercontent.com/78174417/116602989-671a4f80-a8fa-11eb-8582-06ac807f3c00.png)
