### PR TITLE
`!contribute` tag

### DIFF
--- a/bot/resources/tags/contribute.md
+++ b/bot/resources/tags/contribute.md
@@ -1,0 +1,12 @@
+**Contribute to Python Discord Open Source Projects**
+Looking to contribute to Open Source Projects for the first time? Want to contribute to the bots on this server? We have on-going projects that people can contribute to, even if you've never contributed to open source before.
+
+**Projects to Contribute to**
+• [Sir Lancebot](https://github.com/python-discord/sir-lancebot)
+• [Python](https://github.com/python-discord/bot)
+• [Site](https://github.com/python-discord/site)
+
+**Where to start**
+1. Read our [contributing guidelines](https://pythondiscord.com/pages/guides/pydis-guides/contributing/)
+2. Chat with us in <#635950537262759947> for what to work on
+3. Open an issue or ask to be assigned to an issue to work on


### PR DESCRIPTION
Closes python-discord/meta#109

This adds a contributing tag, providing a quick explanation of how to contribute to some of Python Discord's projects.
The tag currently looks like this:
![image](https://user-images.githubusercontent.com/20641196/133912488-305accb9-d059-4c36-b30c-9e3348a25016.png)

I'm still not certain if this is something we want or what the exact wording should be. But I figured a quick explanation and links to where to get started is a good base.