### PR TITLE
Fix guild icon URL getting way in server command

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -200,7 +200,7 @@ class Information(Cog):
             f"\nRoles: {num_roles}"
             f"\nMember status: {member_status}"
         )
-        embed.set_thumbnail(url=ctx.guild.icon_url)
+        embed.set_thumbnail(url=ctx.guild.icon.url)
 
         # Members
         total_members = f"{ctx.guild.member_count:,}"


### PR DESCRIPTION
Fixes BOT-1P0

Another instance of wrong asset URL getting from migration to dpy 2.0.