### PR TITLE
Up duck pond threshold to 7

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -511,7 +511,7 @@ redirect_output:
 
 
 duck_pond:
-    threshold: 5
+    threshold: 7
     channel_blacklist:
         - *ANNOUNCEMENTS
         - *PYNEWS_CHANNEL


### PR DESCRIPTION
Makes duck pond entries less common, by requiring more ducks in order for a message to be ducked.