### PR TITLE
Correctly delete from cache in ModPings

### DIFF
--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -44,7 +44,7 @@ class ModPings(Cog):
         log.trace("Applying the moderators role to the mod team where necessary.")
         for mod in mod_team.members:
             if mod in pings_on:  # Make sure that on-duty mods aren't in the cache.
-                if mod in pings_off:
+                if mod.id in pings_off:
                     await self.pings_off_mods.delete(mod.id)
                 continue
 
@@ -59,6 +59,7 @@ class ModPings(Cog):
         """Reapply the moderator's role to the given moderator."""
         log.trace(f"Re-applying role to mod with ID {mod.id}.")
         await mod.add_roles(self.moderators_role, reason="Pings off period expired.")
+        await self.pings_off_mods.delete(mod.id)
 
     @group(name='modpings', aliases=('modping',), invoke_without_command=True)
     @has_any_role(*MODERATION_ROLES)


### PR DESCRIPTION
* Fixed wrong condition in rescheduler which made the eventual consistency not work.
* Mods now correctly removed from cache on role reapplies.