### PR TITLE
Update paste-site URL in `!paste`

### DIFF
--- a/bot/resources/tags/paste.md
+++ b/bot/resources/tags/paste.md
@@ -1,6 +1,6 @@
 **Pasting large amounts of code**
 
 If your code is too long to fit in a codeblock in discord, you can paste your code here:
-https://paste.pydis.com/
+https://paste.pythondiscord.com/
 
 After pasting your code, **save** it by clicking the floppy disk icon in the top right, or by typing `ctrl + S`. After doing that, the URL should **change**. Copy the URL and post it here so others can see it.


### PR DESCRIPTION
Closes #1842 

`!paste` now uses `https://paste.pythondiscord.com` instead of `https://paste.pydis.com`.