### PR TITLE
Bad async magic method

### DIFF
--- a/bot/exts/info/doc/_inventory_parser.py
+++ b/bot/exts/info/doc/_inventory_parser.py
@@ -36,7 +36,7 @@ class ZlibStreamReader:
 
         yield decompressor.flush()
 
-    async def __aiter__(self) -> AsyncIterator[str]:
+     def __aiter__(self) -> AsyncIterator[str]:
         """Yield lines of decompressed text."""
         buf = b''
         async for chunk in self._read_compressed_chunks():


### PR DESCRIPTION
#Bug risk
Magic methods that are not supposed to be asynchronous would not work as expected if they are made async. It is recommend to not make this magic method async.