### PR TITLE
Regex: add a word boundary before .gg

### DIFF
--- a/bot/utils/regex.py
+++ b/bot/utils/regex.py
@@ -7,7 +7,7 @@ INVITE_RE = re.compile(
     r"discord(?:[\.,]|dot)me|"                        # or discord.me
     r"discord(?:[\.,]|dot)li|"                        # or discord.li
     r"discord(?:[\.,]|dot)io|"                        # or discord.io.
-    r"(?:[\.,]|dot)gg"                                # or .gg/
+    r"(?:\b([\.,]|dot))gg"                                # or .gg/
     r")(?:[\/]|slash)"                                # / or 'slash'
     r"([a-zA-Z0-9\-]+)",                              # the invite code itself
     flags=re.IGNORECASE


### PR DESCRIPTION
Before this commit, `an-arbitrary-domain.gg/notaninvite` would trigger the filter. This solve the issue by adding a word boundary before this branch of the pattern.