### PR TITLE
Infraction: DM mention that the expiration is in UTC time

### DIFF
--- a/bot/exts/moderation/infraction/_utils.py
+++ b/bot/exts/moderation/infraction/_utils.py
@@ -164,7 +164,7 @@ async def notify_infraction(
 
     text = INFRACTION_DESCRIPTION_TEMPLATE.format(
         type=infr_type.title(),
-        expires=expires_at or "N/A",
+        expires=f"{expires_at} UTC" if expires_at else "N/A",
         reason=reason or "No reason provided."
     )
 

--- a/tests/bot/exts/moderation/infraction/test_utils.py
+++ b/tests/bot/exts/moderation/infraction/test_utils.py
@@ -137,7 +137,7 @@ class ModerationUtilsTests(unittest.IsolatedAsyncioTestCase):
                     title=utils.INFRACTION_TITLE,
                     description=utils.INFRACTION_DESCRIPTION_TEMPLATE.format(
                         type="Ban",
-                        expires="2020-02-26 09:20 (23 hours and 59 minutes)",
+                        expires="2020-02-26 09:20 (23 hours and 59 minutes) UTC",
                         reason="No reason provided."
                     ),
                     colour=Colours.soft_red,
@@ -193,7 +193,7 @@ class ModerationUtilsTests(unittest.IsolatedAsyncioTestCase):
                     title=utils.INFRACTION_TITLE,
                     description=utils.INFRACTION_DESCRIPTION_TEMPLATE.format(
                         type="Mute",
-                        expires="2020-02-26 09:20 (23 hours and 59 minutes)",
+                        expires="2020-02-26 09:20 (23 hours and 59 minutes) UTC",
                         reason="Test"
                     ),
                     colour=Colours.soft_red,


### PR DESCRIPTION
We have a few users DMing ModMail to ask why they haven't been unmuted and their mute should have expired. Most of the time it is simply that they forgot to convert their local time to UTC time. This can hopefully avoid some of those instances.