### PR TITLE
Dynamic views for command help embeds

### DIFF
--- a/bot/exts/info/help.py
+++ b/bot/exts/info/help.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import itertools
 import re
 from collections import namedtuple
 from contextlib import suppress
-from typing import List, Union
+from typing import List, Optional, Union
 
-from discord import Colour, Embed
+from discord import ButtonStyle, Colour, Embed, Emoji, Interaction, PartialEmoji, ui
 from discord.ext.commands import Bot, Cog, Command, CommandError, Context, DisabledCommand, Group, HelpCommand
 from rapidfuzz import fuzz, process
 from rapidfuzz.utils import default_process
@@ -24,6 +26,123 @@ PREFIX = constants.Bot.prefix
 NOT_ALLOWED_TO_RUN_MESSAGE = "***You cannot run this command.***\n\n"
 
 Category = namedtuple("Category", ["name", "description", "cogs"])
+
+
+class SubcommandButton(ui.Button):
+    """
+    A button shown in a group's help embed.
+
+    The button represents a subcommand, and pressing it will edit the help embed to that of the subcommand.
+    """
+
+    def __init__(
+        self,
+        help_command: CustomHelpCommand,
+        command: Command,
+        *,
+        style: ButtonStyle = ButtonStyle.primary,
+        label: Optional[str] = None,
+        disabled: bool = False,
+        custom_id: Optional[str] = None,
+        url: Optional[str] = None,
+        emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
+        row: Optional[int] = None
+    ):
+        super().__init__(
+            style=style, label=label, disabled=disabled, custom_id=custom_id, url=url, emoji=emoji, row=row
+        )
+
+        self.help_command = help_command
+        self.command = command
+
+    async def callback(self, interaction: Interaction) -> None:
+        """Edits the help embed to that of the subcommand."""
+        message = interaction.message
+        if not message:
+            return
+
+        subcommand = self.command
+        if isinstance(subcommand, Group):
+            embed, subcommand_view = await self.help_command.format_group_help(subcommand)
+        else:
+            embed, subcommand_view = await self.help_command.command_formatting(subcommand)
+        await message.edit(embed=embed, view=subcommand_view)
+
+
+class GroupButton(ui.Button):
+    """
+    A button shown in a subcommand's help embed.
+
+    The button represents the parent command, and pressing it will edit the help embed to that of the parent.
+    """
+
+    def __init__(
+        self,
+        help_command: CustomHelpCommand,
+        command: Command,
+        *,
+        style: ButtonStyle = ButtonStyle.secondary,
+        label: Optional[str] = None,
+        disabled: bool = False,
+        custom_id: Optional[str] = None,
+        url: Optional[str] = None,
+        emoji: Optional[Union[str, Emoji, PartialEmoji]] = None,
+        row: Optional[int] = None
+    ):
+        super().__init__(
+            style=style, label=label, disabled=disabled, custom_id=custom_id, url=url, emoji=emoji, row=row
+        )
+
+        self.help_command = help_command
+        self.command = command
+
+    async def callback(self, interaction: Interaction) -> None:
+        """Edits the help embed to that of the parent."""
+        message = interaction.message
+        if not message:
+            return
+
+        embed, group_view = await self.help_command.format_group_help(self.command.parent)
+        await message.edit(embed=embed, view=group_view)
+
+
+class CommandView(ui.View):
+    """
+    The view added to any command's help embed.
+
+    If the command has a parent, a button is added to the view to show that parent's help embed.
+    """
+
+    def __init__(self, help_command: CustomHelpCommand, command: Command):
+        super().__init__()
+
+        if command.parent:
+            self.children.append(GroupButton(help_command, command, emoji="↩️"))
+
+
+class GroupView(CommandView):
+    """
+    The view added to a group's help embed.
+
+    The view generates a SubcommandButton for every subcommand the group has.
+    """
+
+    MAX_BUTTONS_IN_ROW = 5
+    MAX_ROWS = 5
+
+    def __init__(self, help_command: CustomHelpCommand, group: Group, subcommands: list[Command]):
+        super().__init__(help_command, group)
+        # Don't add buttons if only a portion of the subcommands can be shown.
+        if len(subcommands) + len(self.children) > self.MAX_ROWS * self.MAX_BUTTONS_IN_ROW:
+            return
+
+        for subcommand in subcommands:
+            presentable_name = subcommand.name.replace("_", " ").title()
+            self.children.append(
+                SubcommandButton(help_command, subcommand, label=presentable_name)
+            )
+        # This is required to normalize the button positions.
+        self.__weights = ui.view._ViewWeights(self.children)
 
 
 class HelpQueryNotFound(ValueError):
