### PR TITLE
Prevent ghost-pings in docs get command

### DIFF
--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -14,7 +14,7 @@ import discord
 from discord.ext import commands
 
 from bot.bot import Bot
-from bot.constants import MODERATION_ROLES, RedirectOutput
+from bot.constants import Emojis, MODERATION_ROLES, RedirectOutput
 from bot.converters import Inventory, PackageName, ValidURL, allowed_strings
 from bot.pagination import LinePaginator
 from bot.utils.lock import SharedEvent, lock
@@ -341,6 +341,9 @@ class DocCog(commands.Cog):
             if doc_embed is None:
                 error_message = await send_denial(ctx, "No documentation found for the requested symbol.")
                 await wait_for_deletion(error_message, (ctx.author.id,), timeout=NOT_FOUND_DELETE_DELAY)
+
+                with suppress(discord.NotFound):
+                    await message.clear_reaction(Emojis.trashcan)
 
                 if not (ctx.message.mentions or ctx.message.role_mentions):
                     with suppress(discord.NotFound):

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -12,7 +12,6 @@ from typing import Dict, NamedTuple, Optional, Tuple, Union
 
 import aiohttp
 import discord
-
 from discord.ext import commands
 
 from bot.bot import Bot

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -343,7 +343,7 @@ class DocCog(commands.Cog):
                 await wait_for_deletion(error_message, (ctx.author.id,), timeout=NOT_FOUND_DELETE_DELAY)
 
                 with suppress(discord.NotFound):
-                    await message.clear_reaction(Emojis.trashcan)
+                    await error_message.clear_reaction(Emojis.trashcan)
 
                 if not (ctx.message.mentions or ctx.message.role_mentions):
                     with suppress(discord.NotFound):

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -13,7 +13,6 @@ from typing import Dict, NamedTuple, Optional, Tuple, Union
 import aiohttp
 import discord
 from discord import Colour, Embed, Message, NotFound, Reaction, User
-
 from discord.ext.commands import BadArgument, Cog, Context, group, has_any_role
 
 from bot.bot import Bot

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -344,6 +344,7 @@ class DocCog(commands.Cog):
                 with suppress(discord.NotFound):
                     await error_message.clear_reaction(Emojis.trashcan)
 
+                # Make sure that we won't cause a ghost-ping by deleting the message
                 if not (ctx.message.mentions or ctx.message.role_mentions):
                     with suppress(discord.NotFound):
                         await ctx.message.delete()

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -6,6 +6,7 @@ import sys
 import textwrap
 from collections import defaultdict
 from contextlib import suppress
+from functools import partial
 from types import SimpleNamespace
 from typing import Dict, NamedTuple, Optional, Tuple, Union
 

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -470,5 +470,6 @@ class DocCog(Cog):
         asyncio.create_task(self.item_fetcher.clear(), name="DocCog.item_fetcher unload clear")
 
 
-def predicate_emoji_reaction(ctx: Context, error_message: Message, reaction: Reaction, user: User):
+def predicate_emoji_reaction(ctx: Context, error_message: Message, reaction: Reaction, user: User) -> bool:
+    """Return whether command author added the `:x:` emote to the `error_message`."""
     return reaction.message == error_message and user == ctx.author and str(reaction) == DELETE_ERROR_MESSAGE_REACTION

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -468,7 +468,7 @@ class DocCog(Cog):
         self.inventory_scheduler.cancel_all()
         self.init_refresh_task.cancel()
         asyncio.create_task(self.item_fetcher.clear(), name="DocCog.item_fetcher unload clear")
-        
-        
+
+
 def predicate_emoji_reaction(ctx: Context, error_message: Message, reaction: Reaction, user: User):
     return reaction.message == error_message and user == ctx.author and str(reaction) == DELETE_ERROR_MESSAGE_REACTION

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from typing import Dict, NamedTuple, Optional, Tuple, Union
 
 import aiohttp
+import asyncio
 import discord
 from discord.ext import commands
 
@@ -34,6 +35,7 @@ FORCE_PREFIX_GROUPS = (
     "pdbcommand",
     "2to3fixer",
 )
