### PR TITLE
Change how the `raw` command is invoked.

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -460,11 +460,12 @@ class Information(Cog):
         # remove trailing whitespace
         return out.rstrip()
 
-    @cooldown_with_role_bypass(2, 60 * 3, BucketType.member, bypass_roles=constants.STAFF_PARTNERS_COMMUNITY_ROLES)
-    @group(invoke_without_command=True)
-    @in_whitelist(channels=(constants.Channels.bot_commands,), roles=constants.STAFF_PARTNERS_COMMUNITY_ROLES)
-    async def raw(self, ctx: Context, *, message: Message, json: bool = False) -> None:
-        """Shows information about the raw API response."""
+    async def send_raw_content(self, ctx: Context, message: Message, json: bool = False) -> None:
+        """
+        Send information about the raw API response for a `discord.Message`.
+
+        If `json` is True, send the information in a copy-pasteable Python format.
+        """
         if ctx.author not in message.channel.members:
             await ctx.send(":x: You do not have permissions to see the channel this message is in.")
             return
@@ -500,10 +501,17 @@ class Information(Cog):
         for page in paginator.pages:
             await ctx.send(page, allowed_mentions=AllowedMentions.none())
 
+    @cooldown_with_role_bypass(2, 60 * 3, BucketType.member, bypass_roles=constants.STAFF_PARTNERS_COMMUNITY_ROLES)
+    @group(invoke_without_command=True)
+    @in_whitelist(channels=(constants.Channels.bot_commands,), roles=constants.STAFF_PARTNERS_COMMUNITY_ROLES)
+    async def raw(self, ctx: Context, message: Message) -> None:
+        """Shows information about the raw API response."""
+        await self.send_raw_content(ctx, message)
+
     @raw.command()
     async def json(self, ctx: Context, message: Message) -> None:
         """Shows information about the raw API response in a copy-pasteable Python format."""
-        await ctx.invoke(self.raw, message=message, json=True)
+        await self.send_raw_content(ctx, message, json=True)
 
 
 def setup(bot: Bot) -> None:


### PR DESCRIPTION
```py
    async def raw(self, ctx: Context, *, message: Message, json: bool = False) -> None:
```

This is the current interface, which doesn't allow you to use `!raw msg-link foo` because of the existence of the `json` parameter which is used by `raw json`. The `json` parameter is also included in the help text by default which isn't ideal.

This PR abstracts `raw`s logic away into a helper function to get the better interface.