### PR TITLE
Add docker-compose.override.yml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ log.*
 
 # Custom user configuration
 config.yml
+docker-compose.override.yml
 
 # xmlrunner unittest XML reports
 TEST-**.xml


### PR DESCRIPTION
The override file is read by docker compose automatically and can be used to customize the configuration locally