### PR TITLE
Use publicly available URL when outputting metabase share URL

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -569,6 +569,7 @@ class Metabase(metaclass=YAMLGetter):
     username: Optional[str]
     password: Optional[str]
     base_url: str
+    public_url: str
     max_session_age: int
 
 

--- a/bot/exts/moderation/metabase.py
+++ b/bot/exts/moderation/metabase.py
@@ -167,7 +167,7 @@ class Metabase(Cog):
 
         async with self.bot.http_session.post(url, headers=self.headers, raise_for_status=True) as resp:
             response_json = await resp.json(encoding="utf-8")
-            sharing_url = f"{MetabaseConfig.base_url}/public/question/{response_json['uuid']}"
+            sharing_url = f"{MetabaseConfig.public_url}/public/question/{response_json['uuid']}"
             await ctx.send(f":+1: {ctx.author.mention} Here's your sharing link: {sharing_url}")
 
     # This cannot be static (must have a __func__ attribute).

--- a/config-default.yml
+++ b/config-default.yml
@@ -441,6 +441,7 @@ metabase:
     username: !ENV      "METABASE_USERNAME"
     password: !ENV      "METABASE_PASSWORD"
     base_url:           "http://metabase.default.svc.cluster.local"
+    public_url:         "https://metabase.pythondiscord.com"
     # 14 days, see https://www.metabase.com/docs/latest/operations-guide/environment-variables.html#max_session_age
     max_session_age:    20160
 


### PR DESCRIPTION
In production we use the internal URL to call the metabase API, to avoid egress
but we still want to output the public url when giving the sharing link.
Making it a constant like this makes it easier to change/overwrite in future if needed.