### PR TITLE
Add `CustomLogger` to prevent IDE lint warnings when calling `log.trace`.

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,11 +1,10 @@
-import logging
-
 import aiohttp
 
 import bot
 from bot import constants
 from bot.bot import Bot, StartupError
 from bot.log import setup_sentry
+from bot.utils.logging import get_logger
 
 setup_sentry()
 
@@ -21,7 +20,7 @@ except StartupError as e:
         message = "Could not connect to Redis. Is it running?"
 
     # The exception is logged with an empty message so the actual message is visible at the bottom
-    log = logging.getLogger("bot")
+    log = get_logger("bot")
     log.fatal("", exc_info=e.exception)
     log.fatal(message)
 

--- a/bot/api.py
+++ b/bot/api.py
@@ -1,13 +1,13 @@
 import asyncio
-import logging
 from typing import Optional
 from urllib.parse import quote as quote_url
 
 import aiohttp
 
 from .constants import Keys, URLs
+from .utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ResponseCodeError(ValueError):

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import socket
 import warnings
 from collections import defaultdict
@@ -14,8 +13,9 @@ from sentry_sdk import push_scope
 
 from bot import api, constants
 from bot.async_stats import AsyncStatsClient
+from bot.utils.logging import get_logger
 
-log = logging.getLogger('bot')
+log = get_logger('bot')
 LOCALHOST = "127.0.0.1"
 
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -9,7 +9,6 @@ the custom configuration. Any settings left
 out in the custom user configuration will stay
 their default values from `config-default.yml`.
 """
-
 import logging
 import os
 from collections.abc import Mapping
@@ -25,7 +24,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(__name__)  # use logging.getLogger (not bot.utils.logging.get_logger) to prevent circular import
 
 
 def _env_var_constructor(loader, node):

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import re
 import typing as t
 from datetime import datetime
@@ -19,12 +18,13 @@ from bot.api import ResponseCodeError
 from bot.constants import URLs
 from bot.exts.info.doc import _inventory_parser
 from bot.utils.extensions import EXTENSIONS, unqualify
+from bot.utils.logging import get_logger
 from bot.utils.regex import INVITE_RE
 from bot.utils.time import parse_duration_string
 if t.TYPE_CHECKING:
     from bot.exts.info.source import SourceType
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 DISCORD_EPOCH_DT = datetime.utcfromtimestamp(DISCORD_EPOCH / 1000)
 RE_USER_MENTION = re.compile(r"<@!?([0-9]+)>$")

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -1,6 +1,5 @@
 import asyncio
 import functools
-import logging
 import types
 import typing as t
 from contextlib import suppress
@@ -13,8 +12,9 @@ from bot.constants import Channels, DEBUG_MODE, RedirectOutput
 from bot.utils import function
 from bot.utils.checks import ContextCheckFailure, in_whitelist_check
 from bot.utils.function import command_wraps
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def in_whitelist(

--- a/bot/exts/backend/branding/_cog.py
+++ b/bot/exts/backend/branding/_cog.py
@@ -1,6 +1,5 @@
 import asyncio
 import contextlib
-import logging
 import random
 import typing as t
 from datetime import timedelta
@@ -17,8 +16,9 @@ from bot.bot import Bot
 from bot.constants import Branding as BrandingConfig, Channels, Colours, Guild, MODERATION_ROLES
 from bot.decorators import mock_in_debug
 from bot.exts.backend.branding._repository import BrandingRepository, Event, RemoteObject
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class AssetType(Enum):

--- a/bot/exts/backend/branding/_repository.py
+++ b/bot/exts/backend/branding/_repository.py
@@ -1,4 +1,3 @@
-import logging
 import typing as t
 from datetime import date, datetime
 
@@ -7,6 +6,7 @@ import frontmatter
 from bot.bot import Bot
 from bot.constants import Keys
 from bot.errors import BrandingMisconfiguration
+from bot.utils.logging import get_logger
 
 # Base URL for requests into the branding repository.
 BRANDING_URL = "https://api.github.com/repos/python-discord/branding/contents"
@@ -25,7 +25,7 @@ ARBITRARY_YEAR = 2020
 # Format used to parse date strings after we inject `ARBITRARY_YEAR` at the end.
 DATE_FMT = "%B %d %Y"  # Ex: July 10 2020
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class RemoteObject:

--- a/bot/exts/backend/config_verifier.py
+++ b/bot/exts/backend/config_verifier.py
@@ -1,12 +1,11 @@
-import logging
-
 from discord.ext.commands import Cog
 
 from bot import constants
 from bot.bot import Bot
+from bot.utils.logging import get_logger
 
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ConfigVerifier(Cog):

--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -1,5 +1,4 @@
 import difflib
-import logging
 import typing as t
 
 from discord import Embed
@@ -12,8 +11,9 @@ from bot.constants import Colours, Icons, MODERATION_ROLES
 from bot.converters import TagNameConverter
 from bot.errors import InvalidInfractedUserError, LockedResourceError
 from bot.utils.checks import ContextCheckFailure
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ErrorHandler(Cog):

--- a/bot/exts/backend/logging.py
+++ b/bot/exts/backend/logging.py
@@ -1,13 +1,12 @@
-import logging
-
 from discord import Embed
 from discord.ext.commands import Cog
 
 from bot.bot import Bot
 from bot.constants import Channels, DEBUG_MODE
+from bot.utils.logging import get_logger
 
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class Logging(Cog):

--- a/bot/exts/backend/sync/_cog.py
+++ b/bot/exts/backend/sync/_cog.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any, Dict
 
 from discord import Member, Role, User
@@ -9,8 +8,9 @@ from bot import constants
 from bot.api import ResponseCodeError
 from bot.bot import Bot
 from bot.exts.backend.sync import _syncers
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class Sync(Cog):

--- a/bot/exts/backend/sync/_syncers.py
+++ b/bot/exts/backend/sync/_syncers.py
@@ -1,5 +1,4 @@
 import abc
-import logging
 import typing as t
 from collections import namedtuple
 
@@ -9,8 +8,9 @@ from more_itertools import chunked
 
 import bot
 from bot.api import ResponseCodeError
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 CHUNK_SIZE = 1000
 

--- a/bot/exts/events/code_jams/_channels.py
+++ b/bot/exts/events/code_jams/_channels.py
@@ -1,11 +1,11 @@
-import logging
 import typing as t
 
 import discord
 
 from bot.constants import Categories, Channels, Roles
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 MAX_CHANNELS = 50
 CATEGORY_NAME = "Code Jam"

--- a/bot/exts/events/code_jams/_cog.py
+++ b/bot/exts/events/code_jams/_cog.py
@@ -1,6 +1,5 @@
 import asyncio
 import csv
-import logging
 import typing as t
 from collections import defaultdict
 
@@ -11,9 +10,10 @@ from discord.ext import commands
 from bot.bot import Bot
 from bot.constants import Emojis, Roles
 from bot.exts.events.code_jams import _channels
+from bot.utils.logging import get_logger
 from bot.utils.services import send_to_paste_service
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 TEAM_LEADERS_COLOUR = 0x11806a
 DELETION_REACTION = "\U0001f4a5"

--- a/bot/exts/filters/antimalware.py
+++ b/bot/exts/filters/antimalware.py
@@ -1,4 +1,3 @@
-import logging
 import typing as t
 from os.path import splitext
 
@@ -8,8 +7,9 @@ from discord.ext.commands import Cog
 from bot.bot import Bot
 from bot.constants import Channels, Filter, URLs
 from bot.exts.events.code_jams._channels import CATEGORY_NAME as JAM_CATEGORY_NAME
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 PY_EMBED_DESCRIPTION = (
     "It looks like you tried to attach a Python file - "

--- a/bot/exts/filters/antispam.py
+++ b/bot/exts/filters/antispam.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -22,11 +21,12 @@ from bot.converters import Duration
 from bot.exts.events.code_jams._channels import CATEGORY_NAME as JAM_CATEGORY_NAME
 from bot.exts.moderation.modlog import ModLog
 from bot.utils import lock, scheduling
+from bot.utils.logging import get_logger
 from bot.utils.message_cache import MessageCache
 from bot.utils.messages import format_user, send_attachments
 
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 RULE_FUNCTION_MAPPING = {
     'attachments': rules.apply_attachments,

--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Optional
 
 from discord import Colour, Embed
@@ -9,8 +8,9 @@ from bot.api import ResponseCodeError
 from bot.bot import Bot
 from bot.converters import ValidDiscordServerInvite, ValidFilterListType
 from bot.pagination import LinePaginator
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class FilterLists(Cog):

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Tuple, Union
@@ -21,11 +20,12 @@ from bot.constants import (
 )
 from bot.exts.events.code_jams._channels import CATEGORY_NAME as JAM_CATEGORY_NAME
 from bot.exts.moderation.modlog import ModLog
+from bot.utils.logging import get_logger
 from bot.utils.messages import format_user
 from bot.utils.regex import INVITE_RE
 from bot.utils.scheduling import Scheduler
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # Regular expressions
 CODE_BLOCK_RE = re.compile(

--- a/bot/exts/filters/security.py
+++ b/bot/exts/filters/security.py
@@ -1,10 +1,9 @@
-import logging
-
 from discord.ext.commands import Cog, Context, NoPrivateMessage
 
 from bot.bot import Bot
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class Security(Cog):

--- a/bot/exts/filters/token_remover.py
+++ b/bot/exts/filters/token_remover.py
@@ -1,6 +1,5 @@
 import base64
 import binascii
-import logging
 import re
 import typing as t
 
@@ -11,9 +10,10 @@ from bot import utils
 from bot.bot import Bot
 from bot.constants import Channels, Colours, Event, Icons
 from bot.exts.moderation.modlog import ModLog
+from bot.utils.logging import get_logger
 from bot.utils.messages import format_user
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 LOG_MESSAGE = (
     "Censored a seemingly valid token sent by {author} in {channel}, "

--- a/bot/exts/filters/webhook_remover.py
+++ b/bot/exts/filters/webhook_remover.py
@@ -1,4 +1,3 @@
-import logging
 import re
 
 from discord import Colour, Message, NotFound
@@ -7,6 +6,7 @@ from discord.ext.commands import Cog
 from bot.bot import Bot
 from bot.constants import Channels, Colours, Event, Icons
 from bot.exts.moderation.modlog import ModLog
+from bot.utils.logging import get_logger
 from bot.utils.messages import format_user
 
 WEBHOOK_URL_RE = re.compile(
@@ -21,7 +21,7 @@ ALERT_MESSAGE_TEMPLATE = (
     "mistake, please let us know."
 )
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class WebhookRemover(Cog):

--- a/bot/exts/fun/duck_pond.py
+++ b/bot/exts/fun/duck_pond.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 from typing import Union
 
 import discord
@@ -10,10 +9,11 @@ from bot import constants
 from bot.bot import Bot
 from bot.converters import MemberOrUser
 from bot.utils.checks import has_any_role
+from bot.utils.logging import get_logger
 from bot.utils.messages import count_unique_users_reaction, send_attachments
 from bot.utils.webhooks import send_webhook
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class DuckPond(Cog):

--- a/bot/exts/fun/off_topic_names.py
+++ b/bot/exts/fun/off_topic_names.py
@@ -1,5 +1,4 @@
 import difflib
-import logging
 from datetime import datetime, timedelta
 
 from discord import Colour, Embed
@@ -11,9 +10,10 @@ from bot.bot import Bot
 from bot.constants import Channels, MODERATION_ROLES
 from bot.converters import OffTopicName
 from bot.pagination import LinePaginator
+from bot.utils.logging import get_logger
 
 CHANNELS = (Channels.off_topic_0, Channels.off_topic_1, Channels.off_topic_2)
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 async def update_names(bot: Bot) -> None:

--- a/bot/exts/help_channels/__init__.py
+++ b/bot/exts/help_channels/__init__.py
@@ -1,10 +1,9 @@
-import logging
-
 from bot import constants
 from bot.bot import Bot
 from bot.exts.help_channels._channel import MAX_CHANNELS_PER_CATEGORY
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def validate_config() -> None:

--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -1,4 +1,3 @@
-import logging
 import typing as t
 from datetime import timedelta
 from enum import Enum
@@ -11,8 +10,9 @@ import bot
 from bot import constants
 from bot.exts.help_channels import _caches, _message
 from bot.utils.channel import try_get_channel
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 MAX_CHANNELS_PER_CATEGORY = 50
 EXCLUDED_CHANNELS = (constants.Channels.cooldown,)

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import random
 import typing as t
 from datetime import timedelta
@@ -15,8 +14,9 @@ from bot.bot import Bot
 from bot.constants import Channels, RedirectOutput
 from bot.exts.help_channels import _caches, _channel, _message, _name, _stats
 from bot.utils import channel as channel_utils, lock, scheduling
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 NAMESPACE = "help"
 HELP_CHANNEL_TOPIC = """

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -1,4 +1,3 @@
-import logging
 import textwrap
 import typing as t
 
