### PR TITLE
Fix typos and grammar in tags

### DIFF
--- a/bot/resources/tags/async-await.md
+++ b/bot/resources/tags/async-await.md
@@ -2,18 +2,18 @@
 
 Python provides the ability to run multiple tasks and coroutines simultaneously with the use of the `asyncio` library, which is included in the Python standard library.
 
-This works by running these coroutines in an event loop, where the context of which coroutine is being run is switches periodically to allow all of them to run, giving the appearance of running at the same time. This is different to using threads or processes in that all code is run in the main process and thread, although it is possible to run coroutines in threads.
+This works by running these coroutines in an event loop, where the context of the running coroutine switches periodically to allow all the coroutines to run, thus giving the appearance of running at the same time. This is different to using threads or processes in that all code runs in the main process and thread, although it is possible to run coroutines in threads.
 
 To call an async function we can either `await` it, or run it in an event loop which we get from `asyncio`.
 
-To create a coroutine that can be used with asyncio we need to define a function using the async keyword:
+To create a coroutine that can be used with asyncio we need to define a function using the `async` keyword:
 ```py
 async def main():
     await something_awaitable()
 ```
-Which means we can call `await something_awaitable()` directly from within the function. If this were a non-async function this would have raised an exception like: `SyntaxError: 'await' outside async function`
+Which means we can call `await something_awaitable()` directly from within the function. If this were a non-async function, this would have raised the exception `SyntaxError: 'await' outside async function`
 
-To run the top level async function from outside of the event loop we can get an event loop from `asyncio`, and then use that loop to run the function:
+To run the top level async function from outside the event loop, we can get the event loop from `asyncio` and then use it to run the function:
 ```py
 from asyncio import get_event_loop
 

--- a/bot/resources/tags/traceback.md
+++ b/bot/resources/tags/traceback.md
@@ -1,4 +1,4 @@
-Please provide a full traceback to your exception in order for us to identify your issue.
+Please provide the full traceback for your exception in order to help us identify your issue.
 
 A full traceback could look like:
 ```py
@@ -6,13 +6,13 @@ Traceback (most recent call last):
     File "tiny", line 3, in
         do_something()
     File "tiny", line 2, in do_something
-        a = 6 / 0
+        a = 6 / b
 ZeroDivisionError: integer division or modulo by zero
 ```
 The best way to read your traceback is bottom to top.
 
-• Identify the exception raised (e.g. ZeroDivisionError)  
-• Make note of the line number, and navigate there in your program.  
-• Try to understand why the error occurred.  
+• Identify the exception raised (e.g. `ZeroDivisionError`)  
+• Make note of the line number (in this case 2), and navigate there in your program.  
+• Try to understand why the error occurred (in this case because `b` must be `0`).
 
-To read more about exceptions and errors, please refer to the [PyDis Wiki](https://pythondiscord.com/pages/asking-good-questions/#examining-tracebacks) or the [official Python tutorial.](https://docs.python.org/3.7/tutorial/errors.html)
+To read more about exceptions and errors, please refer to the [PyDis Wiki](https://pythondiscord.com/pages/guides/pydis-guides/asking-good-questions/#examining-tracebacks) or the [official Python tutorial](https://docs.python.org/3.7/tutorial/errors.html).

--- a/bot/resources/tags/windows-path.md
+++ b/bot/resources/tags/windows-path.md
@@ -1,10 +1,10 @@
 **PATH on Windows**
 
-If you have installed Python but you forgot to check the *Add Python to PATH* option during the installation you may still be able to access your installation with ease.
+If you have installed Python, but you forgot to check the *Add Python to PATH* option during the installation, you may still be able to access your installation with ease.
 
-If you did not uncheck the option to install the Python launcher then you will find a `py` command on your system. If you want to be able to open your Python installation by running `python` then your best option is to re-install Python.
+If you did not uncheck the option to install the Python launcher then you will find a `py` command on your system. If you want to be able to open your Python installation by running `python`, then your best option is to re-install Python.
 
-Otherwise, you can access your install using the `py` command in Command Prompt. Where you may type something with the `python` command like:
+Otherwise, you can access your installation using the `py` command in Command Prompt, where you may type something with the `python` command such as:
 ```
 C:\Users\Username> python3 my_application_file.py
 ```
@@ -24,7 +24,7 @@ You can also access different versions of Python using the version flag, like so
 C:\Users\Username> py -3.7
 ... Python 3.7 starts ...
 C:\Users\Username> py -3.6
-... Python 3.6 stars ...
+... Python 3.6 starts ...
 C:\Users\Username> py -2
 ... Python 2 (any version installed) starts ...
 ```

--- a/bot/resources/tags/xy-problem.md
+++ b/bot/resources/tags/xy-problem.md
@@ -1,7 +1,7 @@
 **xy-problem**
 
-Asking about your attempted solution rather than your actual problem.
+The XY problem can be summarised as asking about your attempted solution, rather than your actual problem.
 
 Often programmers will get distracted with a potential solution they've come up with, and will try asking for help getting it to work. However, it's possible this solution either wouldn't work as they expect, or there's a much better solution instead.
 
-For more information and examples: http://xyproblem.info/
+For more information and examples, see http://xyproblem.info/

--- a/bot/resources/tags/ytdl.md
+++ b/bot/resources/tags/ytdl.md
@@ -1,4 +1,4 @@
-Per [Python Discord's Rule 5](https://pythondiscord.com/pages/rules), we are unable to assist with questions related to youtube-dl, pytube, or other YouTube video downloaders as their usage violates YouTube's Terms of Service.
+Per [Python Discord's Rule 5](https://pythondiscord.com/pages/rules), we are unable to assist with questions related to youtube-dl, pytube, or other YouTube video downloaders, as their usage violates YouTube's Terms of Service.
 
 For reference, this usage is covered by the following clauses in [YouTube's TOS](https://www.youtube.com/static?gl=GB&template=terms), as of 2021-03-17:
 ```

--- a/bot/resources/tags/zip.md
+++ b/bot/resources/tags/zip.md
@@ -3,7 +3,7 @@ The zip function allows you to iterate through multiple iterables simultaneously
 ```py
 letters = 'abc'
 numbers = [1, 2, 3]
-# zip(letters, numbers) --> [('a', 1), ('b', 2), ('c', 3)]
+# list(zip(letters, numbers)) --> [('a', 1), ('b', 2), ('c', 3)]
 for letter, number in zip(letters, numbers):
     print(letter, number)
 ```


### PR DESCRIPTION
Closes #1832.

Fixes typos and grammar in tags, as well as changing a few examples etc. where I felt appropriate (e.g. in `!precedence` I changed to examples where the order is more obviously important).