### PR TITLE
Suppress 403 error when sending DEFCON reject DM

### DIFF
--- a/bot/exts/moderation/defcon.py
+++ b/bot/exts/moderation/defcon.py
@@ -9,7 +9,7 @@ from typing import Optional, Union
 from aioredis import RedisError
 from async_rediscache import RedisCache
 from dateutil.relativedelta import relativedelta
-from discord import Colour, Embed, Member, User
+from discord import Colour, Embed, Forbidden, Member, User
 from discord.ext import tasks
 from discord.ext.commands import Cog, Context, group, has_any_role
 
@@ -118,10 +118,12 @@ class Defcon(Cog):
 
                 try:
                     await member.send(REJECTION_MESSAGE.format(user=member.mention))
-
                     message_sent = True
+                except Forbidden:
+                    log.debug(f"Cannot send DEFCON rejection DM to {member}: DMs disabled")
                 except Exception:
-                    log.exception(f"Unable to send rejection message to user: {member}")
+                    # Broadly catch exceptions because DM isn't critical, but it's imperative to kick them.
+                    log.exception(f"Error sending DEFCON rejection message to {member}")
 
                 await member.kick(reason="DEFCON active, user is too new")
                 self.bot.stats.incr("defcon.leaves")


### PR DESCRIPTION
Sentry Issue: [BOT-37](https://sentry.io/organizations/python-discord/issues/2437630529)

403 occurs if the user has DMs disabled. The specific code is 50007, but I don't think 403 would be raised for any other reason here, so I didn't check the code explicitly. If someone has more insight on this, please comment.