### PR TITLE
Information: make !server use moderation_team

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -46,7 +46,7 @@ class Information(Cog):
         """Return the total number of members for certain roles in `guild`."""
         roles = (
             guild.get_role(role_id) for role_id in (
-                constants.Roles.helpers, constants.Roles.moderators, constants.Roles.admins,
+                constants.Roles.helpers, constants.Roles.moderation_team, constants.Roles.admins,
                 constants.Roles.owners, constants.Roles.contributors,
             )
         )


### PR DESCRIPTION
We use the ping role instead of the team role here, leading to inaccuracies.