@@ -9,8 +8,9 @@ from arrow import Arrow
 import bot
 from bot import constants
 from bot.exts.help_channels import _caches
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 ASKING_GUIDE_URL = "https://pythondiscord.com/pages/asking-good-questions/"
 

--- a/bot/exts/help_channels/_name.py
+++ b/bot/exts/help_channels/_name.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import typing as t
 from collections import deque
 from pathlib import Path
@@ -8,8 +7,9 @@ import discord
 
 from bot import constants
 from bot.exts.help_channels._channel import MAX_CHANNELS_PER_CATEGORY, get_category_channels
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def create_name_queue(*categories: discord.CategoryChannel) -> deque:

--- a/bot/exts/help_channels/_stats.py
+++ b/bot/exts/help_channels/_stats.py
@@ -1,12 +1,11 @@
-import logging
-
 from more_itertools import ilen
 
 import bot
 from bot import constants
 from bot.exts.help_channels import _caches, _channel
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def report_counts() -> None:

--- a/bot/exts/info/code_snippets.py
+++ b/bot/exts/info/code_snippets.py
@@ -10,9 +10,10 @@ from discord.ext.commands import Cog
 
 from bot.bot import Bot
 from bot.constants import Channels
+from bot.utils.logging import get_logger
 from bot.utils.messages import wait_for_deletion
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 GITHUB_RE = re.compile(
     r'https://github\.com/(?P<repo>[a-zA-Z0-9-]+/[\w.-]+)/blob/'

--- a/bot/exts/info/codeblock/_cog.py
+++ b/bot/exts/info/codeblock/_cog.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from typing import Optional
 
@@ -13,9 +12,10 @@ from bot.exts.filters.webhook_remover import WEBHOOK_URL_RE
 from bot.exts.info.codeblock._instructions import get_instructions
 from bot.utils import has_lines
 from bot.utils.channel import is_help_channel
+from bot.utils.logging import get_logger
 from bot.utils.messages import wait_for_deletion
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class CodeBlockCog(Cog, name="Code Block"):

--- a/bot/exts/info/codeblock/_instructions.py
+++ b/bot/exts/info/codeblock/_instructions.py
@@ -1,11 +1,11 @@
 """This module generates and formats instructional messages about fixing Markdown code blocks."""
 
-import logging
 from typing import Optional
 
 from bot.exts.info.codeblock import _parsing
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 _EXAMPLE_PY = "{lang}\nprint('Hello, world!')"  # Make sure to escape any Markdown symbols here.
 _EXAMPLE_CODE_BLOCKS = (

--- a/bot/exts/info/codeblock/_parsing.py
+++ b/bot/exts/info/codeblock/_parsing.py
@@ -1,15 +1,15 @@
 """This module provides functions for parsing Markdown code blocks."""
 
 import ast
-import logging
 import re
 import textwrap
 from typing import NamedTuple, Optional, Sequence
 
 from bot import constants
 from bot.utils import has_lines
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 BACKTICK = "`"
 PY_LANG_CODES = ("python-repl", "python", "pycon", "py")  # Order is important; "py" is last cause it's a subset.

--- a/bot/exts/info/doc/_batch_parser.py
+++ b/bot/exts/info/doc/_batch_parser.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import collections
-import logging
 from collections import defaultdict
 from contextlib import suppress
 from operator import attrgetter
@@ -14,10 +13,11 @@ from bs4 import BeautifulSoup
 import bot
 from bot.constants import Channels
 from bot.utils import scheduling
+from bot.utils.logging import get_logger
 from . import _cog, doc_cache
 from ._parsing import get_symbol_markdown
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class StaleInventoryNotifier:

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import sys
 import textwrap
 from collections import defaultdict
@@ -18,12 +17,13 @@ from bot.constants import MODERATION_ROLES, RedirectOutput
 from bot.converters import Inventory, PackageName, ValidURL, allowed_strings
 from bot.pagination import LinePaginator
 from bot.utils.lock import SharedEvent, lock
+from bot.utils.logging import get_logger
 from bot.utils.messages import send_denial, wait_for_deletion
 from bot.utils.scheduling import Scheduler
 from . import NAMESPACE, PRIORITY_PACKAGES, _batch_parser, doc_cache
 from ._inventory_parser import InventoryDict, fetch_inventory
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # symbols with a group contained here will get the group prefixed on duplicates
 FORCE_PREFIX_GROUPS = (

--- a/bot/exts/info/doc/_html.py
+++ b/bot/exts/info/doc/_html.py
@@ -1,4 +1,3 @@
-import logging
 import re
 from functools import partial
 from typing import Callable, Container, Iterable, List, Union
@@ -6,9 +5,10 @@ from typing import Callable, Container, Iterable, List, Union
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, PageElement, SoupStrainer, Tag
 
+from bot.utils.logging import get_logger
 from . import MAX_SIGNATURE_AMOUNT
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 _UNWANTED_SIGNATURE_SYMBOLS_RE = re.compile(r"\[source]|\\\\|¶")
 _SEARCH_END_TAG_ATTRS = (

--- a/bot/exts/info/doc/_inventory_parser.py
+++ b/bot/exts/info/doc/_inventory_parser.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import zlib
 from collections import defaultdict
@@ -7,8 +6,9 @@ from typing import AsyncIterator, DefaultDict, List, Optional, Tuple
 import aiohttp
 
 import bot
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 FAILED_REQUEST_ATTEMPTS = 3
 _V2_LINE_RE = re.compile(r'(?x)(.+?)\s+(\S*:\S*)\s+(-?\d+)\s+?(\S*)\s+(.*)')

--- a/bot/exts/info/doc/_parsing.py
+++ b/bot/exts/info/doc/_parsing.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import re
 import string
 import textwrap
@@ -11,13 +10,14 @@ from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
 from bot.utils.helpers import find_nth_occurrence
+from bot.utils.logging import get_logger
 from . import MAX_SIGNATURE_AMOUNT
 from ._html import get_dd_description, get_general_description, get_signatures
 from ._markdown import DocMarkdownConverter
 if TYPE_CHECKING:
     from ._cog import DocItem
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 _WHITESPACE_AFTER_NEWLINES_RE = re.compile(r"(?<=\n\n)(\s+)")
 _PARAMETERS_RE = re.compile(r"\((.+)\)")

--- a/bot/exts/info/help.py
+++ b/bot/exts/info/help.py
@@ -1,5 +1,4 @@
 import itertools
-import logging
 from collections import namedtuple
 from contextlib import suppress
 from typing import List, Union
@@ -13,9 +12,10 @@ from bot import constants
 from bot.constants import Channels, STAFF_PARTNERS_COMMUNITY_ROLES
 from bot.decorators import redirect_output
 from bot.pagination import LinePaginator
+from bot.utils.logging import get_logger
 from bot.utils.messages import wait_for_deletion
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 COMMANDS_PER_PAGE = 8
 PREFIX = constants.Bot.prefix

--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -1,5 +1,4 @@
 import colorsys
-import logging
 import pprint
 import textwrap
 from collections import defaultdict
@@ -19,9 +18,10 @@ from bot.errors import NonExistentRoleError
 from bot.pagination import LinePaginator
 from bot.utils.channel import is_mod_channel, is_staff_channel
 from bot.utils.checks import cooldown_with_role_bypass, has_no_roles_check, in_whitelist_check
+from bot.utils.logging import get_logger
 from bot.utils.time import TimestampFormats, discord_timestamp, humanize_delta
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class Information(Cog):

--- a/bot/exts/info/pep.py
+++ b/bot/exts/info/pep.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime, timedelta
 from email.parser import HeaderParser
 from io import StringIO
@@ -10,8 +9,9 @@ from discord.ext.commands import Cog, Context, command
 from bot.bot import Bot
 from bot.constants import Keys
 from bot.utils.caching import AsyncCache
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 ICON_URL = "https://www.python.org/static/opengraph-icon-200x200.png"
 BASE_PEP_URL = "http://www.python.org/dev/peps/pep-"

--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -1,5 +1,4 @@
 import itertools
-import logging
 import random
 import re
 from contextlib import suppress
@@ -10,6 +9,7 @@ from discord.utils import escape_markdown
 
 from bot.bot import Bot
 from bot.constants import Colours, NEGATIVE_REPLIES, RedirectOutput
+from bot.utils.logging import get_logger
 from bot.utils.messages import wait_for_deletion
 
 URL = "https://pypi.org/pypi/{package}/json"
@@ -20,7 +20,7 @@ PYPI_COLOURS = itertools.cycle((Colours.yellow, Colours.blue, Colours.white))
 ILLEGAL_CHARACTERS = re.compile(r"[^-_.a-zA-Z0-9]+")
 INVALID_INPUT_DELETE_DELAY = RedirectOutput.delete_delay
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class PyPi(Cog):

--- a/bot/exts/info/python_news.py
+++ b/bot/exts/info/python_news.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import typing as t
 from datetime import date, datetime
@@ -11,6 +10,7 @@ from discord.ext.tasks import loop
 
 from bot import constants
 from bot.bot import Bot
+from bot.utils.logging import get_logger
 from bot.utils.webhooks import send_webhook
 
 PEPS_RSS_URL = "https://www.python.org/dev/peps/peps.rss/"
@@ -22,7 +22,7 @@ THREAD_URL = "https://mail.python.org/archives/list/{list}@python.org/thread/{id
 
 AVATAR_URL = "https://www.python.org/static/opengraph-icon-200x200.png"
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class PythonNews(Cog):

--- a/bot/exts/info/site.py
+++ b/bot/exts/info/site.py
@@ -1,13 +1,12 @@
-import logging
-
 from discord import Colour, Embed
 from discord.ext.commands import Cog, Context, Greedy, group
 
 from bot.bot import Bot
 from bot.constants import URLs
 from bot.pagination import LinePaginator
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 BASE_URL = f"{URLs.site_schema}{URLs.site}"
 

--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -1,4 +1,3 @@
-import logging
 import re
 import time
 from pathlib import Path
@@ -11,9 +10,10 @@ from bot import constants
 from bot.bot import Bot
 from bot.converters import TagNameConverter
 from bot.pagination import LinePaginator
+from bot.utils.logging import get_logger
 from bot.utils.messages import wait_for_deletion
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 TEST_CHANNELS = (
     constants.Channels.bot_commands,

--- a/bot/exts/moderation/defcon.py
+++ b/bot/exts/moderation/defcon.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import traceback
 from collections import namedtuple
 from datetime import datetime
@@ -17,13 +16,14 @@ from bot.bot import Bot
 from bot.constants import Channels, Colours, Emojis, Event, Icons, MODERATION_ROLES, Roles
 from bot.converters import DurationDelta, Expiry
 from bot.exts.moderation.modlog import ModLog
+from bot.utils.logging import get_logger
 from bot.utils.messages import format_user
 from bot.utils.scheduling import Scheduler
 from bot.utils.time import (
     TimestampFormats, discord_timestamp, humanize_delta, parse_duration_string, relativedelta_to_timedelta
 )
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 REJECTION_MESSAGE = """
 Hi, {user} - Thanks for your interest in our server!

--- a/bot/exts/moderation/dm_relay.py
+++ b/bot/exts/moderation/dm_relay.py
@@ -1,14 +1,13 @@
-import logging
-
 import discord
 from discord.ext.commands import Cog, Context, command, has_any_role
 
 from bot.bot import Bot
 from bot.constants import Emojis, MODERATION_ROLES
 from bot.utils.channel import is_mod_channel
+from bot.utils.logging import get_logger
 from bot.utils.services import send_to_paste_service
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class DMRelay(Cog):

--- a/bot/exts/moderation/incidents.py
+++ b/bot/exts/moderation/incidents.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import typing as t
 from datetime import datetime
 from enum import Enum
@@ -9,9 +8,10 @@ from discord.ext.commands import Cog
 
 from bot.bot import Bot
 from bot.constants import Channels, Colours, Emojis, Guild, Webhooks
+from bot.utils.logging import get_logger
 from bot.utils.messages import sub_clyde
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # Amount of messages for `crawl_task` to process at most on start-up - limited to 50
 # as in practice, there should never be this many messages, and if there are,

--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -1,4 +1,3 @@
-import logging
 import textwrap
 import typing as t
 from abc import abstractmethod
@@ -18,8 +17,9 @@ from bot.exts.moderation.infraction import _utils
 from bot.exts.moderation.modlog import ModLog
 from bot.utils import messages, scheduling, time
 from bot.utils.channel import is_mod_channel
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class InfractionScheduler:

--- a/bot/exts/moderation/infraction/_utils.py
+++ b/bot/exts/moderation/infraction/_utils.py
@@ -1,4 +1,3 @@
-import logging
 import typing as t
 from datetime import datetime
 
@@ -9,8 +8,9 @@ from bot.api import ResponseCodeError
 from bot.constants import Colours, Icons
 from bot.converters import MemberOrUser
 from bot.errors import InvalidInfractedUserError
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # apply icon, pardon icon
 INFRACTION_ICONS = {

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -1,4 +1,3 @@
-import logging
 import textwrap
 import typing as t
 
@@ -14,9 +13,10 @@ from bot.converters import Duration, Expiry, MemberOrUser, UnambiguousMemberOrUs
 from bot.decorators import respect_role_hierarchy
 from bot.exts.moderation.infraction import _utils
 from bot.exts.moderation.infraction._scheduler import InfractionScheduler
+from bot.utils import logging
 from bot.utils.messages import format_user
 
-log = logging.getLogger(__name__)
+log = logging.get_logger(__name__)
 
 
 class Infractions(InfractionScheduler, commands.Cog):

--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -1,4 +1,3 @@
-import logging
 import textwrap
 import typing as t
 from datetime import datetime
@@ -19,9 +18,10 @@ from bot.exts.moderation.modlog import ModLog
 from bot.pagination import LinePaginator
 from bot.utils import messages, time
 from bot.utils.channel import is_mod_channel
+from bot.utils.logging import get_logger
 from bot.utils.time import humanize_delta, until_expiration
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ModManagement(commands.Cog):

--- a/bot/exts/moderation/infraction/superstarify.py
+++ b/bot/exts/moderation/infraction/superstarify.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import random
 import textwrap
 import typing as t
@@ -14,10 +13,11 @@ from bot.bot import Bot
 from bot.converters import Duration, Expiry
 from bot.exts.moderation.infraction import _utils
 from bot.exts.moderation.infraction._scheduler import InfractionScheduler
+from bot.utils.logging import get_logger
 from bot.utils.messages import format_user
 from bot.utils.time import format_infraction
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 NICKNAME_POLICY_URL = "https://pythondiscord.com/pages/rules/#nickname-policy"
 SUPERSTARIFY_DEFAULT_DURATION = "1h"
 

--- a/bot/exts/moderation/metabase.py
+++ b/bot/exts/moderation/metabase.py
@@ -1,6 +1,5 @@
 import csv
 import json
-import logging
 from datetime import timedelta
 from io import StringIO
 from typing import Dict, List, Optional
@@ -16,9 +15,10 @@ from bot.constants import Metabase as MetabaseConfig, Roles
 from bot.converters import allowed_strings
 from bot.utils import send_to_paste_service
 from bot.utils.channel import is_mod_channel
+from bot.utils.logging import get_logger
 from bot.utils.scheduling import Scheduler
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 BASE_HEADERS = {
     "Content-Type": "application/json"

--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -1,7 +1,6 @@
 import asyncio
 import difflib
 import itertools
-import logging
 import typing as t
 from datetime import datetime
 from itertools import zip_longest
@@ -16,10 +15,11 @@ from discord.utils import escape_markdown
 
 from bot.bot import Bot
 from bot.constants import Categories, Channels, Colours, Emojis, Event, Guild as GuildConstant, Icons, Roles, URLs
+from bot.utils.logging import get_logger
 from bot.utils.messages import format_user
 from bot.utils.time import humanize_delta
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 GUILD_CHANNEL = t.Union[discord.CategoryChannel, discord.TextChannel, discord.VoiceChannel]
 

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 
 from async_rediscache import RedisCache
 from dateutil.parser import isoparse
@@ -9,9 +8,10 @@ from discord.ext.commands import Cog, Context, group, has_any_role
 from bot.bot import Bot
 from bot.constants import Colours, Emojis, Guild, Icons, MODERATION_ROLES, Roles
 from bot.converters import Expiry
+from bot.utils.logging import get_logger
 from bot.utils.scheduling import Scheduler
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ModPings(Cog):

--- a/bot/exts/moderation/silence.py
+++ b/bot/exts/moderation/silence.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import typing
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
@@ -14,9 +13,10 @@ from bot import constants
 from bot.bot import Bot
 from bot.converters import HushDurationConverter
 from bot.utils.lock import LockedResourceError, lock, lock_arg
+from bot.utils.logging import get_logger
 from bot.utils.scheduling import Scheduler
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 LOCK_NAMESPACE = "silence"
 

--- a/bot/exts/moderation/slowmode.py
+++ b/bot/exts/moderation/slowmode.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Optional
 
 from dateutil.relativedelta import relativedelta
@@ -9,8 +8,9 @@ from bot.bot import Bot
 from bot.constants import Channels, Emojis, MODERATION_ROLES
 from bot.converters import DurationDelta
 from bot.utils import time
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 SLOWMODE_MAX_DELAY = 21600  # seconds
 

--- a/bot/exts/moderation/stream.py
+++ b/bot/exts/moderation/stream.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import timedelta, timezone
 from operator import itemgetter
 
@@ -15,10 +14,11 @@ from bot.constants import (
 )
 from bot.converters import Expiry
 from bot.pagination import LinePaginator
+from bot.utils.logging import get_logger
 from bot.utils.scheduling import Scheduler
 from bot.utils.time import discord_timestamp, format_infraction_with_duration
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class Stream(commands.Cog):

--- a/bot/exts/moderation/verification.py
+++ b/bot/exts/moderation/verification.py
@@ -1,4 +1,3 @@
-import logging
 import typing as t
 
 import discord
@@ -8,8 +7,9 @@ from bot import constants
 from bot.bot import Bot
 from bot.decorators import in_whitelist
 from bot.utils.checks import InWhitelistCheckFailure
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # Sent via DMs once user joins the guild
 ON_JOIN_MESSAGE = """

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 from contextlib import suppress
 from datetime import datetime, timedelta
 
@@ -15,8 +14,9 @@ from bot.constants import Channels, Event, MODERATION_ROLES, Roles, VoiceGate as
 from bot.decorators import has_no_roles, in_whitelist
 from bot.exts.moderation.modlog import ModLog
 from bot.utils.checks import InWhitelistCheckFailure
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # Flag written to the cog's RedisCache as a value when the Member's (key) notification
 # was already removed ~ this signals both that no further notifications should be sent,

--- a/bot/exts/moderation/watchchannels/_watchchannel.py
+++ b/bot/exts/moderation/watchchannels/_watchchannel.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import re
 import textwrap
 from abc import abstractmethod
@@ -17,11 +16,13 @@ from bot.constants import BigBrother as BigBrotherConfig, Guild as GuildConfig, 
 from bot.exts.filters.token_remover import TokenRemover
 from bot.exts.filters.webhook_remover import WEBHOOK_URL_RE
 from bot.exts.moderation.modlog import ModLog
+from bot.log import CustomLogger
 from bot.pagination import LinePaginator
 from bot.utils import CogABCMeta, messages
+from bot.utils.logging import get_logger
 from bot.utils.time import get_time_delta
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 URL_RE = re.compile(r"(https?://[^\s]+)")
 
@@ -46,7 +47,7 @@ class WatchChannel(metaclass=CogABCMeta):
         webhook_id: int,
         api_endpoint: str,
         api_default_params: dict,
-        logger: logging.Logger,
+        logger: CustomLogger,
         *,
         disable_header: bool = False
     ) -> None:

--- a/bot/exts/moderation/watchchannels/bigbrother.py
+++ b/bot/exts/moderation/watchchannels/bigbrother.py
@@ -1,4 +1,3 @@
-import logging
 import textwrap
 from collections import ChainMap
 
@@ -9,8 +8,9 @@ from bot.constants import Channels, MODERATION_ROLES, Webhooks
 from bot.converters import MemberOrUser
 from bot.exts.moderation.infraction._utils import post_infraction
 from bot.exts.moderation.watchchannels._watchchannel import WatchChannel
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class BigBrother(WatchChannel, Cog, name="Big Brother"):

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -1,6 +1,5 @@
 import asyncio
 import contextlib
-import logging
 import random
 import re
 import textwrap
@@ -16,6 +15,7 @@ from discord.ext.commands import Context
 from bot.api import ResponseCodeError
 from bot.bot import Bot
 from bot.constants import Channels, Colours, Emojis, Guild
+from bot.utils.logging import get_logger
 from bot.utils.messages import count_unique_users_reaction, pin_no_system_message
 from bot.utils.scheduling import Scheduler
 from bot.utils.time import get_time_delta, time_since
@@ -23,7 +23,7 @@ from bot.utils.time import get_time_delta, time_since
 if typing.TYPE_CHECKING:
     from bot.exts.recruitment.talentpool._cog import TalentPool
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 # Maximum amount of days before an automatic review is posted.
 MAX_DAYS_IN_POOL = 30

--- a/bot/exts/utils/bot.py
+++ b/bot/exts/utils/bot.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Optional
 
 from discord import Embed, TextChannel
@@ -6,8 +5,9 @@ from discord.ext.commands import Cog, Context, command, group, has_any_role
 
 from bot.bot import Bot
 from bot.constants import Guild, MODERATION_ROLES, URLs
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class BotCog(Cog, name="Bot"):

--- a/bot/exts/utils/clean.py
+++ b/bot/exts/utils/clean.py
@@ -1,4 +1,3 @@
-import logging
 import random
 import re
 from typing import Iterable, Optional
@@ -12,8 +11,9 @@ from bot.constants import (
     Channels, CleanMessages, Colours, Event, Icons, MODERATION_ROLES, NEGATIVE_REPLIES
 )
 from bot.exts.moderation.modlog import ModLog
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class Clean(Cog):

--- a/bot/exts/utils/extensions.py
+++ b/bot/exts/utils/extensions.py
@@ -1,5 +1,4 @@
 import functools
-import logging
 import typing as t
 from enum import Enum
 
@@ -13,8 +12,9 @@ from bot.constants import Emojis, MODERATION_ROLES, Roles, URLs
 from bot.converters import Extension
 from bot.pagination import LinePaginator
 from bot.utils.extensions import EXTENSIONS
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 UNLOAD_BLACKLIST = {f"{exts.__name__}.utils.extensions", f"{exts.__name__}.moderation.modlog"}

--- a/bot/exts/utils/internal.py
+++ b/bot/exts/utils/internal.py
@@ -1,6 +1,5 @@
 import contextlib
 import inspect
-import logging
 import pprint
 import re
 import textwrap
@@ -16,8 +15,9 @@ from discord.ext.commands import Cog, Context, group, has_any_role, is_owner
 from bot.bot import Bot
 from bot.constants import DEBUG_MODE, Roles
 from bot.utils import find_nth_occurrence, send_to_paste_service
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class Internal(Cog):

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import random
 import textwrap
 import typing as t
@@ -19,11 +18,12 @@ from bot.converters import Duration, UnambiguousUser
 from bot.pagination import LinePaginator
 from bot.utils.checks import has_any_role_check, has_no_roles_check
 from bot.utils.lock import lock_arg
+from bot.utils.logging import get_logger
 from bot.utils.messages import send_denial
 from bot.utils.scheduling import Scheduler
 from bot.utils.time import TimestampFormats, discord_timestamp
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 LOCK_NAMESPACE = "reminder"
 WHITELISTED_CHANNELS = Guild.reminder_whitelist

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import datetime
-import logging
 import re
 import textwrap
 from functools import partial
@@ -15,9 +14,10 @@ from bot.bot import Bot
 from bot.constants import Categories, Channels, Roles, URLs
 from bot.decorators import redirect_output
 from bot.utils import send_to_paste_service
+from bot.utils.logging import get_logger
 from bot.utils.messages import wait_for_deletion
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 ESCAPE_REGEX = re.compile("[`\u202E\u200B]{3,}")
 FORMATTED_CODE_REGEX = re.compile(

--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -1,5 +1,4 @@
 import difflib
-import logging
 import re
 import unicodedata
 from typing import Tuple, Union
@@ -14,9 +13,10 @@ from bot.converters import Snowflake
 from bot.decorators import in_whitelist
 from bot.pagination import LinePaginator
 from bot.utils import messages
+from bot.utils.logging import get_logger
 from bot.utils.time import time_since
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 ZEN_OF_PYTHON = """\
 Beautiful is better than ugly.

--- a/bot/log.py
+++ b/bot/log.py
@@ -14,11 +14,27 @@ from bot import constants
 TRACE_LEVEL = 5
 
 
+class CustomLogger(Logger):
+    """Custom implementation of the `Logger` class with an added `trace` method."""
+
+    def trace(self, msg: str, *args, **kwargs) -> None:
+        """
+        Log 'msg % args' with severity 'TRACE'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.trace("Houston, we have an %s", "interesting problem", exc_info=1)
+        """
+        if self.isEnabledFor(TRACE_LEVEL):
+            self._log(TRACE_LEVEL, msg, args, **kwargs)
+
+
 def setup() -> None:
     """Set up loggers."""
     logging.TRACE = TRACE_LEVEL
     logging.addLevelName(TRACE_LEVEL, "TRACE")
-    Logger.trace = _monkeypatch_trace
+    logging.setLoggerClass(CustomLogger)
 
     format_string = "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
     log_format = logging.Formatter(format_string)
@@ -71,19 +87,6 @@ def setup_sentry() -> None:
         ],
         release=f"bot@{constants.GIT_SHA}"
     )
-
-
-def _monkeypatch_trace(self: logging.Logger, msg: str, *args, **kwargs) -> None:
-    """
-    Log 'msg % args' with severity 'TRACE'.
-
-    To pass exception information, use the keyword argument exc_info with
-    a true value, e.g.
-
-    logger.trace("Houston, we have an %s", "interesting problem", exc_info=1)
-    """
-    if self.isEnabledFor(TRACE_LEVEL):
-        self._log(TRACE_LEVEL, msg, args, **kwargs)
 
 
 def _set_trace_loggers() -> None:

--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import typing as t
 from contextlib import suppress
 from functools import partial
@@ -10,6 +9,7 @@ from discord.ext.commands import Context, Paginator
 
 from bot import constants
 from bot.utils import messages
+from bot.utils.logging import get_logger
 
 FIRST_EMOJI = "\u23EE"   # [:track_previous:]
 LEFT_EMOJI = "\u2B05"    # [:arrow_left:]
@@ -19,7 +19,7 @@ DELETE_EMOJI = constants.Emojis.trashcan  # [:trashcan:]
 
 PAGINATION_EMOJI = (FIRST_EMOJI, LEFT_EMOJI, RIGHT_EMOJI, LAST_EMOJI, DELETE_EMOJI)
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class EmptyPaginatorEmbedError(Exception):

--- a/bot/utils/channel.py
+++ b/bot/utils/channel.py
@@ -1,12 +1,11 @@
-import logging
-
 import discord
 
 import bot
 from bot import constants
 from bot.constants import Categories
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def is_help_channel(channel: discord.TextChannel) -> bool:

--- a/bot/utils/checks.py
+++ b/bot/utils/checks.py
@@ -1,5 +1,4 @@
 import datetime
-import logging
 from typing import Callable, Container, Iterable, Optional, Union
 
 from discord.ext.commands import (
@@ -16,8 +15,9 @@ from discord.ext.commands import (
 )
 
 from bot import constants
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class ContextCheckFailure(CheckFailure):

--- a/bot/utils/function.py
+++ b/bot/utils/function.py
@@ -2,11 +2,12 @@
 
 import functools
 import inspect
-import logging
 import types
 import typing as t
 
-log = logging.getLogger(__name__)
+from bot.utils.logging import get_logger
+
+log = get_logger(__name__)
 
 Argument = t.Union[int, str]
 BoundArgs = t.OrderedDict[str, t.Any]

--- a/bot/utils/lock.py
+++ b/bot/utils/lock.py
@@ -1,6 +1,5 @@
 import asyncio
 import inspect
-import logging
 import types
 from collections import defaultdict
 from functools import partial
@@ -10,8 +9,9 @@ from weakref import WeakValueDictionary
 from bot.errors import LockedResourceError
 from bot.utils import function
 from bot.utils.function import command_wraps
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 __lock_dicts = defaultdict(WeakValueDictionary)
 
 _IdCallableReturn = Union[Hashable, Awaitable[Hashable]]

--- a/bot/utils/logging.py
+++ b/bot/utils/logging.py
@@ -1,0 +1,9 @@
+import logging
+from typing import Optional, cast
+
+from bot.log import CustomLogger
+
+
+def get_logger(name: Optional[str] = None) -> CustomLogger:
+    """Utility to make mypy recognise that logger is of type `CustomLogger`."""
+    return cast(CustomLogger, logging.getLogger(name))

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import random
 import re
 from functools import partial
@@ -12,8 +11,9 @@ from discord.ext.commands import Context
 import bot
 from bot.constants import Emojis, MODERATION_ROLES, NEGATIVE_REPLIES
 from bot.utils import scheduling
+from bot.utils.logging import get_logger
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 def reaction_check(

--- a/bot/utils/scheduling.py
+++ b/bot/utils/scheduling.py
@@ -1,10 +1,11 @@
 import asyncio
 import contextlib
 import inspect
-import logging
 import typing as t
 from datetime import datetime
 from functools import partial
+
+from bot.utils.logging import get_logger
 
 
 class Scheduler:
@@ -27,7 +28,7 @@ class Scheduler:
     def __init__(self, name: str):
         self.name = name
 
-        self._log = logging.getLogger(f"{__name__}.{name}")
+        self._log = get_logger(f"{__name__}.{name}")
         self._scheduled_tasks: t.Dict[t.Hashable, asyncio.Task] = {}
 
     def __contains__(self, task_id: t.Hashable) -> bool:
@@ -187,5 +188,5 @@ def _log_task_exception(task: asyncio.Task, *, suppressed_exceptions: t.Tuple[t.
         exception = task.exception()
         # Log the exception if one exists.
         if exception and not isinstance(exception, suppressed_exceptions):
-            log = logging.getLogger(__name__)
+            log = get_logger(__name__)
             log.error(f"Error in task {task.get_name()} {id(task)}!", exc_info=exception)

--- a/bot/utils/services.py
+++ b/bot/utils/services.py
@@ -6,7 +6,7 @@ from aiohttp import ClientConnectorError
 import bot
 from bot.constants import URLs
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(__name__)  # use logging.getLogger (not bot.utils.logging.get_logger) to prevent circular import
 
 FAILED_REQUEST_ATTEMPTS = 3
 

--- a/bot/utils/webhooks.py
+++ b/bot/utils/webhooks.py
@@ -1,12 +1,12 @@
-import logging
 from typing import Optional
 
 import discord
 from discord import Embed
 
+from bot.utils.logging import get_logger
 from bot.utils.messages import sub_clyde
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 async def send_webhook(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from bot.utils.logging import get_logger
 
-log = logging.getLogger()
+
+log = get_logger()
 log.setLevel(logging.CRITICAL)

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,6 +6,7 @@ from typing import Dict
 import discord
 from discord.ext import commands
 
+from bot.utils.logging import get_logger
 from tests import helpers
 
 
@@ -42,7 +43,7 @@ class LoggingTestsMixin:
         manager when we're testing under the assumption that no log records will be emitted.
         """
         if not isinstance(logger, logging.Logger):
-            logger = logging.getLogger(logger)
+            logger = get_logger(logger)
 
         if level:
             level = logging._nameToLevel.get(level, level)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,7 +2,7 @@ import logging
 import unittest
 import unittest.mock
 
-
+from bot.utils.logging import get_logger
 from tests.base import LoggingTestsMixin, _CaptureLogHandler
 
 
@@ -15,7 +15,7 @@ class LoggingTestCaseTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.log = logging.getLogger(__name__)
+        cls.log = get_logger(__name__)
 
     def test_assert_not_logs_does_not_raise_with_no_logs(self):
         """Test if LoggingTestCase.assertNotLogs does not raise when no logs were emitted."""


### PR DESCRIPTION
Closes bot#1830.

Implements the proposed `CustomLogger` class to fix the lint warnings.