### PR TITLE
Fix edge-case of `user.joined_at` being `None`  in userinfo command.

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -257,7 +257,11 @@ class Information(Cog):
                 badges.append(emoji)
 
         if on_server:
-            joined = discord_timestamp(user.joined_at, TimestampFormats.RELATIVE)
+            if user.joined_at:
+                joined = discord_timestamp(user.joined_at, TimestampFormats.RELATIVE)
+            else:
+                joined = "Unable to get join date"
+
             # The 0 is for excluding the default @everyone role,
             # and the -1 is for reversing the order of the roles to highest to lowest in hierarchy.
             roles = ", ".join(role.mention for role in user.roles[:0:-1])


### PR DESCRIPTION
Solves #1763 

Now displays "Unable to get join date" when `user.joined_at` is `None`.