+DELETE_ERROR_MESSAGE_REACTION = '\u274c'  # :x:
 NOT_FOUND_DELETE_DELAY = RedirectOutput.delete_delay
 # Delay to wait before trying to reach a rescheduled inventory again, in minutes
 FETCH_RESCHEDULE_DELAY = SimpleNamespace(first=2, repeated=5)
@@ -340,11 +342,29 @@ class DocCog(commands.Cog):
 
             if doc_embed is None:
                 error_message = await send_denial(ctx, "No documentation found for the requested symbol.")
-                await wait_for_deletion(error_message, (ctx.author.id,), timeout=NOT_FOUND_DELETE_DELAY)
-                with suppress(discord.NotFound):
-                    await ctx.message.delete()
-                with suppress(discord.NotFound):
-                    await error_message.delete()
+
+                if ctx.message.mentions or ctx.message.role_mentions:
+                    await error_message.add_reaction(DELETE_ERROR_MESSAGE_REACTION)
+
+                    try:
+                        await self.bot.wait_for(
+                            'reaction_add',
+                            check=lambda reaction, user: reaction.message == error_message and user == ctx.author and str(reaction) == DELETE_ERROR_MESSAGE_REACTION,
+                            timeout=NOT_FOUND_DELETE_DELAY
+                        )
+
+                        with suppress(discord.HTTPException):
+                            await error_message.delete()
+
+                    except asyncio.TimeoutError:
+                        await error_message.clear_reaction(DELETE_ERROR_MESSAGE_REACTION)
+
+                else:
+                    await wait_for_deletion(error_message, (ctx.author.id,), timeout=NOT_FOUND_DELETE_DELAY)
+                    with suppress(discord.NotFound):
+                        await ctx.message.delete()
+                    with suppress(discord.NotFound):
+                        await error_message.delete()
             else:
                 msg = await ctx.send(embed=doc_embed)
                 await wait_for_deletion(msg, (ctx.author.id,))

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -341,7 +341,6 @@ class DocCog(commands.Cog):
             if doc_embed is None:
                 error_message = await send_denial(ctx, "No documentation found for the requested symbol.")
                 await wait_for_deletion(error_message, (ctx.author.id,), timeout=NOT_FOUND_DELETE_DELAY)
-
                 with suppress(discord.NotFound):
                     await error_message.clear_reaction(Emojis.trashcan)
 

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -340,7 +340,6 @@ class DocCog(commands.Cog):
 
             if doc_embed is None:
                 error_message = await send_denial(ctx, "No documentation found for the requested symbol.")
-
                 await wait_for_deletion(error_message, (ctx.author.id,), timeout=NOT_FOUND_DELETE_DELAY)
 
                 if not (ctx.message.mentions or ctx.message.role_mentions):

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -10,7 +10,6 @@ from types import SimpleNamespace
 from typing import Dict, NamedTuple, Optional, Tuple, Union
 
 import aiohttp
-import asyncio
 import discord
 from discord.ext import commands
 

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -101,11 +101,11 @@ class DocCog(Cog):
         """
         self.base_urls[package_name] = base_url
 
-        for group, items in inventory.items():
+        for _group, items in inventory.items():
             for symbol_name, relative_doc_url in items:
 
                 # e.g. get 'class' from 'py:class'
-                group_name = group.split(":")[1]
+                group_name = _group.split(":")[1]
                 symbol_name = self.ensure_unique_symbol_name(
                     package_name,
                     group_name,

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -447,13 +447,3 @@ class DocCog(commands.Cog):
         self.inventory_scheduler.cancel_all()
         self.init_refresh_task.cancel()
         asyncio.create_task(self.item_fetcher.clear(), name="DocCog.item_fetcher unload clear")
-
-
-def predicate_emoji_reaction(
-        ctx: commands.Context,
-        message: discord.Message,
-        reaction: discord.Reaction,
-        user: discord.User
-) -> bool:
-    """Return whether command author added the `:x:` emote to the `message`."""
-    return reaction.message == message and user == ctx.author and str(reaction) == DELETE_ERROR_MESSAGE_REACTION

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -11,7 +11,9 @@ from typing import Dict, NamedTuple, Optional, Tuple, Union
 
 import aiohttp
 import discord
-from discord.ext import commands
+from discord import Colour, Embed, Message, NotFound, Reaction, User
+
+from discord.ext.commands import BadArgument, Cog, Context, group, has_any_role
 
 from bot.bot import Bot
 from bot.constants import MODERATION_ROLES, RedirectOutput
@@ -57,7 +59,7 @@ class DocItem(NamedTuple):
         return self.base_url + self.relative_url_path
 
 
-class DocCog(commands.Cog):
+class DocCog(Cog):
     """A set of commands for querying & displaying documentation."""
 
     def __init__(self, bot: Bot):
@@ -265,7 +267,7 @@ class DocCog(commands.Cog):
                 return "Unable to parse the requested symbol."
         return markdown
 
-    async def create_symbol_embed(self, symbol_name: str) -> Optional[discord.Embed]:
+    async def create_symbol_embed(self, symbol_name: str) -> Optional[Embed]:
         """
         Attempt to scrape and fetch the data for the given `symbol_name`, and build an embed from its contents.
 
