### PR TITLE
Prevent ghost-pings in pypi command

### DIFF
--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -14,7 +14,7 @@ import discord
 from discord.ext import commands
 
 from bot.bot import Bot
-from bot.constants import Emojis, MODERATION_ROLES, RedirectOutput
+from bot.constants import MODERATION_ROLES, RedirectOutput
 from bot.converters import Inventory, PackageName, ValidURL, allowed_strings
 from bot.pagination import LinePaginator
 from bot.utils.lock import SharedEvent, lock

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -346,6 +346,7 @@ class DocCog(commands.Cog):
                 if not (ctx.message.mentions or ctx.message.role_mentions):
                     with suppress(discord.NotFound):
                         await ctx.message.delete()
+                        await error_message.delete()
 
             else:
                 msg = await ctx.send(embed=doc_embed)

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -341,8 +341,6 @@ class DocCog(commands.Cog):
             if doc_embed is None:
                 error_message = await send_denial(ctx, "No documentation found for the requested symbol.")
                 await wait_for_deletion(error_message, (ctx.author.id,), timeout=NOT_FOUND_DELETE_DELAY)
-                with suppress(discord.NotFound):
-                    await error_message.clear_reaction(Emojis.trashcan)
 
                 # Make sure that we won't cause a ghost-ping by deleting the message
                 if not (ctx.message.mentions or ctx.message.role_mentions):

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -1,8 +1,8 @@
-import contextlib
 import itertools
 import logging
 import random
 import re
+from contextlib import suppress
 
 from discord import Embed, NotFound
 from discord.ext.commands import Cog, Context, command
@@ -74,7 +74,7 @@ class PyPi(Cog):
 
             # Make sure that we won't cause a ghost-ping by deleting the message
             if not (ctx.message.mentions or ctx.message.role_mentions):
-                with contextlib.suppress(NotFound):
+                with suppress(NotFound):
                     await ctx.message.delete()
 
         else:

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -70,7 +70,7 @@ class PyPi(Cog):
             error_message = await ctx.send(embed=embed)
             await wait_for_deletion(error_message, (ctx.author.id,), timeout=INVALID_INPUT_DELETE_DELAY)
 
-            # If won't ghost-ping when deleting message 
+            # If won't ghost-ping when deleting message
             if not (ctx.message.mentions or ctx.message.role_mentions):
                 with suppress(NotFound):
                     await ctx.message.delete()

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -72,7 +72,7 @@ class PyPi(Cog):
             error_message = await ctx.send(embed=embed)
             await wait_for_deletion(error_message, (ctx.author.id,), timeout=INVALID_INPUT_DELETE_DELAY)
 
-            # If won't ghost-ping when deleting message
+            # Make sure that we won't cause a ghost-ping by deleting the message
             if not (ctx.message.mentions or ctx.message.role_mentions):
                 with contextlib.suppress(NotFound):
                     await ctx.message.delete()

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -76,6 +76,7 @@ class PyPi(Cog):
             if not (ctx.message.mentions or ctx.message.role_mentions):
                 with suppress(NotFound):
                     await ctx.message.delete()
+                    await error_message.delete()
 
         else:
             await ctx.send(embed=embed)

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -67,8 +67,14 @@ class PyPi(Cog):
                     log.trace(f"Error when fetching PyPi package: {response.status}.")
 
         if error:
-            await ctx.send(embed=embed, delete_after=INVALID_INPUT_DELETE_DELAY)
-            await ctx.message.delete(delay=INVALID_INPUT_DELETE_DELAY)
+            error_message = await ctx.send(embed=embed)
+            await wait_for_deletion(error_message, (ctx.author.id,), timeout=INVALID_INPUT_DELETE_DELAY)
+
+            # If won't ghost-ping when deleting message 
+            if not (ctx.message.mentions or ctx.message.role_mentions):
+                with suppress(NotFound):
+                    await ctx.message.delete()
+
         else:
             await ctx.send(embed=embed)
 

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -1,14 +1,16 @@
+import contextlib
 import itertools
 import logging
 import random
 import re
 
-from discord import Embed
+from discord import Embed, NotFound
 from discord.ext.commands import Cog, Context, command
 from discord.utils import escape_markdown
 
 from bot.bot import Bot
 from bot.constants import Colours, NEGATIVE_REPLIES, RedirectOutput
+from bot.utils.messages import wait_for_deletion
 
 URL = "https://pypi.org/pypi/{package}/json"
 PYPI_ICON = "https://cdn.discordapp.com/emojis/766274397257334814.png"
@@ -72,7 +74,7 @@ class PyPi(Cog):
 
             # If won't ghost-ping when deleting message
             if not (ctx.message.mentions or ctx.message.role_mentions):
-                with suppress(NotFound):
+                with contextlib.suppress(NotFound):
                     await ctx.message.delete()
 
         else:

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -95,8 +95,11 @@ async def wait_for_deletion(
         allow_mods=allow_mods,
     )
 
-    with contextlib.suppress(asyncio.TimeoutError):
+    try:
         await bot.instance.wait_for('reaction_add', check=check, timeout=timeout)
+    except asyncio.TimeoutError:
+        await message.clear_reactions()
+    else:
         await message.delete()
 
 

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -69,6 +69,7 @@ async def wait_for_deletion(
 ) -> None:
     """
     Wait for up to `timeout` seconds for a reaction by any of the specified `user_ids` to delete the message.
+    If user doesn't respond in time, will clear all reactions to indicate option to delete has expired.
 
     An `attach_emojis` bool may be specified to determine whether to attach the given
     `deletion_emojis` to the message in the given `context`.

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -68,8 +68,9 @@ async def wait_for_deletion(
     allow_mods: bool = True
 ) -> None:
     """
-    Wait for up to `timeout` seconds for a reaction by any of the specified `user_ids` to delete the message.
-    If user doesn't respond in time, will clear all reactions to indicate option to delete has expired.
+    Wait for any of `user_ids` to react with one of the `deletion_emojis` within `timeout` seconds to delete `message`.
+
+    If `timeout` expires then reactions are cleared to indicate the option to delete has expired.
 
     An `attach_emojis` bool may be specified to determine whether to attach the given
     `deletion_emojis` to the message in the given `context`.

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import logging
 import random
 import re


### PR DESCRIPTION
Solves #1624
Solves #1695


Will no longer delete the invoking message of `!pypi` command when the given package is invalid if the message contains user/role mentions. Always allows deletion of error message through reactions.

`utils.messages.wait_for_deletion()` now also [clears the added reaction(s) once timeout expires.](https://github.com/python-discord/bot/commit/df3d011bd6490eadc2b611c8d21062b14ebd18c4)