### PR TITLE
Manage nomination threads in bot

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -683,9 +683,21 @@ class VideoPermission(metaclass=YAMLGetter):
     default_permission_duration: int
 
 
+class ThreadArchiveTimes(Enum):
+    HOUR = 60
+    DAY = 1440
+    THREE_DAY = 4230
+    WEEK = 10080
+
+
 # Debug mode
 DEBUG_MODE: bool = _CONFIG_YAML["debug"] == "true"
 FILE_LOGS: bool = _CONFIG_YAML["file_logs"].lower() == "true"
+
+if DEBUG_MODE:
+    DEFAULT_THREAD_ARCHIVE_TIME = ThreadArchiveTimes.HOUR.value
+else:
+    DEFAULT_THREAD_ARCHIVE_TIME = ThreadArchiveTimes.WEEK.value
 
 # Paths
 BOT_DIR = os.path.dirname(__file__)

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -483,7 +483,7 @@ class TalentPool(Cog, name="Talentpool"):
     @has_any_role(*MODERATION_ROLES)
     async def get_review(self, ctx: Context, user_id: int) -> None:
         """Get the user's review as a markdown file."""
-        review = (await self.reviewer.make_review(user_id))[0]
+        review, _, _ = await self.reviewer.make_review(user_id)
         if review:
             file = discord.File(StringIO(review), f"{user_id}_review.md")
             await ctx.send(file=file)

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -484,11 +484,8 @@ class TalentPool(Cog, name="Talentpool"):
     async def get_review(self, ctx: Context, user_id: int) -> None:
         """Get the user's review as a markdown file."""
         review, _, _ = await self.reviewer.make_review(user_id)
-        if review:
-            file = discord.File(StringIO(review), f"{user_id}_review.md")
-            await ctx.send(file=file)
-        else:
-            await ctx.send(f"There doesn't appear to be an active nomination for {user_id}")
+        file = discord.File(StringIO(review), f"{user_id}_review.md")
+        await ctx.send(file=file)
 
     @nomination_group.command(aliases=('review',))
     @has_any_role(*MODERATION_ROLES)

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -498,7 +498,7 @@ class TalentPool(Cog, name="Talentpool"):
         await ctx.message.add_reaction(Emojis.check_mark)
 
     @Cog.listener()
-    async def on_member_ban(self, guild: Guild, user: Union[MemberOrUser]) -> None:
+    async def on_member_ban(self, guild: Guild, user: MemberOrUser) -> None:
         """Remove `user` from the talent pool after they are banned."""
         await self.end_nomination(user.id, "User was banned.")
 

--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -516,6 +516,9 @@ class TalentPool(Cog, name="Talentpool"):
         if payload.channel_id != Channels.nomination_voting:
             return
 
+        if payload.user_id == self.bot.user.id:
+            return
+
         message: PartialMessage = self.bot.get_channel(payload.channel_id).get_partial_message(payload.message_id)
         emoji = str(payload.emoji)
 

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Union
 
 import arrow
 from dateutil.parser import isoparse
-from discord import Embed, Emoji, Member, Message, NoMoreItems, PartialMessage, TextChannel
+from discord import Embed, Emoji, Member, Message, NoMoreItems, NotFound, PartialMessage, TextChannel
 from discord.ext.commands import Context
 
 from bot.api import ResponseCodeError
@@ -220,10 +220,13 @@ class Reviewer:
         if not nomination_thread:
             log.warning(f"Could not find a thread linked to {message.channel.id}-{message.id}")
             return
-        await nomination_thread.edit(archived=True)
 
         for message_ in messages:
-            await message_.delete()
+            with contextlib.suppress(NotFound):
+                await message_.delete()
+
+        with contextlib.suppress(NotFound):
+            await nomination_thread.edit(archived=True)
 
     async def _construct_review_body(self, member: Member) -> str:
         """Formats the body of the nomination, with details of activity, infractions, and previous nominations."""

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -36,9 +36,8 @@ MAX_MESSAGE_SIZE = 2000
 MAX_EMBED_SIZE = 4000
 
 # Regex for finding the first message of a nomination, and extracting the nominee.
-# Historic nominations will have 2 role mentions at the start, new ones won't, optionally match for this.
 NOMINATION_MESSAGE_REGEX = re.compile(
-    r"(?:<@&\d+> <@&\d+>\n)*?<@!?(\d+?)> \(.+#\d{4}\) for Helper!\n\n\*\*Nominated by:\*\*",
+    r"<@!?(\d+)> \(.+#\d{4}\) for Helper!\n\n",
     re.MULTILINE
 )
 

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -375,10 +375,10 @@ class Reviewer:
 
     @staticmethod
     def _random_ducky(guild: Guild) -> Union[Emoji, str]:
-        """Picks a random ducky emoji. If no duckies found returns :eyes:."""
+        """Picks a random ducky emoji. If no duckies found returns 👀."""
         duckies = [emoji for emoji in guild.emojis if emoji.name.startswith("ducky")]
         if not duckies:
-            return ":eyes:"
+            return "\N{EYES}"
         return random.choice(duckies)
 
     @staticmethod

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -78,7 +78,7 @@ class Reviewer:
     async def post_review(self, user_id: int, update_database: bool) -> None:
         """Format the review of a user and post it to the nomination voting channel."""
         review, reviewed_emoji, nominee = await self.make_review(user_id)
-        if not review:
+        if not nominee:
             return
 
         guild = self.bot.get_guild(Guild.id)

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -104,8 +104,8 @@ class Reviewer:
             nomination = self._pool.cache.get(user_id)
             await self.bot.api_client.patch(f"bot/nominations/{nomination['id']}", json={"reviewed": True})
 
-    async def make_review(self, user_id: int) -> typing.Tuple[str, Optional[Emoji]]:
-        """Format a generic review of a user and return it with the reviewed emoji."""
+    async def make_review(self, user_id: int) -> typing.Tuple[str, Optional[Emoji], Optional[Member]]:
+        """Format a generic review of a user and return it with the reviewed emoji and the user themselves."""
         log.trace(f"Formatting the review of {user_id}")
 
         # Since `cache` is a defaultdict, we should take care
@@ -115,7 +115,7 @@ class Reviewer:
         nomination = self._pool.cache.get(user_id)
         if not nomination:
             log.trace(f"There doesn't appear to be an active nomination for {user_id}")
-            return "", None
+            return f"There doesn't appear to be an active nomination for {user_id}", None, None
 
         guild = self.bot.get_guild(Guild.id)
         nominee = await get_or_fetch_member(guild, user_id)


### PR DESCRIPTION
These changes moves the management of nomination threads from [Sir Threadevere](https://github.com/python-discord/sir-threadevere) to the bot. Once this PR is merged, Sir Threadevere can be shutdown.

These changes include creating a thread while posting the nomination, pinging staff inside the thread, and then archiving it once the nomination is concluded. 