### PR TITLE
Update username checks

### DIFF
--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -237,10 +237,14 @@ class Filtering(Cog):
         """Send a mod alert every 3 days if a username still matches a watchlist pattern."""
         # Use lock to avoid race conditions
         async with self.name_lock:
+            # Check if we recently alerted about this user first,
+            # to avoid running all the filter tokens against their name again.
+            if not await self.check_send_alert(member):
+                return
+
             # Check whether the users display name contains any words in our blacklist
             matches = self.get_name_matches(member.display_name)
-
-            if not matches or not await self.check_send_alert(member):
+            if not matches:
                 return
 
             log.info(f"Sending bad nickname alert for '{member.display_name}' ({member.id}).")

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -1,8 +1,8 @@
 import asyncio
 import re
+import unicodedata
 from datetime import timedelta
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Tuple, Union
-from unicodedata import normalize
 
 import arrow
 import dateutil.parser
@@ -208,11 +208,12 @@ class Filtering(Cog):
 
     def get_name_match(self, name: str) -> Optional[re.Match]:
         """Check bad words from passed string (name). Return the first match found."""
-        normalised_name = normalize("NFKC", name)
+        normalised_name = unicodedata.normalize("NFKC", name)
+        cleaned_normalised_name = "".join(c for c in normalised_name if not unicodedata.combining(c))
 
-        # Run filters against normalized and original version,
+        # Run filters against normalised, cleaned normalised and the original name,
         # in case we have filters for one but not the other.
-        names_to_check = (name, normalised_name)
+        names_to_check = (name, normalised_name, cleaned_normalised_name)
 
         watchlist_patterns = self._get_filterlist_items('filter_token', allowed=False)
         for pattern in watchlist_patterns:

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -209,7 +209,7 @@ class Filtering(Cog):
     def get_name_match(self, name: str) -> Optional[re.Match]:
         """Check bad words from passed string (name). Return the first match found."""
         normalised_name = unicodedata.normalize("NFKC", name)
-        cleaned_normalised_name = "".join(c for c in normalised_name if not unicodedata.combining(c))
+        cleaned_normalised_name = "".join([c for c in normalised_name if not unicodedata.combining(c)])
 
         # Run filters against normalised, cleaned normalised and the original name,
         # in case we have filters for one but not the other.


### PR DESCRIPTION
Closes #1891

Currently, we check people's usernames when they send a message on the server, to ensure it isn't inappropriate. To get more coverage, we should actually be checking member join and member update events, as people can still have their nickname be visible on server without ever sending a message. They can also update their usernames after sending a message.

I have also:
- Added a check for the normalised version of the name too, using unicodedata.normalize, to ensure unicode versions of names don't bypass our filters.
- Returned the first bad match we find, rather than collecting them all, so we don't run it against *all* of our filters if not needed. If a single bad match is found, I trust our mods to actually read the user's name
- Moved the `check_send_alert()` call to the first thing we do, as a redis call is cheaper than checking all our filter tokens