### PR TITLE
Migrate to on_socket_event_type event

### DIFF
--- a/bot/exts/utils/internal.py
+++ b/bot/exts/utils/internal.py
@@ -37,11 +37,10 @@ class Internal(Cog):
             self.eval.add_check(is_owner().predicate)
 
     @Cog.listener()
-    async def on_socket_response(self, msg: dict) -> None:
+    async def on_socket_event_type(self, event_type: str) -> None:
         """When a websocket event is received, increase our counters."""
-        if event_type := msg.get("t"):
-            self.socket_event_total += 1
-            self.socket_events[event_type] += 1
+        self.socket_event_total += 1
+        self.socket_events[event_type] += 1
 
     def _format(self, inp: str, out: Any) -> Tuple[str, Optional[discord.Embed]]:
         """Format the eval output into a string & attempt to format it into an Embed."""


### PR DESCRIPTION
Discord.py 2.0 (Namely this commit https://github.com/Rapptz/discord.py/commit/e2250d402e8ad035b2653eb411c8e744cc9eb3bf) removed the socket_response event, and replaced it with the socket_event_type event, which just sends the type of event triggered on the websocket.

Since this event was removed, no socket stats were being incremented, as the event never triggered.

I have looked through the rest of the bot, and we do not use the socket_response event type anywhere else.