### PR TITLE
Allow text format warning to remove multiple formats.

### DIFF
--- a/bot/exts/filters/antimalware.py
+++ b/bot/exts/filters/antimalware.py
@@ -15,9 +15,11 @@ PY_EMBED_DESCRIPTION = (
     f"please use a code-pasting service such as {URLs.site_schema}{URLs.site_paste}"
 )
 
+TXT_LIKE_FILES = {".txt", ".csv", ".json"}
 TXT_EMBED_DESCRIPTION = (
     "**Uh-oh!** It looks like your message got zapped by our spam filter. "
-    "We currently don't allow `.txt` attachments, so here are some tips to help you travel safely: \n\n"
+    "We currently don't allow `{blocked_extension_str}` attachments, "
+    "so here are some tips to help you travel safely: \n\n"
     "• If you attempted to send a message longer than 2000 characters, try shortening your message "
     "to fit within the character limit or use a pasting service (see below) \n\n"
     "• If you tried to show someone your code, you can use codeblocks \n(run `!code-blocks` in "
@@ -70,10 +72,13 @@ class AntiMalware(Cog):
         if ".py" in extensions_blocked:
             # Short-circuit on *.py files to provide a pastebin link
             embed.description = PY_EMBED_DESCRIPTION
-        elif ".txt" in extensions_blocked:
+        elif extensions := TXT_LIKE_FILES.intersection(extensions_blocked):
             # Work around Discord AutoConversion of messages longer than 2000 chars to .txt
             cmd_channel = self.bot.get_channel(Channels.bot_commands)
-            embed.description = TXT_EMBED_DESCRIPTION.format(cmd_channel_mention=cmd_channel.mention)
+            embed.description = TXT_EMBED_DESCRIPTION.format(
+                blocked_extension_str=extensions.pop(),
+                cmd_channel_mention=cmd_channel.mention
+            )
         elif extensions_blocked:
             meta_channel = self.bot.get_channel(Channels.meta)
             embed.description = DISALLOWED_EMBED_DESCRIPTION.format(

--- a/bot/exts/filters/antimalware.py
+++ b/bot/exts/filters/antimalware.py
@@ -18,7 +18,7 @@ PY_EMBED_DESCRIPTION = (
 TXT_LIKE_FILES = {".txt", ".csv", ".json"}
 TXT_EMBED_DESCRIPTION = (
     "**Uh-oh!** It looks like your message got zapped by our spam filter. "
-    "We currently don't allow `{blocked_extension_str}` attachments, "
+    "We currently don't allow `{blocked_extension}` attachments, "
     "so here are some tips to help you travel safely: \n\n"
     "• If you attempted to send a message longer than 2000 characters, try shortening your message "
     "to fit within the character limit or use a pasting service (see below) \n\n"
@@ -76,7 +76,7 @@ class AntiMalware(Cog):
             # Work around Discord AutoConversion of messages longer than 2000 chars to .txt
             cmd_channel = self.bot.get_channel(Channels.bot_commands)
             embed.description = TXT_EMBED_DESCRIPTION.format(
-                blocked_extension_str=extensions.pop(),
+                blocked_extension=extensions.pop(),
                 cmd_channel_mention=cmd_channel.mention
             )
         elif extensions_blocked:

--- a/tests/bot/exts/filters/test_antimalware.py
+++ b/tests/bot/exts/filters/test_antimalware.py
@@ -131,7 +131,7 @@ class AntiMalwareCogTests(unittest.IsolatedAsyncioTestCase):
                     antimalware.TXT_EMBED_DESCRIPTION.format.return_value
                 )
                 antimalware.TXT_EMBED_DESCRIPTION.format.assert_called_with(
-                    blocked_extension_str=disallowed_extension,
+                    blocked_extension=disallowed_extension,
                     cmd_channel_mention=cmd_channel.mention
                 )
 

--- a/tests/bot/exts/filters/test_antimalware.py
+++ b/tests/bot/exts/filters/test_antimalware.py
@@ -118,7 +118,10 @@ class AntiMalwareCogTests(unittest.IsolatedAsyncioTestCase):
         cmd_channel = self.bot.get_channel(Channels.bot_commands)
 
         self.assertEqual(embed.description, antimalware.TXT_EMBED_DESCRIPTION.format.return_value)
-        antimalware.TXT_EMBED_DESCRIPTION.format.assert_called_with(cmd_channel_mention=cmd_channel.mention)
+        antimalware.TXT_EMBED_DESCRIPTION.format.assert_called_with(
+            blocked_extension_str=".txt",
+            cmd_channel_mention=cmd_channel.mention
+        )
 
     async def test_other_disallowed_extension_embed_description(self):
         """Test the description for a non .py/.txt disallowed extension."""

--- a/tests/bot/exts/filters/test_antimalware.py
+++ b/tests/bot/exts/filters/test_antimalware.py
@@ -104,7 +104,7 @@ class AntiMalwareCogTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(embed.description, antimalware.PY_EMBED_DESCRIPTION)
 
     async def test_txt_file_redirect_embed_description(self):
-        """A message containing a .txt file should result in the correct embed."""
+        """A message containing a .txt/.json/.csv file should result in the correct embed."""
         test_values = (
             ("text", ".txt"),
             ("json", ".json"),
@@ -136,7 +136,7 @@ class AntiMalwareCogTests(unittest.IsolatedAsyncioTestCase):
                 )
 
     async def test_other_disallowed_extension_embed_description(self):
-        """Test the description for a non .py/.txt disallowed extension."""
+        """Test the description for a non .py/.txt/.json/.csv disallowed extension."""
         attachment = MockAttachment(filename="python.disallowed")
         self.message.attachments = [attachment]
         self.message.channel.send = AsyncMock()

--- a/tests/bot/exts/filters/test_antimalware.py
+++ b/tests/bot/exts/filters/test_antimalware.py
@@ -105,23 +105,35 @@ class AntiMalwareCogTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_txt_file_redirect_embed_description(self):
         """A message containing a .txt file should result in the correct embed."""
-        attachment = MockAttachment(filename="python.txt")
-        self.message.attachments = [attachment]
-        self.message.channel.send = AsyncMock()
-        antimalware.TXT_EMBED_DESCRIPTION = Mock()
-        antimalware.TXT_EMBED_DESCRIPTION.format.return_value = "test"
-
-        await self.cog.on_message(self.message)
-        self.message.channel.send.assert_called_once()
-        args, kwargs = self.message.channel.send.call_args
-        embed = kwargs.pop("embed")
-        cmd_channel = self.bot.get_channel(Channels.bot_commands)
-
-        self.assertEqual(embed.description, antimalware.TXT_EMBED_DESCRIPTION.format.return_value)
-        antimalware.TXT_EMBED_DESCRIPTION.format.assert_called_with(
-            blocked_extension_str=".txt",
-            cmd_channel_mention=cmd_channel.mention
+        test_values = (
+            ("text", ".txt"),
+            ("json", ".json"),
+            ("csv", ".csv"),
         )
+
+        for file_name, disallowed_extension in test_values:
+            with self.subTest(file_name=file_name, disallowed_extension=disallowed_extension):
+
+                attachment = MockAttachment(filename=f"{file_name}{disallowed_extension}")
+                self.message.attachments = [attachment]
+                self.message.channel.send = AsyncMock()
+                antimalware.TXT_EMBED_DESCRIPTION = Mock()
+                antimalware.TXT_EMBED_DESCRIPTION.format.return_value = "test"
+
+                await self.cog.on_message(self.message)
+                self.message.channel.send.assert_called_once()
+                args, kwargs = self.message.channel.send.call_args
+                embed = kwargs.pop("embed")
+                cmd_channel = self.bot.get_channel(Channels.bot_commands)
+
+                self.assertEqual(
+                    embed.description,
+                    antimalware.TXT_EMBED_DESCRIPTION.format.return_value
+                )
+                antimalware.TXT_EMBED_DESCRIPTION.format.assert_called_with(
+                    blocked_extension_str=disallowed_extension,
+                    cmd_channel_mention=cmd_channel.mention
+                )
 
     async def test_other_disallowed_extension_embed_description(self):
         """Test the description for a non .py/.txt disallowed extension."""


### PR DESCRIPTION
Closes https://github.com/python-discord/bot/issues/943

Users sometimes post `.csv` or `.json` files without being redirected to the paste system.

This PR resolves that issue by still deleting their file, but mentioning what file got deleted, which file extension it contained, and how they can access our pasting service.

- [x] Functionally works after posting text, JSON, and Comma Separated Value files.
- [x] Working written tests.