### PR TITLE
Catch various 404s from message operations

### DIFF
--- a/bot/exts/fun/duck_pond.py
+++ b/bot/exts/fun/duck_pond.py
@@ -171,8 +171,14 @@ class DuckPond(Cog):
         if not self.is_helper_viewable(channel):
             return
 
-        message = await channel.fetch_message(payload.message_id)
+        try:
+            message = await channel.fetch_message(payload.message_id)
+        except discord.NotFound:
+            return  # Message was deleted.
+
         member = discord.utils.get(message.guild.members, id=payload.user_id)
+        if not member:
+            return  # Member left or wasn't in the cache.
 
         # Was the message sent by a human staff member?
         if not self.is_staff(message.author) or message.author.bot:

--- a/bot/exts/info/codeblock/_cog.py
+++ b/bot/exts/info/codeblock/_cog.py
@@ -177,10 +177,13 @@ class CodeBlockCog(Cog, name="Code Block"):
         if not bot_message:
             return
 
-        if not instructions:
-            log.info("User's incorrect code block has been fixed. Removing instructions message.")
-            await bot_message.delete()
-            del self.codeblock_message_ids[payload.message_id]
-        else:
-            log.info("Message edited but still has invalid code blocks; editing the instructions.")
-            await bot_message.edit(embed=self.create_embed(instructions))
+        try:
+            if not instructions:
+                log.info("User's incorrect code block was fixed. Removing instructions message.")
+                await bot_message.delete()
+                del self.codeblock_message_ids[payload.message_id]
+            else:
+                log.info("Message edited but still has invalid code blocks; editing instructions.")
+                await bot_message.edit(embed=self.create_embed(instructions))
+        except discord.NotFound:
+            log.debug("Could not find instructions message; it was probably deleted.")


### PR DESCRIPTION
Fixes Sentry issues [BOT-ZN](https://sentry.io/organizations/python-discord/issues/2385622541), [BOT-J2](https://sentry.io/organizations/python-discord/issues/2091776305/?referrer=github_integration), and [BOT-1J7](https://sentry.io/organizations/python-discord/issues/2529286507/?referrer=github_integration)