### PR TITLE
Disable filter in codejam team channels

### DIFF
--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -283,7 +283,7 @@ class Filtering(Cog):
                             continue
 
                     if filter_name == "filter_invites":
-                        # Disable domains filter in codejam team channels
+                        # Disable invites filter in codejam team channels
                         category = msg.channel.category
                         if category and category.name == JAM_CATEGORY_NAME:
                             continue

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -20,6 +20,7 @@ from bot.constants import (
     Guild, Icons, URLs
 )
 from bot.exts.moderation.modlog import ModLog
+from bot.exts.utils.jams import CATEGORY_NAME as JAM_CATEGORY_NAME
 from bot.utils.messages import format_user
 from bot.utils.regex import INVITE_RE
 from bot.utils.scheduling import Scheduler
@@ -279,6 +280,12 @@ class Filtering(Cog):
                         # If the edit delta is less than 0.001 seconds, then we're probably dealing
                         # with a double filter trigger.
                         if delta is not None and delta < 100:
+                            continue
+
+                    if filter_name == "filter_invites":
+                        # Disable domains filter in codejam team channels
+                        category = msg.channel.category
+                        if category and category.name == JAM_CATEGORY_NAME:
                             continue
 
                     # Does the filter only need the message content or the full message?


### PR DESCRIPTION
This disables `filter_invites` in the code jam team channels 

Code jam team channels are based on the category name `Code Jam` used by the jams cog, so we shouldn't put any public channels under a category with that name. This code will likely be replaced by the new filters system in the near future so this should be fine anyway.