### PR TITLE
chore: ensmallen the star-imports tag

### DIFF
--- a/bot/resources/tags/star-imports.md
+++ b/bot/resources/tags/star-imports.md
@@ -16,33 +16,24 @@ Example:
 >>> from math import *
 >>> sin(pi / 2)  # uses sin from math rather than your custom sin
 ```
-
 • Potential namespace collision. Names defined from a previous import might get shadowed by a wildcard import.
-
 • Causes ambiguity. From the example, it is unclear which `sin` function is actually being used. From the Zen of Python **[3]**: `Explicit is better than implicit.`
-
 • Makes import order significant, which they shouldn't. Certain IDE's `sort import` functionality may end up breaking code due to namespace collision.
 
 **How should you import?**
 
 • Import the module under the module's namespace (Only import the name of the module, and names defined in the module can be used by prefixing the module's name)
-
 ```python
 >>> import math
 >>> math.sin(math.pi / 2)
 ```
-
 • Explicitly import certain names from the module
-
 ```python
 >>> from math import sin, pi
 >>> sin(pi / 2)
 ```
-
 Conclusion: Namespaces are one honking great idea -- let's do more of those! *[3]*
 
 **[1]** If the module defines the variable `__all__`, the names defined in `__all__` will get imported by the wildcard import, otherwise all the names in the module get imported (except for names with a leading underscore)
-
 **[2]** [Namespaces and scopes](https://www.programiz.com/python-programming/namespace)
-
 **[3]** [Zen of Python](https://www.python.org/dev/peps/pep-0020/)


### PR DESCRIPTION
This PR removes a bunch of blank lines to make the star-imports tag smaller, discussed [here](https://canary.discord.com/channels/267624335836053506/635950537262759947/850349882379599902)

Before:
![image](https://user-images.githubusercontent.com/16879430/120801898-b0813e80-c539-11eb-985d-1487104506bf.png)

After: 
![image](https://user-images.githubusercontent.com/16879430/120801858-a3644f80-c539-11eb-9178-868d91268425.png)
