### PR TITLE
Use MISSING sentinal rather than None for no files

### DIFF
--- a/bot/exts/moderation/incidents.py
+++ b/bot/exts/moderation/incidents.py
@@ -105,7 +105,7 @@ async def make_embed(incident: discord.Message, outcome: Signal, actioned_by: di
         else:
             embed.set_author(name="[Failed to relay attachment]", url=attachment.proxy_url)  # Embed links the file
     else:
-        file = None
+        file = discord.utils.MISSING
 
     return embed, file
 


### PR DESCRIPTION
Fixes #1884
Fixes BOT-1NY

Discord.py 2.0 changed how this works, webhooks now look for the MISSING sentinel, rather than None to determine whether files are being passed.
This was updated in this commit: https://github.com/Rapptz/discord.py/commit/a6f7213c89e9d592c69ea3c631b0cb2bdab19577