### PR TITLE
Use Arrow.fromtimestamp to get an aware datetime

### DIFF
--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -1,9 +1,9 @@
 import textwrap
 import typing as t
-from datetime import datetime
 
 import dateutil.parser
 import discord
+from arrow import Arrow
 from dateutil.relativedelta import relativedelta
 from discord.ext import commands
 from discord.ext.commands import Context
@@ -314,7 +314,7 @@ class ModManagement(commands.Cog):
         if expires_at is None:
             duration = "*Permanent*"
         else:
-            date_from = datetime.fromtimestamp(float(time.DISCORD_TIMESTAMP_REGEX.match(created).group(1)))
+            date_from = Arrow.fromtimestamp(float(time.DISCORD_TIMESTAMP_REGEX.match(created).group(1)))
             date_to = dateutil.parser.isoparse(expires_at)
             duration = humanize_delta(relativedelta(date_to, date_from))
 


### PR DESCRIPTION
Fixes #1905
Fixes BOT-1P9

datetime.fromtimestamp returned an naive datetime, so when comparing to the aware datetime from dateutil.parser.isoparse, it would raise an error.