### PR TITLE
Help channels: fix initialisation of available channels set

### DIFF
--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -267,9 +267,7 @@ class HelpChannels(commands.Cog):
             for channel in channels[:abs(missing)]:
                 await self.unclaim_channel(channel, closed_on=_channel.ClosingReason.CLEANUP)
 
-        self.available_help_channels = {
-            c for c in self.available_category.channels if not _channel.is_excluded_channel(c)
-        }
+        self.available_help_channels = set(_channel.get_category_channels(self.available_category))
 
         # Getting channels that need to be included in the dynamic message.
         await self.update_available_help_channels()

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -391,13 +391,10 @@ class HelpChannels(commands.Cog):
         )
 
         log.trace(f"Sending dormant message for #{channel} ({channel.id}).")
-        dormant_category = await channel_utils.try_get_channel(constants.Categories.help_dormant)
-        available_category = await channel_utils.try_get_channel(constants.Categories.help_available)
         embed = discord.Embed(
             description=_message.DORMANT_MSG.format(
-                dormant=dormant_category.name,
-                available=available_category.name,
-                asking_guide=_message.ASKING_GUIDE_URL
+                dormant=self.dormant_category.name,
+                available=self.available_category.name,
             )
         )
         await channel.send(embed=embed)

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -267,6 +267,10 @@ class HelpChannels(commands.Cog):
             for channel in channels[:abs(missing)]:
                 await self.unclaim_channel(channel, closed_on=_channel.ClosingReason.CLEANUP)
 
+        self.available_help_channels = {
+            c for c in self.available_category.channels if not _channel.is_excluded_channel(c)
+        }
+
         # Getting channels that need to be included in the dynamic message.
         await self.update_available_help_channels()
         log.trace("Dynamic available help message updated.")
@@ -519,11 +523,6 @@ class HelpChannels(commands.Cog):
 
     async def update_available_help_channels(self) -> None:
         """Updates the dynamic message within #how-to-get-help for available help channels."""
-        if not self.available_help_channels:
-            self.available_help_channels = set(
-                c for c in self.available_category.channels if not _channel.is_excluded_channel(c)
-            )
-
         available_channels = AVAILABLE_HELP_CHANNELS.format(
             available=", ".join(
                 c.mention for c in sorted(self.available_help_channels, key=attrgetter("position"))

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -29,15 +29,15 @@ AVAILABLE_TITLE = "Available help channel"
 
 AVAILABLE_FOOTER = "Closes after a period of inactivity, or when you send !close."
 
-DORMANT_MSG = """
-This help channel has been marked as **dormant**, and has been moved into the **{dormant}** \
+DORMANT_MSG = f"""
+This help channel has been marked as **dormant**, and has been moved into the **{{dormant}}** \
 category at the bottom of the channel list. It is no longer possible to send messages in this \
 channel until it becomes available again.
 
 If your question wasn't answered yet, you can claim a new help channel from the \
-**{available}** category by simply asking your question again. Consider rephrasing the \
+**{{available}}** category by simply asking your question again. Consider rephrasing the \
 question to maximize your chance of getting a good answer. If you're not sure how, have a look \
-through our guide for **[asking a good question]({asking_guide})**.
+through our guide for **[asking a good question]({ASKING_GUIDE_URL})**.
 """
 
 


### PR DESCRIPTION
Fixes #1715

If the cog is reloaded while there are less than the maximum amount of available channels, it makes some channels available until the limit is reached. When a channel is made available, it updates the `available_help_channels` set. The `update_available_help_channels()` function would not update this set if it sees that the set already contains elements. This resulted in only the channels that were just made available being in the set; the set would not contain the channels that were already available when the bot started.

Fix this by unconditionally populating the set, but moving it to `init_available()` so it only happens once.

Also refactor the changes made by #1738 to simplify the implementation.
