### PR TITLE
Add discord.li to invite filter

### DIFF
--- a/bot/utils/regex.py
+++ b/bot/utils/regex.py
@@ -5,6 +5,7 @@ INVITE_RE = re.compile(
     r"discord(?:[\.,]|dot)com(?:\/|slash)invite|"     # or discord.com/invite/
     r"discordapp(?:[\.,]|dot)com(?:\/|slash)invite|"  # or discordapp.com/invite/
     r"discord(?:[\.,]|dot)me|"                        # or discord.me
+    r"discord(?:[\.,]|dot)li|"                        # or discord.li
     r"discord(?:[\.,]|dot)io"                         # or discord.io.
     r")(?:[\/]|slash)"                                # / or 'slash'
     r"([a-zA-Z0-9\-]+)",                              # the invite code itself


### PR DESCRIPTION
Discord.li is an alias for discord.io, a domain already on the denylist.