### PR TITLE
Subscribe with buttons

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -484,7 +484,12 @@ class Roles(metaclass=YAMLGetter):
     section = "guild"
     subsection = "roles"
 
+    # Self-assignable roles, see the Subscribe cog
+    advent_of_code: int
     announcements: int
+    lovefest: int
+    pyweek_announcements: int
+
     contributors: int
     help_cooldown: int
     muted: int

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -66,6 +66,9 @@ class HelpChannels(commands.Cog):
         self.bot = bot
         self.scheduler = scheduling.Scheduler(self.__class__.__name__)
 
+        self.guild: discord.Guild = None
+        self.cooldown_role: discord.Role = None
+
         # Categories
         self.available_category: discord.CategoryChannel = None
         self.in_use_category: discord.CategoryChannel = None
@@ -95,24 +98,6 @@ class HelpChannels(commands.Cog):
 
         self.scheduler.cancel_all()
 
-    async def _handle_role_change(self, member: discord.Member, coro: t.Callable[..., t.Coroutine]) -> None:
-        """
-        Change `member`'s cooldown role via awaiting `coro` and handle errors.
-
-        `coro` is intended to be `discord.Member.add_roles` or `discord.Member.remove_roles`.
-        """
-        try:
-            await coro(self.bot.get_guild(constants.Guild.id).get_role(constants.Roles.help_cooldown))
-        except discord.NotFound:
-            log.debug(f"Failed to change role for {member} ({member.id}): member not found")
-        except discord.Forbidden:
-            log.debug(
-                f"Forbidden to change role for {member} ({member.id}); "
-                f"possibly due to role hierarchy"
-            )
-        except discord.HTTPException as e:
-            log.error(f"Failed to change role for {member} ({member.id}): {e.status} {e.code}")
-
     @lock.lock_arg(NAMESPACE, "message", attrgetter("channel.id"))
     @lock.lock_arg(NAMESPACE, "message", attrgetter("author.id"))
     @lock.lock_arg(f"{NAMESPACE}.unclaim", "message", attrgetter("author.id"), wait=True)
@@ -130,7 +115,7 @@ class HelpChannels(commands.Cog):
         if not isinstance(message.author, discord.Member):
             log.debug(f"{message.author} ({message.author.id}) isn't a member. Not giving cooldown role or sending DM.")
         else:
-            await self._handle_role_change(message.author, message.author.add_roles)
+            await members.handle_role_change(message.author, message.author.add_roles, self.cooldown_role)
 
             try:
                 await _message.dm_on_open(message)
@@ -302,6 +287,9 @@ class HelpChannels(commands.Cog):
         await self.bot.wait_until_guild_available()
 
         log.trace("Initialising the cog.")
+        self.guild = self.bot.get_guild(constants.Guild.id)
+        self.cooldown_role = self.guild.get_role(constants.Roles.help_cooldown)
+
         await self.init_categories()
 
         self.channel_queue = self.create_channel_queue()
@@ -445,11 +433,11 @@ class HelpChannels(commands.Cog):
         await _caches.claimants.delete(channel.id)
         await _caches.session_participants.delete(channel.id)
 
-        claimant = await members.get_or_fetch_member(self.bot.get_guild(constants.Guild.id), claimant_id)
+        claimant = await members.get_or_fetch_member(self.guild, claimant_id)
         if claimant is None:
             log.info(f"{claimant_id} left the guild during their help session; the cooldown role won't be removed")
         else:
-            await self._handle_role_change(claimant, claimant.remove_roles)
+            await members.handle_role_change(claimant, claimant.remove_roles, self.cooldown_role)
 
         await _message.unpin(channel)
         await _stats.report_complete_session(channel.id, closed_on)

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -1,5 +1,3 @@
-import logging
-
 import arrow
 import discord
 from discord.ext import commands
@@ -8,6 +6,7 @@ from discord.interactions import Interaction
 from bot import constants
 from bot.bot import Bot
 from bot.decorators import in_whitelist
+from bot.log import get_logger
 from bot.utils import checks, members, scheduling
 
 # Tuple of tuples, where each inner tuple is a role id and a month number.
@@ -21,7 +20,7 @@ ASSIGNABLE_ROLES = (
 )
 ITEMS_PER_ROW = 3
 
-log = logging.getLogger(__name__)
+log = get_logger(__name__)
 
 
 class RoleButtonView(discord.ui.View):

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -115,6 +115,7 @@ class Subscribe(commands.Cog):
                 continue
             self.assignable_roles.append(role)
 
