### PR TITLE
Declare TalentPool.cache on init of cog

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -72,7 +72,8 @@ class Information(Cog):
         """Return additional server info only visible in moderation channels."""
         talentpool_info = ""
         if cog := self.bot.get_cog("Talentpool"):
-            talentpool_info = f"Nominated: {len(cog.cache)}\n"
+            num_nominated = len(cog.cache) if cog.cache else 0
+            talentpool_info = f"Nominated: {num_nominated}\n"
 
         bb_info = ""
         if cog := self.bot.get_cog("Big Brother"):

--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -72,7 +72,7 @@ class Information(Cog):
         """Return additional server info only visible in moderation channels."""
         talentpool_info = ""
         if cog := self.bot.get_cog("Talentpool"):
-            num_nominated = len(cog.cache) if cog.cache else 0
+            num_nominated = len(cog.cache) if cog.cache else "-"
             talentpool_info = f"Nominated: {num_nominated}\n"
 
         bb_info = ""

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -291,18 +291,7 @@ class TalentPool(Cog, name="Talentpool"):
         if await self.autoreview_enabled() and user.id not in self.reviewer:
             self.reviewer.schedule_review(user.id)
 
-        history = await self.bot.api_client.get(
-            'bot/nominations',
-            params={
-                "user__id": str(user.id),
-                "active": "false",
-                "ordering": "-inserted_at"
-            }
-        )
-
         msg = f"✅ The nomination for {user.mention} has been added to the talent pool"
-        if history:
-            msg += f"\n\n({len(history)} previous nominations in total)"
 
         await ctx.send(msg)
 

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -57,8 +57,6 @@ class Reviewer:
         """Reschedule all active nominations to be reviewed at the appropriate time."""
         log.trace("Rescheduling reviews")
         await self.bot.wait_until_guild_available()
-        # TODO Once the watch channel is removed, this can be done in a smarter way, e.g create a sync function.
-        await self._pool.refresh_cache()
 
         for user_id, user_data in self._pool.cache.items():
             if not user_data["reviewed"]:


### PR DESCRIPTION
Closes #1812

This avoids issues in the server cog trying to access it before it's assigned and refreshed.

I also migrated to the tasks to `scheduling.create_task()` as the created tasks currently don't have any error handling they can hide errors in development until the task object is destroyed (if that occurs at all) which logs the exception. The scheduling alternative attaches a callback which logs exceptions to prevent this.