### PR TITLE
Add a newline character in code-blocks to ensure content isn't interpreted as the language.

### DIFF
--- a/bot/exts/utils/extensions.py
+++ b/bot/exts/utils/extensions.py
@@ -109,7 +109,7 @@ class Extensions(commands.Cog):
         blacklisted = "\n".join(UNLOAD_BLACKLIST & set(extensions))
 
         if blacklisted:
-            msg = f":x: The following extension(s) may not be unloaded:```{blacklisted}```"
+            msg = f":x: The following extension(s) may not be unloaded:```\n{blacklisted}```"
         else:
             if "*" in extensions or "**" in extensions:
                 extensions = set(self.bot.extensions.keys()) - UNLOAD_BLACKLIST
@@ -212,7 +212,7 @@ class Extensions(commands.Cog):
 
         if failures:
             failures = "\n".join(f"{ext}\n    {err}" for ext, err in failures.items())
-            msg += f"\nFailures:```{failures}```"
+            msg += f"\nFailures:```\n{failures}```"
 
         log.debug(f"Batch {verb}ed extensions.")
 
@@ -239,7 +239,7 @@ class Extensions(commands.Cog):
             log.exception(f"Extension '{ext}' failed to {verb}.")
 
             error_msg = f"{e.__class__.__name__}: {e}"
-            msg = f":x: Failed to {verb} extension `{ext}`:\n```{error_msg}```"
+            msg = f":x: Failed to {verb} extension `{ext}`:\n```\n{error_msg}```"
         else:
             msg = f":ok_hand: Extension successfully {verb}ed: `{ext}`."
             log.debug(msg[10:])


### PR DESCRIPTION
<img width="540" alt="Screenshot 2021-05-08 at 12 23 58 AM" src="https://user-images.githubusercontent.com/74311372/117495770-b2d09700-af93-11eb-9495-d1ff7537a488.png">

The lack of a newline makes Discord ignore `bot.exts.moderation.modlog`. This bug also shows itself while displaying the failures in `batch_manage`.
