### PR TITLE
Handle channel category being None in antispam/malware checks

### DIFF
--- a/bot/exts/filters/antimalware.py
+++ b/bot/exts/filters/antimalware.py
@@ -63,7 +63,7 @@ class AntiMalware(Cog):
             return
 
         # Ignore code jam channels
-        if hasattr(message.channel, "category") and message.channel.category.name == JAM_CATEGORY_NAME:
+        if getattr(message.channel, "category", None) and message.channel.category.name == JAM_CATEGORY_NAME:
             return
 
         # Check if user is staff, if is, return

--- a/bot/exts/filters/antispam.py
+++ b/bot/exts/filters/antispam.py
@@ -166,7 +166,7 @@ class AntiSpam(Cog):
             not message.guild
             or message.guild.id != GuildConfig.id
             or message.author.bot
-            or (hasattr(message.channel, "category") and message.channel.category.name == JAM_CATEGORY_NAME)
+            or (getattr(message.channel, "category", None) and message.channel.category.name == JAM_CATEGORY_NAME)
             or (message.channel.id in Filter.channel_whitelist and not DEBUG_MODE)
             or (any(role.id in Filter.role_whitelist for role in message.author.roles) and not DEBUG_MODE)
         ):


### PR DESCRIPTION
The code already handled the attribute not existing (e.g from a DM channel), but didn't handle TextChannels not in a category.

This doesn't currently affect the server as all our channels are in categories