### PR TITLE
python-news escape fixes

### DIFF
--- a/bot/exts/info/python_news.py
+++ b/bot/exts/info/python_news.py
@@ -139,7 +139,7 @@ class PythonNews(Cog):
             self.bot.stats.incr("python_news.posted.pep")
 
             if msg.channel.is_news():
-                log.trace("Publishing PEP annnouncement because it was in a news channel")
+                log.trace("Publishing PEP announcement because it was in a news channel")
                 await msg.publish()
 
         # Apply new sent news to DB to avoid duplicate sending

--- a/bot/exts/info/python_news.py
+++ b/bot/exts/info/python_news.py
@@ -119,7 +119,7 @@ class PythonNews(Cog):
 
             # Build an embed and send a webhook
             embed = discord.Embed(
-                title=new["title"],
+                title=self.escape_markdown(new["title"]),
                 description=self.escape_markdown(new["summary"]),
                 timestamp=new_datetime,
                 url=new["link"],
@@ -189,7 +189,7 @@ class PythonNews(Cog):
 
                 # Build an embed and send a message to the webhook
                 embed = discord.Embed(
-                    title=thread_information["subject"],
+                    title=self.escape_markdown(thread_information["subject"]),
                     description=content[:1000] + f"... [continue reading]({link})" if len(content) > 1000 else content,
                     timestamp=new_date,
                     url=link,


### PR DESCRIPTION
Closes #1821.

Adds escapes to post titles and also no longer escapes markdown inside of codeblocks for python news posts.

Haven't been able to test in the context of python-news but have done simulated tests locally which work:
```py
>>> string = """
Hey,

I noticed that writing a class with a classmethod __eq__, it does not work as expected:
```py
class ANY:
    @classmethod
    def __eq__(cls, other):
        return True

assert ANY == 2   # succeeds
assert ANY == 2   # fails
\`\`\`  # backslashes aren't actually there, added here because of GitHub markdown
"""
>>> regex = re.compile(
    r"(?P<codeblock>`.*?`)"  # matches everything within a codeblock
    r"|(?P<markdown>(?<!\\)[_|])",  # matches unescaped `_` and `|`
    re.DOTALL  # required to support multi-line codeblocks
)
>>> indices_of_markdown_outside_codeblocks = {
    m.start()
    for m in re.finditer(regex, string)
    if m.group('markdown')
}
>>> indices_of_markdown_outside_codeblocks
{640, 641, 637, 57, 58, 636, 61, 62}
>>> new_str = regex.sub(
    lambda match: match.group("codeblock") or "\\" + match.group("markdown"),
    content
)
>>> print(new_str)
"""  # quotes added for GitHub markdown
Hey,

I noticed that writing a class with a classmethod \_\_eq\_\_, it does not work as expected:
```py
class ANY:
    @classmethod
    def __eq__(cls, other):
        return True

assert ANY == 2   # succeeds
assert ANY == 2   # fails
\`\`\`  # backslashes aren't actually there, added here because of GitHub markdown
"""  # quotes added for GitHub markdown
```
As we can see, markdown inside of codeblocks no-longer gets escaped. Have done others tests for spoilers/in-line codeblocks/pre-escaped locally and everything works perfectly (thanks to quite a bit of help from @mbaruh).
