### PR TITLE
Add metricity to docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ log.*
 # Custom user configuration
 config.yml
 docker-compose.override.yml
+metricity-config.toml
 
 # xmlrunner unittest XML reports
 TEST-**.xml

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -109,7 +109,7 @@ class Bot(commands.Bot):
     def create(cls) -> "Bot":
         """Create and return an instance of a Bot."""
         loop = asyncio.get_event_loop()
-        allowed_roles = [discord.Object(id_) for id_ in constants.MODERATION_ROLES]
+        allowed_roles = list({discord.Object(id_) for id_ in constants.MODERATION_ROLES})
 
         intents = discord.Intents.all()
         intents.presences = False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,11 @@ services:
       POSTGRES_DB: pysite
       POSTGRES_PASSWORD: pysite
       POSTGRES_USER: pysite
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U pysite"]
+      interval: 2s
+      timeout: 1s
+      retries: 5
 
   redis:
     << : *logging
@@ -30,6 +35,21 @@ services:
     image: redis:5.0.9
     ports:
       - "127.0.0.1:6379:6379"
+
+  metricity:
+    << : *logging
+    restart: on-failure  # USE_METRICITY=false will stop the container, so this ensures it only restarts on error
+    depends_on:
+      postgres:
+        condition: service_healthy
+    image: ghcr.io/python-discord/metricity:latest
+    env_file:
+      - .env
+    environment:
+      DATABASE_URI: postgres://pysite:pysite@postgres/metricity
+      USE_METRICITY: ${USE_METRICITY-false}
+    volumes:
+      - .:/tmp/bot:ro
 
   snekbox:
     << : *logging
@@ -56,7 +76,7 @@ services:
       - "127.0.0.1:8000:8000"
     tty: true
     depends_on:
-      - postgres
+      - metricity
     environment:
       DATABASE_URL: postgres://pysite:pysite@postgres:5432/pysite
       METRICITY_DB_URL: postgres://pysite:pysite@postgres:5432/metricity


### PR DESCRIPTION
By adding metricity to the compose, we allow it to migrate itself, rather than needing the site to do it.

Defaulting 'skip_metricity' to true means that it will run migrations, but not actually start the bot. This means we don't add another service that needs to run all the time, which could impact some contribs on lower powered hardware.

This needs to be merged at the same time as https://github.com/python-discord/site/pull/588