### PR TITLE
Change to unless-stopped restart policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ x-logging: &logging
       max-size: "10m"
 
 x-restart-policy: &restart_policy
-  restart: always
+  restart: unless-stopped
 
 services:
   postgres:


### PR DESCRIPTION
Since we use the same port for redis, site  and postgres on all out projects, having this always restart causes conflicts for people starting up docker and wanting to any of those for any other projects.