### PR TITLE
Add a persistent scheduler

### DIFF
--- a/bot/exts/moderation/stream.py
+++ b/bot/exts/moderation/stream.py
@@ -1,18 +1,17 @@
 import logging
-from datetime import timedelta, timezone
+from datetime import timedelta
 from operator import itemgetter
 
 import arrow
 import discord
 from arrow import Arrow
-from async_rediscache import RedisCache
 from discord.ext import commands
 
 from bot.bot import Bot
 from bot.constants import Colours, Emojis, Guild, MODERATION_ROLES, Roles, STAFF_ROLES, VideoPermission
 from bot.converters import Expiry
 from bot.pagination import LinePaginator
-from bot.utils.scheduling import Scheduler
+from bot.utils.persistent_scheduling import PersistentScheduler
 from bot.utils.time import format_infraction_with_duration
 
 log = logging.getLogger(__name__)
@@ -21,54 +20,32 @@ log = logging.getLogger(__name__)
 class Stream(commands.Cog):
     """Grant and revoke streaming permissions from members."""
 
-    # Stores tasks to remove streaming permission
-    # RedisCache[discord.Member.id, UtcPosixTimestamp]
-    task_cache = RedisCache()
-
     def __init__(self, bot: Bot):
         self.bot = bot
-        self.scheduler = Scheduler(self.__class__.__name__)
-        self.reload_task = self.bot.loop.create_task(self._reload_tasks_from_redis())
+        self.scheduler = PersistentScheduler(self.__class__.__name__, self._revoke_streaming_permission, bot)
 
     def cog_unload(self) -> None:
         """Cancel all scheduled tasks."""
-        self.reload_task.cancel()
-        self.reload_task.add_done_callback(lambda _: self.scheduler.cancel_all())
+        self.scheduler.cancel_all()
 
-    async def _revoke_streaming_permission(self, member: discord.Member) -> None:
+    async def _revoke_streaming_permission(self, member_id: int) -> None:
         """Remove the streaming permission from the given Member."""
-        await self.task_cache.delete(member.id)
+        guild = self.bot.get_guild(Guild.id)
+        member = guild.get_member(member_id)
+        if not member:
+            # Member isn't found in the cache
+            try:
+                member = await guild.fetch_member(member_id)
+            except discord.errors.NotFound:
+                log.debug(
+                    f"Member {member_id} left the guild before we could schedule "
+                    "the revoking of their streaming permissions."
+                )
+                await self.scheduler.delete(member_id)
+            except discord.HTTPException:
+                log.exception(f"Exception while trying to retrieve member {member_id} from Discord.")
+
         await member.remove_roles(discord.Object(Roles.video), reason="Streaming access revoked")
-
-    async def _reload_tasks_from_redis(self) -> None:
-        """Reload outstanding tasks from redis on startup, delete the task if the member has since left the server."""
-        await self.bot.wait_until_guild_available()
-        items = await self.task_cache.items()
-        for key, value in items:
-            member = self.bot.get_guild(Guild.id).get_member(key)
-
-            if not member:
-                # Member isn't found in the cache
-                try:
-                    member = await self.bot.get_guild(Guild.id).fetch_member(key)
-                except discord.errors.NotFound:
-                    log.debug(
-                        f"Member {key} left the guild before we could schedule "
-                        "the revoking of their streaming permissions."
-                    )
-                    await self.task_cache.delete(key)
-                    continue
-                except discord.HTTPException:
-                    log.exception(f"Exception while trying to retrieve member {key} from Discord.")
-                    continue
-
-            revoke_time = Arrow.utcfromtimestamp(value)
-            log.debug(f"Scheduling {member} ({member.id}) to have streaming permission revoked at {revoke_time}")
-            self.scheduler.schedule_at(
-                revoke_time,
-                key,
-                self._revoke_streaming_permission(member)
-            )
 
     @commands.command(aliases=("streaming",))
     @commands.has_any_role(*MODERATION_ROLES)
@@ -94,10 +71,6 @@ class Stream(commands.Cog):
             # Use default duration and convert back to datetime as Embed.timestamp doesn't support Arrow
             duration = arrow.utcnow() + timedelta(minutes=VideoPermission.default_permission_duration)
             duration = duration.datetime
-        elif duration.tzinfo is None:
-            # Make duration tz-aware.
-            # ISODateTime could already include tzinfo, this check is so it isn't overwritten.
-            duration.replace(tzinfo=timezone.utc)
 
         # Check if the member already has streaming permission
         already_allowed = any(Roles.video == role.id for role in member.roles)
@@ -107,8 +80,7 @@ class Stream(commands.Cog):
             return
 
         # Schedule task to remove streaming permission from Member and add it to task cache
-        self.scheduler.schedule_at(duration, member.id, self._revoke_streaming_permission(member))
-        await self.task_cache.set(member.id, duration.timestamp())
+        await self.scheduler.schedule_at(duration, member.id)
 
         await member.add_roles(discord.Object(Roles.video), reason="Temporary streaming access granted")
 