+    @commands.cooldown(1, 10, commands.BucketType.member)
     @commands.command(name="subscribe")
     @in_whitelist(channels=(constants.Channels.bot_commands,))
     async def subscribe_command(self, ctx: commands.Context, *_) -> None:  # We don't actually care about the args

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -80,8 +80,8 @@ class SingleRoleButton(discord.ui.Button):
     """A button that adds or removes a role from the member depending on it's current state."""
 
     ADD_STYLE = discord.ButtonStyle.success
-    REMOVE_STYLE = discord.ButtonStyle.secondary
-    UNAVAILABLE_STYLE = discord.ButtonStyle.red
+    REMOVE_STYLE = discord.ButtonStyle.red
+    UNAVAILABLE_STYLE = discord.ButtonStyle.secondary
     LABEL_FORMAT = "{action} role {role_name}."
     CUSTOM_ID_FORMAT = "subscribe-{role_id}"
 

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -181,7 +181,7 @@ class Subscribe(commands.Cog):
             row = index // ITEMS_PER_ROW
             button_view.add_item(SingleRoleButton(role, role.role_id in author_roles, row))
 
-        await ctx.send(
+        await ctx.reply(
             "Click the buttons below to add or remove your roles!",
             view=button_view,
             delete_after=DELETE_MESSAGE_AFTER,

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -1,0 +1,139 @@
+import logging
+
+import arrow
+import discord
+from discord.ext import commands
+from discord.interactions import Interaction
+
+from bot import constants
+from bot.bot import Bot
+from bot.decorators import in_whitelist
+from bot.utils import checks, members, scheduling
+
+# Tuple of tuples, where each inner tuple is a role id and a month number.
+# The month number signifies what month the role should be assignable,
+# use None for the month number if it should always be active.
+ASSIGNABLE_ROLES = (
+    (constants.Roles.announcements, None),
+    (constants.Roles.pyweek_announcements, None),
+    (constants.Roles.lovefest, 2),
+    (constants.Roles.advent_of_code, 12),
+)
+ITEMS_PER_ROW = 3
+
+log = logging.getLogger(__name__)
+
+
+class RoleButtonView(discord.ui.View):
+    """A list of SingleRoleButtons to show to the member."""
+
+    def __init__(self, member: discord.Member):
+        super().__init__()
+        self.interaction_owner = member
+
+    async def interaction_check(self, interaction: Interaction) -> bool:
+        """Ensure that the user clicking the button is the member who invoked the command."""
+        if interaction.user != self.interaction_owner:
+            await interaction.response.send_message(
+                ":x: This is not your command to react to!",
+                ephemeral=True
+            )
+            return False
+        return True
+
+
+class SingleRoleButton(discord.ui.Button):
+    """A button that adds or removes a role from the member depending on it's current state."""
+
+    ADD_STYLE = discord.ButtonStyle.success
+    REMOVE_STYLE = discord.ButtonStyle.secondary
+    LABEL_FORMAT = "{action} role {role_name}"
+    CUSTOM_ID_FORMAT = "subscribe-{role_id}"
+
+    def __init__(self, role: discord.Role, assigned: bool, row: int):
+        super().__init__(
+            style=self.REMOVE_STYLE if assigned else self.ADD_STYLE,
+            label=self.LABEL_FORMAT.format(action="Remove" if assigned else "Add", role_name=role.name),
+            custom_id=self.CUSTOM_ID_FORMAT.format(role_id=role.id),
+            row=row,
+        )
+        self.role = role
+        self.assigned = assigned
+
+    async def callback(self, interaction: Interaction) -> None:
+        """Update the member's role and change button text to reflect current text."""
+        await members.handle_role_change(
+            interaction.user,
+            interaction.user.remove_roles if self.assigned else interaction.user.add_roles,
+            self.role,
+        )
+
+        self.assigned = not self.assigned
+        await self.update_view(interaction)
+        await interaction.response.send_message(
+            self.LABEL_FORMAT.format(action="Added" if self.assigned else "Removed", role_name=self.role.name),
+            ephemeral=True,
+        )
+
+    async def update_view(self, interaction: Interaction) -> None:
+        """Updates the original interaction message with a new view object with the updated buttons."""
+        self.style = self.REMOVE_STYLE if self.assigned else self.ADD_STYLE
+        self.label = self.LABEL_FORMAT.format(action="Remove" if self.assigned else "Add", role_name=self.role.name)
+        try:
+            await interaction.message.edit(view=self.view)
+        except discord.NotFound:
+            log.debug("Subscribe message for %s removed before buttons could be updated", interaction.user)
+            self.view.stop()
+
+
+class Subscribe(commands.Cog):
+    """Cog to allow user to self-assign & remove the roles present in ASSIGNABLE_ROLES."""
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+        self.init_task = scheduling.create_task(self.init_cog(), event_loop=self.bot.loop)
+        self.assignable_roles: list[discord.Role] = []
+        self.guild: discord.Guild = None
+
+    async def init_cog(self) -> None:
+        """Initialise the cog by resolving the role IDs in ASSIGNABLE_ROLES to role names."""
+        await self.bot.wait_until_guild_available()
+
+        current_month = arrow.utcnow().month
+        self.guild = self.bot.get_guild(constants.Guild.id)
+
+        for role_id, month_available in ASSIGNABLE_ROLES:
+            if month_available is not None and month_available != current_month:
+                continue
+            role = self.guild.get_role(role_id)
+            if role is None:
+                log.warning("Could not resolve %d to a role in the guild, skipping.", role_id)
+                continue
+            self.assignable_roles.append(role)
+
+    @commands.command(name="subscribe")
+    @in_whitelist(channels=(constants.Channels.bot_commands,))
+    async def subscribe_command(self, ctx: commands.Context, *_) -> None:  # We don't actually care about the args
+        """Display the member's current state for each role, and allow them to add/remove the roles."""
+        await self.init_task
+
+        button_view = RoleButtonView(ctx.author)
+        for index, role in enumerate(self.assignable_roles):
+            row = index // ITEMS_PER_ROW
+            button_view.add_item(SingleRoleButton(role, role in ctx.author.roles, row))
+
+        await ctx.send("Click the buttons below to add or remove your roles!", view=button_view)
+
+    # This cannot be static (must have a __func__ attribute).
+    async def cog_command_error(self, ctx: commands.Context, error: Exception) -> None:
+        """Check for & ignore any InWhitelistCheckFailure."""
+        if isinstance(error, checks.InWhitelistCheckFailure):
+            error.handled = True
+
+
+def setup(bot: Bot) -> None:
+    """Load the Subscribe cog."""
+    if len(ASSIGNABLE_ROLES) > ITEMS_PER_ROW*5:  # Discord limits views to 5 rows of buttons.
+        log.error("Too many roles for 5 rows, not loading the Subscribe cog.")
+    else:
+        bot.add_cog(Subscribe(bot))

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -1,4 +1,5 @@
 import calendar
+import operator
 import typing as t
 from dataclasses import dataclass
 
@@ -164,6 +165,8 @@ class Subscribe(commands.Cog):
                     name=discord_role.name,
                 )
             )
