### PR TITLE
Prevent accidental addition of users to talentpool cache when using `!talentpool get_review`

### DIFF
--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -57,7 +57,7 @@ class Reviewer:
         """Schedules a single user for review."""
         log.trace(f"Scheduling review of user with ID {user_id}")
 
-        user_data = self._pool.watched_users[user_id]
+        user_data = self._pool.watched_users.get(user_id)
         inserted_at = isoparse(user_data['inserted_at']).replace(tzinfo=None)
         review_at = inserted_at + timedelta(days=MAX_DAYS_IN_POOL)
 
@@ -81,14 +81,18 @@ class Reviewer:
                 await message.add_reaction(reaction)
 
         if update_database:
-            nomination = self._pool.watched_users[user_id]
+            nomination = self._pool.watched_users.get(user_id)
             await self.bot.api_client.patch(f"{self._pool.api_endpoint}/{nomination['id']}", json={"reviewed": True})
 
     async def make_review(self, user_id: int) -> typing.Tuple[str, Optional[Emoji]]:
         """Format a generic review of a user and return it with the seen emoji."""
         log.trace(f"Formatting the review of {user_id}")
 
-        nomination = self._pool.watched_users[user_id]
+        # Since `watched_users` is a defaultdict, we should take care
+        # not to accidentally insert the IDs of users that have no
+        # active nominated by using the `watched_users.get(user_id)`
+        # instead of `watched_users[user_id]`.
+        nomination = self._pool.watched_users.get(user_id)
         if not nomination:
             log.trace(f"There doesn't appear to be an active nomination for {user_id}")
             return "", None
@@ -303,7 +307,7 @@ class Reviewer:
             await ctx.send(f":x: Can't find a currently nominated user with id `{user_id}`")
             return False
 
-        nomination = self._pool.watched_users[user_id]
+        nomination = self._pool.watched_users.get(user_id)
         if nomination["reviewed"]:
             await ctx.send(":x: This nomination was already reviewed, but here's a cookie :cookie:")
             return False


### PR DESCRIPTION
## Bug Description
When asking for a review for a user that isn't currently nominated using the `!talentpool get_review <userid>` command, the user is added to the talentpool `watched_users` cache, causing their messages to be relayed to the talentpool watch channel.

## Steps to reproduce
Use `!talentpool get_review <user_id>`, where `<user_id>` is the ID of a user with no active nomination. The command will correctly reply that the user does not have an active nomination, but their ID will nonetheless be added as a key to the `defaultdict` used to keep track of watched users in the talentpool .

## Solution
Replace all regular getitem usages with `.get(<user_id>)`, as the `Reviewer` should never insert IDs using the regular `defaultdict` path.

### Additional note
I've replaced all occurrences of regular getitem access into the defaultdict, even those that are normally not reachable with the id of a user that's currently not nominated, to prevent a future refactor from accidentally introducing this bug again.