### PR TITLE
Lowering log level to info for missing reminder replies.

### DIFF
--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -200,7 +200,7 @@ class Reminders(Cog):
         try:
             await partial_message.reply(content=f"{additional_mentions}", embed=embed)
         except discord.HTTPException as e:
-            log.error(
+            log.info(
                 f"There was an error when trying to reply to a reminder invocation message, {e}, "
                 "fall back to using jump_url"
             )


### PR DESCRIPTION
We don't need sentry to trigger because of this, `info` is good.