### PR TITLE
Add black-formatter to reminders overrides

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -433,6 +433,8 @@ class Channels(metaclass=YAMLGetter):
     off_topic_1: int
     off_topic_2: int
 
+    black_formatter: int
+
     bot_commands: int
     discord_py: int
     esoteric: int

--- a/config-default.yml
+++ b/config-default.yml
@@ -176,6 +176,9 @@ guild:
         user_log:                           528976905546760203
         voice_log:                          640292421988646961
 
+        # Open Source Projects
+        black_formatter:    &BLACK_FORMATTER 846434317021741086
+
         # Off-topic
         off_topic_0:    291284109232308226
         off_topic_1:    463035241142026251
@@ -244,6 +247,7 @@ guild:
     reminder_whitelist:
         - *BOT_CMD
         - *DEV_CONTRIB
+        - *BLACK_FORMATTER
 
     roles:
         announcements:                          463658397560995840


### PR DESCRIPTION
Adds the black-formatter channel to the remind command overrides to
allow usage of the command in the channel. This isn't the cleanest
patch, ideally the whole OSS category would be whitelisted but the
filter currently doesn't support categories.

Co-authored-by:  Hassan Abouelela <hassan@hassanamr.com>

--- 

Signed off here: https://discord.com/channels/267624335836053506/846434317021741086/852958371497377892