### PR TITLE
Filters: up character limit to 4,200

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -398,7 +398,7 @@ anti_spam:
 
         chars:
             interval: 5
-            max: 3_000
+            max: 4_200
 
         discord_emojis:
             interval: 10


### PR DESCRIPTION
Since Discord Nitro now unlock a 4,000 character limit, some of our code broke, including our filters which limit you to only post up to 3,000 character in 10s. This limit has been upped to 4,200.

I added 200 characters so if a full length message is sent with another small comment it wouldn't trigger the filter. I can think of some past instances where that would have happened.