### PR TITLE
Server command now uses correct TalentPool attr

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -72,7 +72,7 @@ class Information(Cog):
         """Return additional server info only visible in moderation channels."""
         talentpool_info = ""
         if cog := self.bot.get_cog("Talentpool"):
-            talentpool_info = f"Nominated: {len(cog.watched_users)}\n"
+            talentpool_info = f"Nominated: {len(cog.cache)}\n"
 
         bb_info = ""
         if cog := self.bot.get_cog("Big Brother"):


### PR DESCRIPTION
Closes #1809 
This was attr changed when we removed the concept of a user being 'watched' while removing the talentpool.