### PR TITLE
Proposed alternative "available help channel" message.

### DIFF
--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -15,15 +15,13 @@ log = logging.getLogger(__name__)
 ASKING_GUIDE_URL = "https://pythondiscord.com/pages/asking-good-questions/"
 
 AVAILABLE_MSG = f"""
-**Send your question here to claim the channel**
-This channel will be dedicated to answering your question only. Others will try to answer and help you solve the issue.
+**Send your question here to claim the channel.**
 
-**Keep in mind:**
-• It's always ok to just ask your question. You don't need permission.
-• Explain what you expect to happen and what actually happens.
-• Include a code sample and error message, if you got any.
+• **Ask your actual question, not if you can ask a question.**
+• **Provide a code sample as text (not as a screenshot) and the error message, if you got one.**
+• **Explain what you expect to happen and what actually happens.**
 
-For more tips, check out our guide on **[asking good questions]({ASKING_GUIDE_URL})**.
+For more tips, check out our guide on [asking good questions]({ASKING_GUIDE_URL}).
 """
 
 AVAILABLE_TITLE = "Available help channel"

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -15,11 +15,12 @@ log = logging.getLogger(__name__)
 ASKING_GUIDE_URL = "https://pythondiscord.com/pages/asking-good-questions/"
 
 AVAILABLE_MSG = f"""
-**Send your question here to claim the channel.**
+Send your question here to claim the channel.
 
-• **Ask your actual question, not if you can ask a question.**
-• **Provide a code sample as text (not as a screenshot) and the error message, if you got one.**
-• **Explain what you expect to happen and what actually happens.**
+**Remember to:**
+• **Ask** your Python question, not if you can ask or if there's an expert who can help.
+• **Show** a code sample as text (rather than a screenshot) and the error message, if you got one.
+• **Explain** what you expect to happen and what actually happens.
 
 For more tips, check out our guide on [asking good questions]({ASKING_GUIDE_URL}).
 """


### PR DESCRIPTION
Having spent more time in the help channels lately, I don't think the "available help channel" message is having the intended effect. I suggest this version, which eliminates the part explaining that the channel will be allocated specifically for the one user (I think everyone knows this or infers as much), and more directly instruct them not to "ask to ask" and to avoid posting code as screenshots.

![image](https://user-images.githubusercontent.com/32915757/121791038-87088880-cbb3-11eb-8be7-e596cd1c155a.png)

The proposed wording is arguably less friendly, but I don't think this will be an issue if the people who help them are friendly, and I think those who are helping will be more friendly if the questions being posted are easier to jump into.

@Xithrius, perhaps we can discuss this at the staff meeting tomorrow?