### PR TITLE
Fix pre-commit, since flake8 isn't a task

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: flake8
         name: Flake8
         description: This hook runs flake8 within our project's environment.
-        entry: poetry run task flake8
+        entry: poetry run flake8
         language: system
         types: [python]
         require_serial: true


### PR DESCRIPTION
The pre-commit file current runs flake8 via `poetry run task flake8` but flake 8 isn't a task, so it fails.