### PR TITLE
Prevent repetitive stale inventory warnings from erroneously generated inventories

### DIFF
--- a/bot/exts/info/doc/_batch_parser.py
+++ b/bot/exts/info/doc/_batch_parser.py
@@ -16,12 +16,15 @@ from bot.constants import Channels
 from bot.utils import scheduling
 from . import _cog, doc_cache
 from ._parsing import get_symbol_markdown
+from ._redis_cache import StaleItemCounter
 
 log = logging.getLogger(__name__)
 
 
 class StaleInventoryNotifier:
     """Handle sending notifications about stale inventories through `DocItem`s to dev log."""
+
+    symbol_counter = StaleItemCounter()
 
     def __init__(self):
         self._init_task = bot.instance.loop.create_task(
@@ -38,13 +41,16 @@ class StaleInventoryNotifier:
     async def send_warning(self, doc_item: _cog.DocItem) -> None:
         """Send a warning to dev log if one wasn't already sent for `item`'s url."""
         if doc_item.url not in self._warned_urls:
-            self._warned_urls.add(doc_item.url)
-            await self._init_task
-            embed = discord.Embed(
-                description=f"Doc item `{doc_item.symbol_id=}` present in loaded documentation inventories "
-                            f"not found on [site]({doc_item.url}), inventories may need to be refreshed."
-            )
-            await self._dev_log.send(embed=embed)
+            # Only warn if the item got less than 3 warnings
+            # or if it has been more than 3 weeks since the last warning
+            if await self.symbol_counter.increment_for(doc_item) < 3:
+                self._warned_urls.add(doc_item.url)
+                await self._init_task
+                embed = discord.Embed(
+                    description=f"Doc item `{doc_item.symbol_id=}` present in loaded documentation inventories "
+                                f"not found on [site]({doc_item.url}), inventories may need to be refreshed."
+                )
+                await self._dev_log.send(embed=embed)
 
 
 class QueueItem(NamedTuple):

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -439,6 +439,7 @@ class DocCog(commands.Cog):
     ) -> None:
         """Clear the persistent redis cache for `package`."""
         if await doc_cache.delete(package_name):
+            await self.item_fetcher.stale_inventory_notifier.symbol_counter.delete()
             await ctx.send(f"Successfully cleared the cache for `{package_name}`.")
         else:
             await ctx.send("No keys matching the package found.")


### PR DESCRIPTION
Some symbols always generate stale inventory warnings because some of the symbols they list are not present on the linked page, presumably because the formatting of the rst file or some other part of the doc build process is wrong. (for example the `environment-variables` symbol on https://www.pygame.org/docs/ref/pygame.html)

This PR adds a counter that's kept in redis and is incremented every time a warning is attempted to be raised for an item, its expire is also set to 3 weeks in the future to clear the counter in case the docs only needed a refresh or were fixed by the maintainers.
If that counter has a value above 2, the stale warning is not sent.