### PR TITLE
Recruitment: reverse nomination order

### DIFF
--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -120,7 +120,8 @@ class Reviewer:
         opening = f"<@&{Roles.mod_team}> <@&{Roles.admins}>\n{member.mention} ({member}) for Helper!"
 
         current_nominations = "\n\n".join(
-            f"**<@{entry['actor']}>:** {entry['reason'] or '*no reason given*'}" for entry in nomination['entries']
+            f"**<@{entry['actor']}>:** {entry['reason'] or '*no reason given*'}"
+            for entry in nomination['entries'][::-1]
         )
         current_nominations = f"**Nominated by:**\n{current_nominations}"
 


### PR DESCRIPTION
This makes review appear in chronological order, making it easier to say things like "^^ what they said".