### PR TITLE
Handle autoban filtering in DMs

### DIFF
--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -370,7 +370,8 @@ class Filtering(Cog):
                             # This sends the ban confirmation directly under watchlist trigger embed, to inform
                             # mods that the user was auto-banned for the message.
                             context = await self.bot.get_context(msg)
-                            context.author = self.bot.get_guild(Guild.id).get_member(self.bot.user.id)
+                            context.guild = self.bot.get_guild(Guild.id)
+                            context.author = context.guild.get_member(self.bot.user.id)
                             context.channel = self.bot.get_channel(Channels.mod_alerts)
                             context.command = self.bot.get_command("tempban")
 


### PR DESCRIPTION
Fixes #1912
Fixes BOT-1PD

An autoban trigger being sent in DMs caused the ban to fail, but for it to still be registered in the database. That is becuase the ban command uses the `ctx.guild.ban` method, but in DMs `ctx.guild` is None. This commit solves it by overriding the `context.guild` field.