### PR TITLE
Formatting issues on the !server command

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -186,8 +186,8 @@ class Information(Cog):
         online_presences = py_invite.approximate_presence_count
         offline_presences = py_invite.approximate_member_count - online_presences
         member_status = (
-            f"{constants.Emojis.status_online} {online_presences} "
-            f"{constants.Emojis.status_offline} {offline_presences}"
+            f"{constants.Emojis.status_online} {online_presences:,} "
+            f"{constants.Emojis.status_offline} {offline_presences:,}"
         )
 
         embed.description = (
@@ -200,7 +200,7 @@ class Information(Cog):
         embed.set_thumbnail(url=ctx.guild.icon_url)
 
         # Members
-        total_members = ctx.guild.member_count
+        total_members = f"{ctx.guild.member_count:,}"
         member_counts = self.get_member_counts(ctx.guild)
         member_info = "\n".join(f"{role}: {count}" for role, count in member_counts.items())
         embed.add_field(name=f"Members: {total_members}", value=member_info)

--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -190,13 +190,13 @@ class Information(Cog):
             f"{constants.Emojis.status_offline} {offline_presences}"
         )
 
-        embed.description = textwrap.dedent(f"""
-            Created: {created}
-            Voice region: {region}\
-            {features}
-            Roles: {num_roles}
-            Member status: {member_status}
-        """)
+        embed.description = (
+            f"Created: {created}"
+            f"\nVoice region: {region}"
+            f"{features}"
+            f"\nRoles: {num_roles}"
+            f"\nMember status: {member_status}"
+        )
         embed.set_thumbnail(url=ctx.guild.icon_url)
 
         # Members


### PR DESCRIPTION
This fixes linebreak formatting on the server command.
The `features` part of the embed isn't included in some channels, this leads to there not being a linebreak between voice regions and roles in the embed. By changing it to this, rather than dedent, we specify exact where we want the linebreaks to be.

This also adds comma separators to the large member counts in the embed too. 