@@ -294,7 +296,7 @@ class DocCog(commands.Cog):
             else:
                 footer_text = ""
 
-            embed = discord.Embed(
+            embed = Embed(
                 title=discord.utils.escape_markdown(symbol_name),
                 url=f"{doc_item.url}#{doc_item.symbol_id}",
                 description=await self.get_symbol_markdown(doc_item)
@@ -302,13 +304,13 @@ class DocCog(commands.Cog):
             embed.set_footer(text=footer_text)
             return embed
 
-    @commands.group(name="docs", aliases=("doc", "d"), invoke_without_command=True)
-    async def docs_group(self, ctx: commands.Context, *, symbol_name: Optional[str]) -> None:
+    @group(name="docs", aliases=("doc", "d"), invoke_without_command=True)
+    async def docs_group(self, ctx: Context, *, symbol_name: Optional[str]) -> None:
         """Look up documentation for Python symbols."""
         await self.get_command(ctx, symbol_name=symbol_name)
 
     @docs_group.command(name="getdoc", aliases=("g",))
-    async def get_command(self, ctx: commands.Context, *, symbol_name: Optional[str]) -> None:
+    async def get_command(self, ctx: Context, *, symbol_name: Optional[str]) -> None:
         """
         Return a documentation embed for a given symbol.
 
@@ -321,9 +323,9 @@ class DocCog(commands.Cog):
             !docs getdoc aiohttp.ClientSession
         """
         if not symbol_name:
-            inventory_embed = discord.Embed(
+            inventory_embed = Embed(
                 title=f"All inventories (`{len(self.base_urls)}` total)",
-                colour=discord.Colour.blue()
+                colour=Colour.blue()
             )
 
             lines = sorted(f"• [`{name}`]({url})" for name, url in self.base_urls.items())
@@ -345,14 +347,15 @@ class DocCog(commands.Cog):
                 if ctx.message.mentions or ctx.message.role_mentions:
                     await error_message.add_reaction(DELETE_ERROR_MESSAGE_REACTION)
 
+                    _predicate_emoji_reaction = partial(predicate_emoji_reaction, ctx, error_message)
                     try:
                         await self.bot.wait_for(
                             'reaction_add',
-                            check=lambda reaction, user: reaction.message == error_message and user == ctx.author and str(reaction) == DELETE_ERROR_MESSAGE_REACTION,
+                            check=_predicate_emoji_reaction
                             timeout=NOT_FOUND_DELETE_DELAY
                         )
 
-                        with suppress(discord.HTTPException):
+                        with suppress(NotFound):
                             await error_message.delete()
 
                     except asyncio.TimeoutError:
@@ -360,20 +363,20 @@ class DocCog(commands.Cog):
 
                 else:
                     await wait_for_deletion(error_message, (ctx.author.id,), timeout=NOT_FOUND_DELETE_DELAY)
-                    with suppress(discord.NotFound):
+                    with suppress(NotFound):
                         await ctx.message.delete()
-                    with suppress(discord.NotFound):
+                    with suppress(NotFound):
                         await error_message.delete()
             else:
                 msg = await ctx.send(embed=doc_embed)
                 await wait_for_deletion(msg, (ctx.author.id,))
 
     @docs_group.command(name="setdoc", aliases=("s",))
-    @commands.has_any_role(*MODERATION_ROLES)
+    @has_any_role(*MODERATION_ROLES)
     @lock(NAMESPACE, COMMAND_LOCK_SINGLETON, raise_error=True)
     async def set_command(
         self,
-        ctx: commands.Context,
+        ctx: Context,
         package_name: PackageName,
         base_url: ValidURL,
         inventory: Inventory,
@@ -390,7 +393,7 @@ class DocCog(commands.Cog):
                     https://docs.python.org/3/objects.inv
         """
         if not base_url.endswith("/"):
-            raise commands.BadArgument("The base url must end with a slash.")
+            raise BadArgument("The base url must end with a slash.")
         inventory_url, inventory_dict = inventory
         body = {
             "package": package_name,
@@ -408,9 +411,9 @@ class DocCog(commands.Cog):
         await ctx.send(f"Added the package `{package_name}` to the database and updated the inventories.")
 
     @docs_group.command(name="deletedoc", aliases=("removedoc", "rm", "d"))
-    @commands.has_any_role(*MODERATION_ROLES)
+    @has_any_role(*MODERATION_ROLES)
     @lock(NAMESPACE, COMMAND_LOCK_SINGLETON, raise_error=True)
-    async def delete_command(self, ctx: commands.Context, package_name: PackageName) -> None:
+    async def delete_command(self, ctx: Context, package_name: PackageName) -> None:
         """
         Removes the specified package from the database.
 
@@ -425,9 +428,9 @@ class DocCog(commands.Cog):
         await ctx.send(f"Successfully deleted `{package_name}` and refreshed the inventories.")
 
     @docs_group.command(name="refreshdoc", aliases=("rfsh", "r"))
-    @commands.has_any_role(*MODERATION_ROLES)
+    @has_any_role(*MODERATION_ROLES)
     @lock(NAMESPACE, COMMAND_LOCK_SINGLETON, raise_error=True)
-    async def refresh_command(self, ctx: commands.Context) -> None:
+    async def refresh_command(self, ctx: Context) -> None:
         """Refresh inventories and show the difference."""
         old_inventories = set(self.base_urls)
         with ctx.typing():
@@ -440,17 +443,17 @@ class DocCog(commands.Cog):
         if removed := ", ".join(old_inventories - new_inventories):
             removed = "- " + removed
 
-        embed = discord.Embed(
+        embed = Embed(
             title="Inventories refreshed",
             description=f"```diff\n{added}\n{removed}```" if added or removed else ""
         )
         await ctx.send(embed=embed)
 
     @docs_group.command(name="cleardoccache", aliases=("deletedoccache",))
-    @commands.has_any_role(*MODERATION_ROLES)
+    @has_any_role(*MODERATION_ROLES)
     async def clear_cache_command(
         self,
-        ctx: commands.Context,
+        ctx: Context,
         package_name: Union[PackageName, allowed_strings("*")]  # noqa: F722
     ) -> None:
         """Clear the persistent redis cache for `package`."""
@@ -464,3 +467,7 @@ class DocCog(commands.Cog):
         self.inventory_scheduler.cancel_all()
         self.init_refresh_task.cancel()
         asyncio.create_task(self.item_fetcher.clear(), name="DocCog.item_fetcher unload clear")
+        
+        
+def predicate_emoji_reaction(ctx: Context, error_message: Message, reaction: Reaction, user: User):
+    return reaction.message == error_message and user == ctx.author and str(reaction) == DELETE_ERROR_MESSAGE_REACTION

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -352,7 +352,7 @@ class DocCog(Cog):
                     try:
                         await self.bot.wait_for(
                             'reaction_add',
-                            check=_predicate_emoji_reaction
+                            check=_predicate_emoji_reaction,
                             timeout=NOT_FOUND_DELETE_DELAY
                         )
 


### PR DESCRIPTION
Solves #1624.

Will no longer delete the invoking message when the given symbol is invalid if the message contains user/role mentions. If it has mentions, allows deletion of error message through reactions.