### PR TITLE
Change the class docstring on `ErrorHandler` cog to the imperative mood

### DIFF
--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 class ErrorHandler(Cog):
-    """Handles errors emitted from commands."""
+    """Handle errors emitted from commands."""
 
     def __init__(self, bot: Bot):
         self.bot = bot


### PR DESCRIPTION
## Description
I'm not even sure if this is worth a pull request, I was literally bored and while sifting through the source code I saw this lol
"Handles errors" should be "Handle errors" (in the imperative mood, as described by [the PyDis Styleguide](https://pythondiscord.com/pages/contributing/style-guide/#mood).)

Can we get a speedrun merge??