+        # Sort unavailable roles to the end of the list
+        self.assignable_roles.sort(key=operator.methodcaller("is_currently_available"), reverse=True)
 
     @commands.cooldown(1, 10, commands.BucketType.member)
     @commands.command(name="subscribe")

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -91,7 +91,7 @@ class SingleRoleButton(discord.ui.Button):
             label = self.LABEL_FORMAT.format(action="Remove" if assigned else "Add", role_name=role.name)
         else:
             style = self.UNAVAILABLE_STYLE
-            label = role.name
+            label = f"🔒 {role.name}"
 
         super().__init__(
             style=style,

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -19,6 +19,7 @@ ASSIGNABLE_ROLES = (
     (constants.Roles.advent_of_code, 12),
 )
 ITEMS_PER_ROW = 3
+DELETE_MESSAGE_AFTER = 300  # Seconds
 
 log = get_logger(__name__)
 
@@ -128,7 +129,11 @@ class Subscribe(commands.Cog):
             row = index // ITEMS_PER_ROW
             button_view.add_item(SingleRoleButton(role, role in ctx.author.roles, row))
 
-        await ctx.send("Click the buttons below to add or remove your roles!", view=button_view)
+        await ctx.send(
+            "Click the buttons below to add or remove your roles!",
+            view=button_view,
+            delete_after=DELETE_MESSAGE_AFTER,
+        )
 
     # This cannot be static (must have a __func__ attribute).
     async def cog_command_error(self, ctx: commands.Context, error: Exception) -> None:

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -65,7 +65,9 @@ class SingleRoleButton(discord.ui.Button):
         if isinstance(interaction.user, discord.User):
             log.trace("User %s is not a member", interaction.user)
             await interaction.message.delete()
+            self.view.stop()
             return
+
         await members.handle_role_change(
             interaction.user,
             interaction.user.remove_roles if self.assigned else interaction.user.add_roles,

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -62,6 +62,10 @@ class SingleRoleButton(discord.ui.Button):
 
     async def callback(self, interaction: Interaction) -> None:
         """Update the member's role and change button text to reflect current text."""
+        if isinstance(interaction.user, discord.User):
+            log.trace("User %s is not a member", interaction.user)
+            await interaction.message.delete()
+            return
         await members.handle_role_change(
             interaction.user,
             interaction.user.remove_roles if self.assigned else interaction.user.add_roles,

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -1,3 +1,7 @@
+import calendar
+import typing as t
+from dataclasses import dataclass
+
 import arrow
 import discord
 from discord.ext import commands
@@ -9,15 +13,44 @@ from bot.decorators import in_whitelist
 from bot.log import get_logger
 from bot.utils import checks, members, scheduling
 
-# Tuple of tuples, where each inner tuple is a role id and a month number.
-# The month number signifies what month the role should be assignable,
-# use None for the month number if it should always be active.
+
+@dataclass(frozen=True)
+class AssignableRole:
+    """
+    A role that can be assigned to a user.
+
+    months_available is a tuple that signifies what months the role should be
+    self-assignable, using None for when it should always be available.
+    """
+
+    role_id: int
+    months_available: t.Optional[tuple[int]]
+    name: t.Optional[str] = None  # This gets populated within Subscribe.init_cog()
+
+    def is_currently_available(self) -> bool:
+        """Check if the role is available for the current month."""
+        if self.months_available is None:
+            return True
+        return arrow.utcnow().month in self.months_available
+
+    def get_readable_available_months(self) -> str:
+        """Get a readable string of the months the role is available."""
+        if self.months_available is None:
+            return f"{self.name} is always available."
+
+        # Join the months together with comma separators, but use "and" for the final seperator.
+        month_names = [calendar.month_name[month] for month in self.months_available]
+        available_months_str = ", ".join(month_names[:-1]) + f" and {month_names[-1]}"
+        return f"{self.name} can only be assigned during {available_months_str}."
+
+
 ASSIGNABLE_ROLES = (
-    (constants.Roles.announcements, None),
-    (constants.Roles.pyweek_announcements, None),
-    (constants.Roles.lovefest, 2),
-    (constants.Roles.advent_of_code, 12),
+    AssignableRole(constants.Roles.announcements, None),
+    AssignableRole(constants.Roles.pyweek_announcements, None),
+    AssignableRole(constants.Roles.lovefest, (1, 2)),
+    AssignableRole(constants.Roles.advent_of_code, (11, 12)),
 )
+
 ITEMS_PER_ROW = 3
 DELETE_MESSAGE_AFTER = 300  # Seconds
 
@@ -47,14 +80,22 @@ class SingleRoleButton(discord.ui.Button):
 
     ADD_STYLE = discord.ButtonStyle.success
     REMOVE_STYLE = discord.ButtonStyle.secondary
-    LABEL_FORMAT = "{action} role {role_name}"
+    UNAVAILABLE_STYLE = discord.ButtonStyle.red
+    LABEL_FORMAT = "{action} role {role_name}."
     CUSTOM_ID_FORMAT = "subscribe-{role_id}"
 
-    def __init__(self, role: discord.Role, assigned: bool, row: int):
+    def __init__(self, role: AssignableRole, assigned: bool, row: int):
+        if role.is_currently_available():
+            style = self.REMOVE_STYLE if assigned else self.ADD_STYLE
+            label = self.LABEL_FORMAT.format(action="Remove" if assigned else "Add", role_name=role.name)
+        else:
+            style = self.UNAVAILABLE_STYLE
+            label = role.name
+
         super().__init__(
-            style=self.REMOVE_STYLE if assigned else self.ADD_STYLE,
-            label=self.LABEL_FORMAT.format(action="Remove" if assigned else "Add", role_name=role.name),
-            custom_id=self.CUSTOM_ID_FORMAT.format(role_id=role.id),
+            style=style,
+            label=label,
+            custom_id=self.CUSTOM_ID_FORMAT.format(role_id=role.role_id),
             row=row,
         )
         self.role = role
@@ -68,10 +109,14 @@ class SingleRoleButton(discord.ui.Button):
             self.view.stop()
             return
 
+        if not self.role.is_currently_available():
+            await interaction.response.send_message(self.role.get_readable_available_months(), ephemeral=True)
+            return
+
         await members.handle_role_change(
             interaction.user,
             interaction.user.remove_roles if self.assigned else interaction.user.add_roles,
-            self.role,
+            discord.Object(self.role.role_id),
         )
 
         self.assigned = not self.assigned
@@ -98,24 +143,27 @@ class Subscribe(commands.Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
         self.init_task = scheduling.create_task(self.init_cog(), event_loop=self.bot.loop)
-        self.assignable_roles: list[discord.Role] = []
+        self.assignable_roles: list[AssignableRole] = []
         self.guild: discord.Guild = None
 
     async def init_cog(self) -> None:
         """Initialise the cog by resolving the role IDs in ASSIGNABLE_ROLES to role names."""
         await self.bot.wait_until_guild_available()
 
-        current_month = arrow.utcnow().month
         self.guild = self.bot.get_guild(constants.Guild.id)
 
-        for role_id, month_available in ASSIGNABLE_ROLES:
-            if month_available is not None and month_available != current_month:
+        for role in ASSIGNABLE_ROLES:
+            discord_role = self.guild.get_role(role.role_id)
+            if discord_role is None:
+                log.warning("Could not resolve %d to a role in the guild, skipping.", role.role_id)
                 continue
-            role = self.guild.get_role(role_id)
-            if role is None:
-                log.warning("Could not resolve %d to a role in the guild, skipping.", role_id)
-                continue
-            self.assignable_roles.append(role)
+            self.assignable_roles.append(
+                AssignableRole(
+                    role_id=role.role_id,
+                    months_available=role.months_available,
+                    name=discord_role.name,
+                )
+            )
 
     @commands.cooldown(1, 10, commands.BucketType.member)
     @commands.command(name="subscribe")
@@ -125,9 +173,10 @@ class Subscribe(commands.Cog):
         await self.init_task
 
         button_view = RoleButtonView(ctx.author)
+        author_roles = [role.id for role in ctx.author.roles]
         for index, role in enumerate(self.assignable_roles):
             row = index // ITEMS_PER_ROW
-            button_view.add_item(SingleRoleButton(role, role in ctx.author.roles, row))
+            button_view.add_item(SingleRoleButton(role, role.role_id in author_roles, row))
 
         await ctx.send(
             "Click the buttons below to add or remove your roles!",

--- a/bot/utils/members.py
+++ b/bot/utils/members.py
@@ -23,3 +23,26 @@ async def get_or_fetch_member(guild: discord.Guild, member_id: int) -> t.Optiona
             return None
         log.trace("%s fetched from API.", member)
     return member
+
+
+async def handle_role_change(
+    member: discord.Member,
+    coro: t.Callable[..., t.Coroutine],
+    role: discord.Role
+) -> None:
+    """
+    Change `member`'s cooldown role via awaiting `coro` and handle errors.
+
+    `coro` is intended to be `discord.Member.add_roles` or `discord.Member.remove_roles`.
+    """
+    try:
+        await coro(role)
+    except discord.NotFound:
+        log.debug(f"Failed to change role for {member} ({member.id}): member not found")
+    except discord.Forbidden:
+        log.debug(
+            f"Forbidden to change role for {member} ({member.id}); "
+            f"possibly due to role hierarchy"
+        )
+    except discord.HTTPException as e:
+        log.error(f"Failed to change role for {member} ({member.id}): {e.status} {e.code}")

--- a/config-default.yml
+++ b/config-default.yml
@@ -264,7 +264,12 @@ guild:
         - *BLACK_FORMATTER
 
     roles:
+        # Self-assignable roles, see the Subscribe cog
+        advent_of_code:                         518565788744024082
         announcements:                          463658397560995840
+        lovefest:                               542431903886606399
+        pyweek_announcements:                   897568414044938310
+
         contributors:                           295488872404484098
         help_cooldown:                          699189276025421825
         muted:              &MUTED_ROLE         277914926603829249


### PR DESCRIPTION
# Description
This PR updates the subscribe command to be interactive with discord buttons.

Running this command now gives the users a set of buttons to click to add or remove pre-determined announcement roles.
Adding or removing a role updates the button state to reflect the change and what would happen if the user clicks the button again.

# Screenshot(s)
This is what the command looks like after I ran it with no roles, then added the PyWeek role to myself.
![image](https://user-images.githubusercontent.com/9753350/137036476-b59d9290-10fe-4d79-a674-d42faaa846bf.png)