### PR TITLE
Update pixels token regex to false match less

### DIFF
--- a/bot/exts/filters/pixels_token_remover.py
+++ b/bot/exts/filters/pixels_token_remover.py
@@ -21,7 +21,7 @@ DELETION_MESSAGE_TEMPLATE = (
     "You can go to <https://pixels.pythondiscord.com/authorize> to get a new key."
 )
 
-PIXELS_TOKEN_RE = re.compile(r"[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+\=]*")
+PIXELS_TOKEN_RE = re.compile(r"[A-Za-z0-9-_=]{30,}\.[A-Za-z0-9-_=]{50,}\.[A-Za-z0-9-_.+\=]{30,}")
 
 
 class PixelsTokenRemover(Cog):


### PR DESCRIPTION
This new regex means there needs to be a minimum number of characters between each `.`, along with requiring there to be 3 "sections" to the API token.

This should reduce the number of false matches 