### PR TITLE
Add an optional loop kwarg to scheduling.create_task

### DIFF
--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -54,7 +54,7 @@ def reaction_check(
         log.trace(f"Removing reaction {reaction} by {user} on {reaction.message.id}: disallowed user.")
         scheduling.create_task(
             reaction.message.remove_reaction(reaction.emoji, user),
-            HTTPException,  # Suppress the HTTPException if adding the reaction fails
+            suppressed_exceptions=(HTTPException,),
             name=f"remove_reaction-{reaction}-{reaction.message.id}-{user}"
         )
         return False

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -161,9 +161,21 @@ class Scheduler:
                 self._log.error(f"Error in task #{task_id} {id(done_task)}!", exc_info=exception)
 
 
-def create_task(coro: t.Awaitable, *suppressed_exceptions: t.Type[Exception], **kwargs) -> asyncio.Task:
-    """Wrapper for `asyncio.create_task` which logs exceptions raised in the task."""
-    task = asyncio.create_task(coro, **kwargs)
+def create_task(
+        coro: t.Awaitable,
+        *suppressed_exceptions: t.Type[Exception],
+        event_loop: asyncio.AbstractEventLoop = None,
+        **kwargs
+) -> asyncio.Task:
+    """
+    Wrapper for creating asyncio `Task`s which logs exceptions raised in the task.
+
+    If the loop kwarg is provided, the task is created from that event loop, otherwise the running loop is used.
+    """
+    if event_loop is not None:
+        task = event_loop.create_task(coro, **kwargs)
+    else:
+        task = asyncio.create_task(coro, **kwargs)
     task.add_done_callback(partial(_log_task_exception, suppressed_exceptions=suppressed_exceptions))
     return task
 

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -163,7 +163,8 @@ class Scheduler:
 
 def create_task(
     coro: t.Awaitable,
-    *suppressed_exceptions: t.Type[Exception],
+    *,
+    suppressed_exceptions: tuple[t.Type[Exception]] = (),
     event_loop: t.Optional[asyncio.AbstractEventLoop] = None,
     **kwargs,
 ) -> asyncio.Task:

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -162,10 +162,10 @@ class Scheduler:
 
 
 def create_task(
-        coro: t.Awaitable,
-        *suppressed_exceptions: t.Type[Exception],
-        event_loop: asyncio.AbstractEventLoop = None,
-        **kwargs
+    coro: t.Awaitable,
+    *suppressed_exceptions: t.Type[Exception],
+    event_loop: t.Optional[asyncio.AbstractEventLoop] = None,
+    **kwargs,
 ) -> asyncio.Task:
     """
     Wrapper for creating asyncio `Task`s which logs exceptions raised in the task.


### PR DESCRIPTION
The `create_task` util is used to create tasks which log their exceptions to make debugging easier, but with its current implementation it cannot be used to schedule tasks from the init of cogs as there's no running loop when they execute.

The loop kwarg allows the caller to pass in `bot.loop` in these situations to get a task with the same exception logging.