### PR TITLE
Delete Webhooks when one is accidentally posted.

### DIFF
--- a/bot/exts/filters/webhook_remover.py
+++ b/bot/exts/filters/webhook_remover.py
@@ -13,8 +13,8 @@ WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(?:app)?\.com/api/webhooks/\
 
 ALERT_MESSAGE_TEMPLATE = (
     "{user}, looks like you posted a Discord webhook URL. Therefore, your "
-    "message has been removed. Your webhook may have been **compromised** so "
-    "please re-create the webhook **immediately**. If you believe this was a "
+    "message has been removed, alongside with your webhook"
+    "you can re-create it if you wish to. If you believe this was a "
     "mistake, please let us know."
 )
 
@@ -32,7 +32,7 @@ class WebhookRemover(Cog):
         """Get current instance of `ModLog`."""
         return self.bot.get_cog("ModLog")
 
-    async def delete_and_respond(self, msg: Message, redacted_url: str) -> None:
+    async def delete_and_respond(self, msg: Message, redacted_url: str, webhook_deleted: bool) -> None:
         """Delete `msg` and send a warning that it contained the Discord webhook `redacted_url`."""
         # Don't log this, due internal delete, not by user. Will make different entry.
         self.mod_log.ignore(Event.message_delete, msg.id)
@@ -44,9 +44,12 @@ class WebhookRemover(Cog):
             return
 
         await msg.channel.send(ALERT_MESSAGE_TEMPLATE.format(user=msg.author.mention))
-
+        if webhook_deleted:
+            delete_state = "The webhook was successfully deleted."
+        else:
+            delete_state = "There was an error when deleting the webhook, it might have already been removed."
         message = (
-            f"{format_user(msg.author)} posted a Discord webhook URL to {msg.channel.mention}. "
+            f"{format_user(msg.author)} posted a Discord webhook URL to {msg.channel.mention}.{delete_state} "
             f"Webhook URL was `{redacted_url}`"
         )
         log.debug(message)
@@ -72,7 +75,12 @@ class WebhookRemover(Cog):
 
         matches = WEBHOOK_URL_RE.search(msg.content)
         if matches:
-            await self.delete_and_respond(msg, matches[1] + "xxx")
+            async with self.bot.http_session.delete(msg.content) as resp:
+                # The Discord API Returns a 204 NO CONTENT repsonse on success.
+                if resp.status == 204:
+                    await self.delete_and_respond(msg, matches[1] + "xxx", True)
+                else:
+                    await self.delete_and_respond(msg, matches[1] + "xxx", False)
 
     @Cog.listener()
     async def on_message_edit(self, before: Message, after: Message) -> None:

--- a/bot/exts/filters/webhook_remover.py
+++ b/bot/exts/filters/webhook_remover.py
@@ -9,7 +9,10 @@ from bot.constants import Channels, Colours, Event, Icons
 from bot.exts.moderation.modlog import ModLog
 from bot.utils.messages import format_user
 
-WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(?:app)?\.com/api/webhooks/\d+/)\S+/?", re.IGNORECASE)
+WEBHOOK_URL_RE = re.compile(
+    r"((?:https?:\/\/)?(?:ptb\.|canary\.)?discord(?:app)?\.com\/api\/webhooks\/\d+\/)\S+\/?",
+    re.IGNORECASE
+)
 
 ALERT_MESSAGE_TEMPLATE = (
     "{user}, looks like you posted a Discord webhook URL. Therefore, your "

--- a/bot/exts/filters/webhook_remover.py
+++ b/bot/exts/filters/webhook_remover.py
@@ -16,7 +16,7 @@ WEBHOOK_URL_RE = re.compile(
 
 ALERT_MESSAGE_TEMPLATE = (
     "{user}, looks like you posted a Discord webhook URL. Therefore, your "
-    "message has been removed, and your webhook has been deleted."
+    "message has been removed, and your webhook has been deleted. "
     "You can re-create it if you wish to. If you believe this was a "
     "mistake, please let us know."
 )

--- a/bot/exts/filters/webhook_remover.py
+++ b/bot/exts/filters/webhook_remover.py
@@ -13,8 +13,8 @@ WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(?:app)?\.com/api/webhooks/\
 
 ALERT_MESSAGE_TEMPLATE = (
     "{user}, looks like you posted a Discord webhook URL. Therefore, your "
-    "message has been removed, alongside with your webhook"
-    "you can re-create it if you wish to. If you believe this was a "
+    "message has been removed, alongside with your webhook."
+    "You can re-create it if you wish to. If you believe this was a "
     "mistake, please let us know."
 )
 
@@ -32,7 +32,7 @@ class WebhookRemover(Cog):
         """Get current instance of `ModLog`."""
         return self.bot.get_cog("ModLog")
 
-    async def delete_and_respond(self, msg: Message, redacted_url: str, webhook_deleted: bool) -> None:
+    async def delete_and_respond(self, msg: Message, redacted_url: str, *, webhook_deleted: bool) -> None:
         """Delete `msg` and send a warning that it contained the Discord webhook `redacted_url`."""
         # Don't log this, due internal delete, not by user. Will make different entry.
         self.mod_log.ignore(Event.message_delete, msg.id)
@@ -49,7 +49,7 @@ class WebhookRemover(Cog):
         else:
             delete_state = "There was an error when deleting the webhook, it might have already been removed."
         message = (
-            f"{format_user(msg.author)} posted a Discord webhook URL to {msg.channel.mention}.{delete_state} "
+            f"{format_user(msg.author)} posted a Discord webhook URL to {msg.channel.mention}. {delete_state} "
             f"Webhook URL was `{redacted_url}`"
         )
         log.debug(message)
@@ -76,11 +76,9 @@ class WebhookRemover(Cog):
         matches = WEBHOOK_URL_RE.search(msg.content)
         if matches:
             async with self.bot.http_session.delete(msg.content) as resp:
-                # The Discord API Returns a 204 NO CONTENT repsonse on success.
-                if resp.status == 204:
-                    await self.delete_and_respond(msg, matches[1] + "xxx", True)
-                else:
-                    await self.delete_and_respond(msg, matches[1] + "xxx", False)
+                # The Discord API Returns a 204 NO CONTENT response on success.
+                deleted_successfully = resp.status == 204
+            await self.delete_and_respond(msg, matches[1] + "xxx", webhook_deleted=deleted_successfully)
 
     @Cog.listener()
     async def on_message_edit(self, before: Message, after: Message) -> None:

--- a/bot/exts/filters/webhook_remover.py
+++ b/bot/exts/filters/webhook_remover.py
@@ -13,7 +13,7 @@ WEBHOOK_URL_RE = re.compile(r"((?:https?://)?discord(?:app)?\.com/api/webhooks/\
 
 ALERT_MESSAGE_TEMPLATE = (
     "{user}, looks like you posted a Discord webhook URL. Therefore, your "
-    "message has been removed, alongside with your webhook."
+    "message has been removed, and your webhook has been deleted."
     "You can re-create it if you wish to. If you believe this was a "
     "mistake, please let us know."
 )
@@ -75,7 +75,7 @@ class WebhookRemover(Cog):
 
         matches = WEBHOOK_URL_RE.search(msg.content)
         if matches:
-            async with self.bot.http_session.delete(msg.content) as resp:
+            async with self.bot.http_session.delete(matches[0]) as resp:
                 # The Discord API Returns a 204 NO CONTENT response on success.
                 deleted_successfully = resp.status == 204
             await self.delete_and_respond(msg, matches[1] + "xxx", webhook_deleted=deleted_successfully)


### PR DESCRIPTION
Closes  #1747 

From now on, webhooks that were posted in the chat will be also
deleted from Discord in order to eliminate the risk.