### PR TITLE
Metabase sharing

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -568,7 +568,7 @@ class Metabase(metaclass=YAMLGetter):
 
     username: Optional[str]
     password: Optional[str]
-    url: str
+    base_url: str
     max_session_age: int
 
 

--- a/bot/exts/moderation/metabase.py
+++ b/bot/exts/moderation/metabase.py
@@ -125,36 +125,36 @@ class Metabase(Cog):
 
         Valid extensions are: csv and json.
         """
-        async with ctx.typing():
+        await ctx.trigger_typing()
 
-            # Make sure we have a session token before running anything
-            await self.init_task
+        # Make sure we have a session token before running anything
+        await self.init_task
 
-            url = f"{MetabaseConfig.base_url}/api/card/{question_id}/query/{extension}"
+        url = f"{MetabaseConfig.base_url}/api/card/{question_id}/query/{extension}"
 
-            async with self.bot.http_session.post(url, headers=self.headers, raise_for_status=True) as resp:
-                if extension == "csv":
-                    out = await resp.text(encoding="utf-8")
-                    # Save the output for use with int e
-                    self.exports[question_id] = list(csv.DictReader(StringIO(out)))
+        async with self.bot.http_session.post(url, headers=self.headers, raise_for_status=True) as resp:
+            if extension == "csv":
+                out = await resp.text(encoding="utf-8")
+                # Save the output for use with int e
+                self.exports[question_id] = list(csv.DictReader(StringIO(out)))
 
-                elif extension == "json":
-                    out = await resp.json(encoding="utf-8")
-                    # Save the output for use with int e
-                    self.exports[question_id] = out
+            elif extension == "json":
+                out = await resp.json(encoding="utf-8")
+                # Save the output for use with int e
+                self.exports[question_id] = out
 
-                    # Format it nicely for human eyes
-                    out = json.dumps(out, indent=4, sort_keys=True)
+                # Format it nicely for human eyes
+                out = json.dumps(out, indent=4, sort_keys=True)
 
-            paste_link = await send_to_paste_service(out, extension=extension)
-            if paste_link:
-                message = f":+1: {ctx.author.mention} Here's your link: {paste_link}"
-            else:
-                message = f":x: {ctx.author.mention} Link service is unavailible."
-            await ctx.send(
-                f"{message}\nYou can also access this data within internal eval by doing: "
-                f"`bot.get_cog('Metabase').exports[{question_id}]`"
-            )
+        paste_link = await send_to_paste_service(out, extension=extension)
+        if paste_link:
+            message = f":+1: {ctx.author.mention} Here's your link: {paste_link}"
+        else:
+            message = f":x: {ctx.author.mention} Link service is unavailible."
+        await ctx.send(
+            f"{message}\nYou can also access this data within internal eval by doing: "
+            f"`bot.get_cog('Metabase').exports[{question_id}]`"
+        )
 
     # This cannot be static (must have a __func__ attribute).
     async def cog_check(self, ctx: Context) -> bool:

--- a/bot/exts/moderation/metabase.py
+++ b/bot/exts/moderation/metabase.py
@@ -156,6 +156,20 @@ class Metabase(Cog):
             f"`bot.get_cog('Metabase').exports[{question_id}]`"
         )
 
+    @metabase_group.command(name="publish", aliases=("share",))
+    async def metabase_publish(self, ctx: Context, question_id: int) -> None:
+        """Publically shares the given question and posts the link."""
+        await ctx.trigger_typing()
+        # Make sure we have a session token before running anything
+        await self.init_task
+
+        url = f"{MetabaseConfig.base_url}/api/card/{question_id}/public_link"
+
+        async with self.bot.http_session.post(url, headers=self.headers, raise_for_status=True) as resp:
+            response_json = await resp.json(encoding="utf-8")
+            sharing_url = f"{MetabaseConfig.base_url}/public/question/{response_json['uuid']}"
+            await ctx.send(f":+1: {ctx.author.mention} Here's your sharing link: {sharing_url}")
+
     # This cannot be static (must have a __func__ attribute).
     async def cog_check(self, ctx: Context) -> bool:
         """Only allow admins inside moderator channels to invoke the commands in this cog."""

--- a/bot/exts/moderation/metabase.py
+++ b/bot/exts/moderation/metabase.py
@@ -105,7 +105,7 @@ class Metabase(Cog):
         """A group of commands for interacting with metabase."""
         await ctx.send_help(ctx.command)
 
-    @metabase_group.command(name="extract")
+    @metabase_group.command(name="extract", aliases=("export",))
     async def metabase_extract(
         self,
         ctx: Context,

--- a/bot/exts/moderation/metabase.py
+++ b/bot/exts/moderation/metabase.py
@@ -84,7 +84,7 @@ class Metabase(Cog):
             "username": MetabaseConfig.username,
             "password": MetabaseConfig.password
         }
-        async with self.bot.http_session.post(f"{MetabaseConfig.url}/session", json=data) as resp:
+        async with self.bot.http_session.post(f"{MetabaseConfig.base_url}/api/session", json=data) as resp:
             json_data = await resp.json()
             self.session_token = json_data.get("id")
 
@@ -130,7 +130,7 @@ class Metabase(Cog):
             # Make sure we have a session token before running anything
             await self.init_task
 
-            url = f"{MetabaseConfig.url}/card/{question_id}/query/{extension}"
+            url = f"{MetabaseConfig.base_url}/api/card/{question_id}/query/{extension}"
 
             async with self.bot.http_session.post(url, headers=self.headers, raise_for_status=True) as resp:
                 if extension == "csv":

--- a/config-default.yml
+++ b/config-default.yml
@@ -432,14 +432,12 @@ anti_spam:
             max: 3
 
 
-
 metabase:
-    username: !ENV "METABASE_USERNAME"
-    password: !ENV "METABASE_PASSWORD"
-    url: "http://metabase.default.svc.cluster.local/api"
+    username: !ENV      "METABASE_USERNAME"
+    password: !ENV      "METABASE_PASSWORD"
+    base_url:           "http://metabase.default.svc.cluster.local"
     # 14 days, see https://www.metabase.com/docs/latest/operations-guide/environment-variables.html#max_session_age
-    max_session_age: 20160
-
+    max_session_age:    20160
 
 
 big_brother:


### PR DESCRIPTION
This adds the ability to publicly share metabase questions via the bot, since admins don't have admin access to metabase, but the bot does.

This also refactors the error handling in the metabase cog to avoid copy pasting.