### PR TITLE
Handle 400 when setting pre-existing doc package

### DIFF
--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -401,7 +401,7 @@ class DocCog(commands.Cog):
         except ResponseCodeError as err:
             if err.status == 400 and "already exists" in err.response_json.get("package", [""])[0]:
                 log.info(f"Ignoring HTTP 400 as package {package_name} has already been added.")
-                await ctx.send(f"Package {package_name} has already already added.")
+                await ctx.send(f"Package {package_name} has already been added.")
                 return
             raise
 


### PR DESCRIPTION
If you run, for example:

    !doc setdoc black https://black.readthedocs/en/stable/objects.inv

twice over. You'll get an unhelpful "According to the API, your request
is malformed." error message back. This commit adds an error handler
to catch the HTTP 400 and tell the user the package already exists.

---

Fixes #1858 

FYI this is my first proper contribution to the project so have fun requesting changes :wink: 