@@ -148,7 +267,7 @@ class CustomHelpCommand(HelpCommand):
 
         await self.context.send(embed=embed)
 
-    async def command_formatting(self, command: Command) -> Embed:
+    async def command_formatting(self, command: Command) -> tuple[Embed, Optional[CommandView]]:
         """
         Takes a command and turns it into an embed.
 
@@ -186,12 +305,14 @@ class CustomHelpCommand(HelpCommand):
         command_details += f"*{formatted_doc or 'No details provided.'}*\n"
         embed.description = command_details
 
-        return embed
+        # If the help is invoked in the context of an error, don't show subcommand navigation.
+        view = CommandView(self, command) if not self.context.command_failed else None
+        return embed, view
 
     async def send_command_help(self, command: Command) -> None:
         """Send help for a single command."""
-        embed = await self.command_formatting(command)
-        message = await self.context.send(embed=embed)
+        embed, view = await self.command_formatting(command)
+        message = await self.context.send(embed=embed, view=view)
         await wait_for_deletion(message, (self.context.author.id,))
 
     @staticmethod
@@ -212,25 +333,31 @@ class CustomHelpCommand(HelpCommand):
         else:
             return "".join(details)
 
-    async def send_group_help(self, group: Group) -> None:
-        """Sends help for a group command."""
+    async def format_group_help(self, group: Group) -> tuple[Embed, Optional[CommandView]]:
+        """Formats help for a group command."""
         subcommands = group.commands
 
         if len(subcommands) == 0:
             # no subcommands, just treat it like a regular command
-            await self.send_command_help(group)
-            return
+            return await self.command_formatting(group)
 
         # remove commands that the user can't run and are hidden, and sort by name
         commands_ = await self.filter_commands(subcommands, sort=True)
 
-        embed = await self.command_formatting(group)
+        embed, _ = await self.command_formatting(group)
 
         command_details = self.get_commands_brief_details(commands_)
         if command_details:
             embed.description += f"\n**Subcommands:**\n{command_details}"
 
-        message = await self.context.send(embed=embed)
+        # If the help is invoked in the context of an error, don't show subcommand navigation.
+        view = GroupView(self, group, commands_) if not self.context.command_failed else None
+        return embed, view
+
+    async def send_group_help(self, group: Group) -> None:
+        """Sends help for a group command."""
+        embed, view = await self.format_group_help(group)
+        message = await self.context.send(embed=embed, view=view)
         await wait_for_deletion(message, (self.context.author.id,))
 
     async def send_cog_help(self, cog: Cog) -> None:

--- a/bot/exts/info/help.py
+++ b/bot/exts/info/help.py
@@ -137,9 +137,8 @@ class GroupView(CommandView):
             return
 
         for subcommand in subcommands:
-            presentable_name = subcommand.name.replace("_", " ").title()
             self.children.append(
-                SubcommandButton(help_command, subcommand, label=presentable_name)
+                SubcommandButton(help_command, subcommand, label=subcommand.name)
             )
         # This is required to normalize the button positions.
         self.__weights = ui.view._ViewWeights(self.children)

--- a/bot/exts/info/help.py
+++ b/bot/exts/info/help.py
@@ -134,12 +134,11 @@ class GroupView(CommandView):
         super().__init__(help_command, group)
         # Don't add buttons if only a portion of the subcommands can be shown.
         if len(subcommands) + len(self.children) > self.MAX_ROWS * self.MAX_BUTTONS_IN_ROW:
+            log.trace(f"Attempted to add navigation buttons for `{group.qualified_name}`, but there was no space.")
             return
 
         for subcommand in subcommands:
-            self.add_item(
-                SubcommandButton(help_command, subcommand, label=subcommand.name)
-            )
+            self.add_item(SubcommandButton(help_command, subcommand, label=subcommand.name))
 
 
 class HelpQueryNotFound(ValueError):

--- a/bot/exts/info/help.py
+++ b/bot/exts/info/help.py
@@ -137,11 +137,9 @@ class GroupView(CommandView):
             return
 
         for subcommand in subcommands:
-            self.children.append(
+            self.add_item(
                 SubcommandButton(help_command, subcommand, label=subcommand.name)
             )
-        # This is required to normalize the button positions.
-        self.__weights = ui.view._ViewWeights(self.children)
 
 
 class HelpQueryNotFound(ValueError):

--- a/tests/bot/exts/backend/test_error_handler.py
+++ b/tests/bot/exts/backend/test_error_handler.py
@@ -572,38 +572,6 @@ class IndividualErrorHandlerTests(unittest.IsolatedAsyncioTestCase):
                 push_scope_mock.set_extra.has_calls(set_extra_calls)
 
 
-class OtherErrorHandlerTests(unittest.IsolatedAsyncioTestCase):
-    """Other `ErrorHandler` tests."""
-
-    def setUp(self):
-        self.bot = MockBot()
-        self.ctx = MockContext()
-
-    async def test_get_help_command_command_specified(self):
-        """Should return coroutine of help command of specified command."""
-        self.ctx.command = "foo"
-        result = ErrorHandler.get_help_command(self.ctx)
-        expected = self.ctx.send_help("foo")
-        self.assertEqual(result.__qualname__, expected.__qualname__)
-        self.assertEqual(result.cr_frame.f_locals, expected.cr_frame.f_locals)
-
-        # Await coroutines to avoid warnings
-        await result
-        await expected
-
-    async def test_get_help_command_no_command_specified(self):
-        """Should return coroutine of help command."""
-        self.ctx.command = None
-        result = ErrorHandler.get_help_command(self.ctx)
-        expected = self.ctx.send_help()
-        self.assertEqual(result.__qualname__, expected.__qualname__)
-        self.assertEqual(result.cr_frame.f_locals, expected.cr_frame.f_locals)
-
-        # Await coroutines to avoid warnings
-        await result
-        await expected
-
-
 class ErrorHandlerSetupTests(unittest.TestCase):
     """Tests for `ErrorHandler` `setup` function."""
 


### PR DESCRIPTION
Adds views for commands to navigate groups.
For subcommands, a button is added to show the parent's help embed.
For groups, buttons are added for each subcommand to show their help embeds.

The views are not generated when help is invoked in the context of an error.

The code has gone through several iterations of design, and this is what I arrived at.
Because conversion of callbacks to buttons is done in __subclass_init__ of the view baseclass, I had to create Button subclasses.
Because the normalization of button positions is in the view init and is obfuscated, I had to meddle with discord.py internals a bit in GroupView to make it work. The only way I can think of around all that is to instantiate an instance of `type` on the fly, but that doesn't sound very reader-friendly.

I also don't really like the help formatting functions returning the views, so if anyone has a better idea let me know. At least in the case of a group, I had to do get the view from there because I needed the filtered subcommands. Since the filtering is asynchronous I couldn't do it in the view's init.

https://user-images.githubusercontent.com/18114431/140521230-3923da4b-99d1-4eaf-8c9b-69f8eb35f225.mp4


