### PR TITLE
Prevent one from using the `!echo` command for a channel in which one can't speak

### DIFF
--- a/bot/exts/utils/bot.py
+++ b/bot/exts/utils/bot.py
@@ -45,7 +45,7 @@ class BotCog(Cog, name="Bot"):
         if channel is None:
             await ctx.send(text)
         elif not channel.permissions_for(ctx.author).send_messages:
-            await ctx.send('You don\'t have permission to speak in that channel.')
+            await ctx.send("You don't have permission to speak in that channel.")
         else:
             await channel.send(text)
 

--- a/bot/exts/utils/bot.py
+++ b/bot/exts/utils/bot.py
@@ -44,6 +44,8 @@ class BotCog(Cog, name="Bot"):
         """Repeat the given message in either a specified channel or the current channel."""
         if channel is None:
             await ctx.send(text)
+        elif not channel.permissions_for(ctx.author).send_messages:
+            await ctx.send('You don\'t have permission to speak in that channel.')
         else:
             await channel.send(text)
 


### PR DESCRIPTION
Changes the `!echo` command so that if someone attempts to echo to a channel in which they don't have send message permissions, the message is not relayed. Though that has never happened in the history of Python Discord.