### PR TITLE
Improve doc symbol name conflict resolution

### DIFF
--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -30,6 +30,7 @@ FORCE_PREFIX_GROUPS = (
     "term",
     "label",
     "token",
+    "doc",
     "pdbcommand",
     "2to3fixer",
 )

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -27,11 +27,11 @@ log = logging.getLogger(__name__)
 
 # symbols with a group contained here will get the group prefixed on duplicates
 FORCE_PREFIX_GROUPS = (
-    "2to3fixer",
-    "token",
-    "label",
-    "pdbcommand",
     "term",
+    "label",
+    "token",
+    "pdbcommand",
+    "2to3fixer",
 )
 NOT_FOUND_DELETE_DELAY = RedirectOutput.delete_delay
 # Delay to wait before trying to reach a rescheduled inventory again, in minutes
@@ -191,7 +191,11 @@ class DocCog(commands.Cog):
         # If the symbol's group is a non-priority group from FORCE_PREFIX_GROUPS,
         # add it as a prefix to disambiguate the symbols.
         elif group_name in FORCE_PREFIX_GROUPS:
-            return rename(item.group)
+            if item.group in FORCE_PREFIX_GROUPS:
+                needs_moving = FORCE_PREFIX_GROUPS.index(group_name) < FORCE_PREFIX_GROUPS.index(item.group)
+            else:
+                needs_moving = False
+            return rename(item.group if needs_moving else group_name, rename_extant=needs_moving)
 
         # If the above conditions didn't pass, either the existing symbol has its group in FORCE_PREFIX_GROUPS,
         # or deciding which item to rename would be arbitrary, so we rename the existing symbol.

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -181,22 +181,22 @@ class DocCog(commands.Cog):
             else:
                 return new_name
 
-        # Certain groups are added as prefixes to disambiguate the symbols.
-        if group_name in FORCE_PREFIX_GROUPS:
-            return rename(group_name)
+        # When there's a conflict, and the package names of the items differ, use the package name as a prefix.
+        if package_name != item.package:
+            if package_name in PRIORITY_PACKAGES:
+                return rename(item.package, rename_extant=True)
+            else:
+                return rename(package_name)
 
-        # The existing symbol with which the current symbol conflicts should have a group prefix.
-        # It currently doesn't have the group prefix because it's only added once there's a conflict.
-        elif item.group in FORCE_PREFIX_GROUPS:
-            return rename(item.group, rename_extant=True)
+        # If the symbol's group is a non-priority group from FORCE_PREFIX_GROUPS,
+        # add it as a prefix to disambiguate the symbols.
+        elif group_name in FORCE_PREFIX_GROUPS:
+            return rename(item.group)
 
-        elif package_name in PRIORITY_PACKAGES:
-            return rename(item.package, rename_extant=True)
-
-        # If we can't specially handle the symbol through its group or package,
-        # fall back to prepending its package name to the front.
+        # If the above conditions didn't pass, either the existing symbol has its group in FORCE_PREFIX_GROUPS,
+        # or deciding which item to rename would be arbitrary, so we rename the existing symbol.
         else:
-            return rename(package_name)
+            return rename(item.group, rename_extant=True)
 
     async def refresh_inventories(self) -> None:
         """Refresh internal documentation inventories."""


### PR DESCRIPTION
Instead of only using the package name as a fallback to resolve the conflicts, it's now used as the first path with the group renames only used for conflicts within packages, this should make it clearer what the symbol may be about when it's shown in the similar names footer.
This also makes the names a bit less dependent on the order the inventories were fetched in.

In addition to using the package name, conflicts within a package where both of the symbols have their group in `FORCE_PREFIX_GROUPS` are now handled with respect to their order in the constant, where the symbol with the higher priority group uses the un-modified key.

Takes care of the initial issue in #1548 where non python docs were fetched for certain symbols.