### PR TITLE
Update time format in reminder message to DAY_TIME from RELATIVE

### DIFF
--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -270,7 +270,7 @@ class Reminders(Cog):
             }
         )
 
-        mention_string = f"Your reminder will arrive {discord_timestamp(expiration, TimestampFormats.RELATIVE)}"
+        mention_string = f"Your reminder will arrive {discord_timestamp(expiration, TimestampFormats.DAY_TIME)}"
 
         if mentions:
             mention_string += f" and will mention {len(mentions)} other(s)"

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -270,7 +270,7 @@ class Reminders(Cog):
             }
         )
 
-        mention_string = f"Your reminder will arrive {discord_timestamp(expiration, TimestampFormats.DAY_TIME)}"
+        mention_string = f"Your reminder will arrive on {discord_timestamp(expiration, TimestampFormats.DAY_TIME)}"
 
         if mentions:
             mention_string += f" and will mention {len(mentions)} other(s)"


### PR DESCRIPTION
Closes #1750 

The message sent when you create a new reminder now uses the DAY_TIME time formatting instead of RELATIVE time format.