### PR TITLE
Fix Ping Bugs On Localhost

### DIFF
--- a/bot/exts/utils/ping.py
+++ b/bot/exts/utils/ping.py
@@ -42,8 +42,12 @@ class Latency(commands.Cog):
 
         try:
             url = urllib.parse.urlparse(URLs.site_schema + URLs.site).hostname
-            delay = await aioping.ping(url, family=socket.AddressFamily.AF_INET) * 1000
-            site_ping = f"{delay:.{ROUND_LATENCY}f} ms"
+            try:
+                delay = await aioping.ping(url, family=socket.AddressFamily.AF_INET) * 1000
+                site_ping = f"{delay:.{ROUND_LATENCY}f} ms"
+            except OSError:
+                # Some machines do not have permission to run ping
+                site_ping = "Permission denied, could not ping."
 
         except TimeoutError:
             site_ping = f"{Emojis.cross_mark} Connection timed out."

--- a/bot/exts/utils/ping.py
+++ b/bot/exts/utils/ping.py
@@ -35,7 +35,10 @@ class Latency(commands.Cog):
         # datetime.datetime objects do not have the "milliseconds" attribute.
         # It must be converted to seconds before converting to milliseconds.
         bot_ping = (datetime.utcnow() - ctx.message.created_at).total_seconds() * 1000
-        bot_ping = f"{bot_ping:.{ROUND_LATENCY}f} ms"
+        if bot_ping <= 0:
+            bot_ping = "Your clock is out of sync, could not calculate ping."
+        else:
+            bot_ping = f"{bot_ping:.{ROUND_LATENCY}f} ms"
 
         try:
             url = urllib.parse.urlparse(URLs.site_schema + URLs.site).hostname

--- a/bot/exts/utils/ping.py
+++ b/bot/exts/utils/ping.py
@@ -1,4 +1,5 @@
 import socket
+import urllib.parse
 from datetime import datetime
 
 import aioping
@@ -37,7 +38,8 @@ class Latency(commands.Cog):
         bot_ping = f"{bot_ping:.{ROUND_LATENCY}f} ms"
 
         try:
-            delay = await aioping.ping(URLs.site, family=socket.AddressFamily.AF_INET) * 1000
+            url = urllib.parse.urlparse(URLs.site_schema + URLs.site).hostname
+            delay = await aioping.ping(url, family=socket.AddressFamily.AF_INET) * 1000
             site_ping = f"{delay:.{ROUND_LATENCY}f} ms"
 
         except TimeoutError:


### PR DESCRIPTION
## Description
Closes #1407.

## Changes
- Improves parsing of site URL, to make it work locally and in prod. This has been tested in prod, locally, and on docker.
- Changes the output of the bot latency for when ping is < 0. This is usually caused by a desynced closk. Interestingly, the docker container is always a few seconds out of sync, even after syncing my system clock, and rebuilding the container. This seems like a docker problem though, so I'm not quite sure how to fix it.
- Added another fix where the ping utility is not available on Linux based OSes, if not running as root. Simplest solution was to just say it didn't work.

## Screenshots
The new error message when ping is < 0.

![New error message](https://user-images.githubusercontent.com/47495861/117582983-74f77e00-b10d-11eb-90ab-ba0a9b92dd78.png)

Error message for missing permissions.

![Missing perms](https://user-images.githubusercontent.com/47495861/117585489-54362500-b11b-11eb-96cb-336e857ef299.png)
