### PR TITLE
Force utf-8 decoding when querying metabase

### DIFF
--- a/bot/exts/moderation/metabase.py
+++ b/bot/exts/moderation/metabase.py
@@ -115,12 +115,12 @@ class Metabase(Cog):
             try:
                 async with self.bot.http_session.post(url, headers=self.headers, raise_for_status=True) as resp:
                     if extension == "csv":
-                        out = await resp.text()
+                        out = await resp.text(encoding="utf-8")
                         # Save the output for use with int e
                         self.exports[question_id] = list(csv.DictReader(StringIO(out)))
 
                     elif extension == "json":
-                        out = await resp.json()
+                        out = await resp.json(encoding="utf-8")
                         # Save the output for use with int e
                         self.exports[question_id] = out
 


### PR DESCRIPTION
Closes #1713

Some discord usernames contain unicode characters, which causes an decoding error as chardet isn't 100% and can falsely detect the response text as Windows-1254.