### PR TITLE
Add alias for voice_verify command

### DIFF
--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -118,7 +118,7 @@ class VoiceGate(Cog):
         await self.redis_cache.set(member.id, message.id)
         return True, message.channel
 
-    @command(aliases=('voiceverify',))
+    @command(aliases=("voiceverify", "voice-verify",))
     @has_no_roles(Roles.voice_verified)
     @in_whitelist(channels=(Channels.voice_gate,), redirect=None)
     async def voice_verify(self, ctx: Context, *_) -> None:


### PR DESCRIPTION
Added voice-verify alias as the channel and tag are hyphenated so it may be confusing as it is currently.