@@ -137,8 +109,7 @@ class Stream(commands.Cog):
         if any(Roles.video == role.id for role in member.roles):
             if member.id in self.scheduler:
                 # Member has temp permission, so cancel the task to revoke later and delete from cache
-                self.scheduler.cancel(member.id)
-                await self.task_cache.delete(member.id)
+                await self.scheduler.delete(member.id)
 
                 await ctx.send(f"{Emojis.check_mark} Permanently granted {member.mention} the permission to stream.")
                 log.debug(
@@ -164,9 +135,8 @@ class Stream(commands.Cog):
         if any(Roles.video == role.id for role in member.roles):
             if member.id in self.scheduler:
                 # Member has temp permission, so cancel the task to revoke later and delete from cache
-                self.scheduler.cancel(member.id)
-                await self.task_cache.delete(member.id)
-            await self._revoke_streaming_permission(member)
+                await self.scheduler.delete(member.id)
+            await self._revoke_streaming_permission(member.id)
 
             await ctx.send(f"{Emojis.check_mark} Revoked the permission to stream from {member.mention}.")
             log.debug(f"Successfully revoked streaming permission from {member} ({member.id}).")
@@ -189,9 +159,9 @@ class Stream(commands.Cog):
         # So that the list can be sorted on the UtcPosixTimestamp before the message is passed to the paginator.
         streamer_info = []
         for member in non_staff_members_with_stream:
-            if revoke_time := await self.task_cache.get(member.id):
+            if revoke_time := await self.scheduler.get(member.id):
                 # Member only has temporary streaming perms
-                revoke_delta = Arrow.utcfromtimestamp(revoke_time).humanize()
+                revoke_delta = revoke_time.humanize()
                 message = f"{member.mention} will have stream permissions revoked {revoke_delta}."
             else:
                 message = f"{member.mention} has permanent streaming permissions."

--- a/bot/utils/persistent_scheduling.py
+++ b/bot/utils/persistent_scheduling.py
@@ -1,0 +1,155 @@
+import asyncio
+import typing as t
+from datetime import datetime, timedelta, timezone
+
+import arrow
+from arrow import Arrow
+from async_rediscache import RedisCache
+
+from bot.bot import Bot
+from bot.utils.scheduling import Scheduler
+
+SchedulerTaskFactory = t.Callable[[t.Union[str, int]], t.Coroutine[None, None, None]]
+CacheKey = t.Union[str, int]
+
+
+class PersistentScheduler(Scheduler):
+    """
+    Schedule the execution of coroutines and keep track of them even across restarts and cog reloads.
+
+    When instantiating a PersistentScheduler, a name must be provided. This name is used to distinguish the
+    instance's log messages and RedisCache from other instances. Using the name of the class or module containing
+    the instance is suggested. The same name must be provided after a restart for the tasks to be preserved.
+
+    A coroutine must be provided in order to reschedule each of the keys contained in the cache at init.
+    The coroutine will take a single argument, the ID used to create the Scheduler task in the first place.
+
+    Coroutines can be scheduled immediately with `schedule` or in the future with `schedule_at`
+    or `schedule_later`. A unique ID is required to be given in order to keep track of the
+    resulting Tasks. Any scheduled task can be cancelled prematurely using `cancel` by providing
+    the same ID used to schedule it.  The `in` operator is supported for checking if a task with a
+    given ID is currently scheduled.
+
+    Any exception raised in a scheduled task is logged when the task is done.
+    """
+
+    def __init__(self, name: str, task_factory: SchedulerTaskFactory, bot: Bot):
+        super().__init__(name)
+
+        self.cache = RedisCache(namespace=f"{__name__}.{name}")
+
+        self.task_factory = task_factory
+        self.bot = bot
+
+        self.ready = asyncio.Event()
+
+        self.reschedule_task = self.bot.loop.create_task(self._start_scheduler())
+
+    async def wait_until_ready(self) -> None:
+        """Wait until the scheduler is ready and the cache is ready (and all cached tasks are scheduled)."""
+        await self.ready.wait()
+
+    async def get(self, task_id: CacheKey) -> t.Optional[Arrow]:
+        """Get the time in which `task_id`'s task should go off. If the task is not found return None."""
+        timestamp = await self.cache.get(task_id)
+
+        if not timestamp:
+            return None
+        return Arrow.utcfromtimestamp(timestamp)
+
+    async def to_dict(self) -> t.Dict[CacheKey, Arrow]:
+        """
+        Get a dict representation of the currently scheduled tasks.
+
+        The dictionary contains the task_id's as keys, and the times in which the tasks should go off as values.
+        """
+        dict_ = await self.cache.to_dict()
+        return {task_id: Arrow.utcfromtimestamp(timestamp) for task_id, timestamp in dict_.items()}
+
+    async def reschedule_task(self, task_id: CacheKey) -> None:
+        """Reschedule the task according to `task_factory` and `task_id`."""
+        time = await self.scheduled_at(task_id)
+        super().schedule_at(time, task_id, coroutine=self._to_schedule(task_id))
+
+    async def reschedule_all_tasks(self) -> None:
+        """Reschedule all tasks according to `task_factory` and the ID's in the cache."""
+        tasks = await self.cache.items()
+        for task_id, timestamp in tasks:
+            time = Arrow.utcfromtimestamp(timestamp)
+            super().schedule_at(time.datetime, task_id, coroutine=self._to_schedule(task_id))
+
+    async def delete(self, task_id: CacheKey) -> None:
+        """
+        Unschedule the task identified by `task_id` and delete it from the cache.
+
+        `cancel` is left as-is in order to be able to pause execution until the next reschedule.
+        Log a warning if the task doesn't exist.
+        """
+        await self.cache.delete(task_id)
+
+        super().cancel(task_id)
+
+    async def delete_all(self) -> None:
+        """
+        Unschedule all known tasks and wipe the cache.
+
+        `cancel_all` remains untouched so that it can be used in instances such as cog unloads while preserving cache.
+        """
+        self.reschedule_task.cancel()
+        await self.cache.clear()
+
+        self.reschedule_task.add_done_callback(super().cancel_all())
+
+    async def schedule_at(self, time: datetime, task_id: CacheKey) -> None:
+        """
+        Schedule `coroutine` to be executed at the given `time` and add it to the cache.
+
+        If `time` is timezone aware, then use that timezone to calculate now() when subtracting.
+        If `time` is naïve, then use UTC.
+
+        If `time` is in the past, schedule `coroutine` immediately.
+
+        If a task with `task_id` already exists, close `coroutine` instead of scheduling it. This
+        prevents unawaited coroutine warnings. Don't pass a coroutine that'll be re-used elsewhere.
+        """
+        super().schedule_at(time, task_id, self._to_schedule(task_id))
+
+        if time.tzinfo is None:
+            time.replace(tzinfo=timezone.utc)
+        await self.cache.set(task_id, time.timestamp())
+
+    async def schedule_later(self, delay: t.Union[int, float], task_id: CacheKey) -> None:
+        """
+        Schedule `coroutine` to be executed after the given `delay` number of seconds and add it to the cache.
+
+        If a task with `task_id` already exists, close `coroutine` instead of scheduling it. This
+        prevents unawaited coroutine warnings. Don't pass a coroutine that'll be re-used elsewhere.
+        """
+        super().schedule_later(delay, task_id, self._to_schedule(task_id))
+
+        time = arrow.utcnow() + timedelta(seconds=delay)
+        await self.cache.set(task_id, time.timestamp())
+
+    def cancel_all(self) -> None:
+        """Unschedule all known tasks."""
+        self.reschedule_task.cancel()
+        self.reschedule_task.add_done_callback(lambda _: super(PersistentScheduler, self).cancel_all())
+
+    async def _start_scheduler(self) -> None:
+        """Starts the persistent scheduler by awaiting the guild before rescheduling the tasks."""
+        await self.bot.wait_until_guild_available()
+
+        await self.reschedule_all_tasks()
+
+        self.ready.set()
+
+    async def _to_schedule(self, task_id: CacheKey) -> None:
+        """
+        Wraps the task to run, so that we can delete the key from the cache.
+
+        We delete the task from the cache first. If deletion fails for some reason the task will be run on
+        the next load. If the task fails we don't care about rerunning it on the next load.
+        """
+        await self.cache.delete(task_id)
+
+        await self.task_factory(task_id)


### PR DESCRIPTION
It is gradually becoming a more common pattern to use a combination of the Scheduler class with an async redis cache to persistent scheduled tasks across restarts. Both a Scheduler and a redis cache are initialized in a cog, and there's a function to reschedule tasks on load. It is currently used in the `ModPings` and `Stream` cogs, and I foresee it being used in a couple more places in the near future as well.

I created a class that abstracts that combo away, to create the interface of a scheduler which can be assumed to persist across restarts (within the limitations of persistence of a redis cache).

Additionally, doing so allows us to standardize the usage of unix timestamps.

## Choices and limitations
* This scheduler is limited to taking a single async function, which is used to schedule all tasks, represented by keys in the cache. I don't see an easy way to automatically reschedule those tasks when the persistent scheduler is created.
* At first I tried to make it subclass the Scheduler, but couldn't make it work cleanly, as I needed to change method signatures, and the immediate `schedule` method didn't make much sense in this context. So there's now a Scheduler attribute instead,
* Currently, the async function can only take the key as an argument, and the value in the cache is the timestamp in which the task should go off. This is a bit inflexible. It might be better to make the value a JSON string with a `'timestamp'` field, and another field for keyword arguments the async function can take (that way it might be possible to use it for the help channel system as well).