### PR TITLE
Consider parent channels when checking mod channels

### DIFF
--- a/bot/utils/channel.py
+++ b/bot/utils/channel.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import discord
 
 import bot
@@ -16,8 +18,11 @@ def is_help_channel(channel: discord.TextChannel) -> bool:
     return any(is_in_category(channel, category) for category in categories)
 
 
-def is_mod_channel(channel: discord.TextChannel) -> bool:
-    """True if `channel` is considered a mod channel."""
+def is_mod_channel(channel: Union[discord.TextChannel, discord.Thread]) -> bool:
+    """True if channel, or channel.parent for threads, is considered a mod channel."""
+    if isinstance(channel, discord.Thread):
+        channel = channel.parent
+
     if channel.id in constants.MODERATION_CHANNELS:
         log.trace(f"Channel #{channel} is a configured mod channel")
         return True


### PR DESCRIPTION
This allows commands that check if a channel is a mod channel to also work in threads of that channel