### PR TITLE
Improve anti-spam logs

### DIFF
--- a/bot/exts/filters/antispam.py
+++ b/bot/exts/filters/antispam.py
@@ -85,7 +85,7 @@ class DeletionContext:
         # For multiple messages or those with excessive newlines, use the logs API
         if any((
             len(self.messages) > 1,
-            self.messages[0].attachments,
+            len(self.messages[0].attachments) > 0,
             self.messages[0].count('\n') > 15
         )):
             url = await modlog.upload_log(self.messages.values(), actor_id, self.attachments)

--- a/bot/exts/filters/antispam.py
+++ b/bot/exts/filters/antispam.py
@@ -46,6 +46,7 @@ RULE_FUNCTION_MAPPING = {
 @dataclass
 class DeletionContext:
     """Represents a Deletion Context for a single spam event."""
+
     members: frozenset[Member]
     triggered_in: TextChannel
     channels: set[TextChannel] = field(default_factory=set)

--- a/bot/exts/filters/antispam.py
+++ b/bot/exts/filters/antispam.py
@@ -46,7 +46,6 @@ RULE_FUNCTION_MAPPING = {
 @dataclass
 class DeletionContext:
     """Represents a Deletion Context for a single spam event."""
-
     members: frozenset[Member]
     triggered_in: TextChannel
     channels: set[TextChannel] = field(default_factory=set)
@@ -82,34 +81,34 @@ class DeletionContext:
             f"**Rules:** {', '.join(rule for rule in self.rules)}\n"
         )
 
-        # For multiple messages or those with excessive newlines, use the logs API
+        messages_as_list = list(self.messages.values())
+        first_message = messages_as_list[0]
+        # For multiple messages and those with attachments or excessive newlines, use the logs API
         if any((
-            len(self.messages) > 1,
-            len(self.messages[0].attachments) > 0,
-            self.messages[0].count('\n') > 15
+            len(messages_as_list) > 1,
+            len(first_message.attachments) > 0,
+            first_message.content.count('\n') > 15
         )):
             url = await modlog.upload_log(self.messages.values(), actor_id, self.attachments)
             mod_alert_message += f"A complete log of the offending messages can be found [here]({url})"
         else:
             mod_alert_message += "Message:\n"
-            [message] = self.messages.values()
-            content = message.clean_content
+            content = first_message.clean_content
             remaining_chars = 4080 - len(mod_alert_message)
 
             if len(content) > remaining_chars:
-                url = await modlog.upload_log([message], actor_id, self.attachments)
+                url = await modlog.upload_log([first_message], actor_id, self.attachments)
                 log_site_msg = f"The full message can be found [here]({url})"
                 content = content[:remaining_chars - (3 + len(log_site_msg))] + "..."
 
             mod_alert_message += content
 
-        *_, last_message = self.messages.values()
         await modlog.send_log_message(
             icon_url=Icons.filtering,
             colour=Colour(Colours.soft_red),
             title="Spam detected!",
             text=mod_alert_message,
-            thumbnail=last_message.author.avatar_url_as(static_format="png"),
+            thumbnail=first_message.author.avatar_url_as(static_format="png"),
             channel_id=Channels.mod_alerts,
             ping_everyone=AntiSpamConfig.ping_everyone
         )


### PR DESCRIPTION
Closes #1850.

Messages triggering antispam which have attachments will now *always* be uploaded to the log site, and messages that are truncated will now be uploaded to the paste site as well as showing the truncated version of the message.