### PR TITLE
Remove coveralls from lint-test

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -121,13 +121,6 @@ jobs:
       - name: Run tests and generate coverage report
         run: pytest -n auto --cov --disable-warnings -q
 
-      # This step will publish the coverage reports coveralls.io and
-      # print a "job" link in the output of the GitHub Action
-      - name: Publish coverage report to coveralls.io
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: coveralls
-
       # Prepare the Pull Request Payload artifact. If this fails, we
       # we fail silently using the `continue-on-error` option. It's
       # nice if this succeeds, but if it fails for any reason, it


### PR DESCRIPTION
Exactly as title says.

Removes coveralls from the lint-test stage due to the recent issues with their API.