### PR TITLE
Sync Help Cooldown role with help channel claimants

### DIFF
--- a/tests/bot/exts/help_channels/test_cog.py
+++ b/tests/bot/exts/help_channels/test_cog.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch
+
+from bot.exts.help_channels import _cog
+from tests.helpers import MockBot, MockMember, MockRedisCache
+
+
+class HelpChannelsCogTest(unittest.IsolatedAsyncioTestCase):
+    """Test the HelpChannels cog."""
+
+    def setUp(self):
+        self.bot = MockBot()
+        self.cog = _cog.HelpChannels(self.bot)
+
+    @patch("bot.exts.help_channels._cog._caches")
+    async def test_sync_cooldown_roles(self, _caches):
+        # Given
+        claimant_member = MockMember(id="345")
+        non_claimant_member = MockMember(id="456")
+
+        _caches.claimants = MockRedisCache()
+        _caches.claimants.to_dict.return_value = {"123": claimant_member.id}
+
+        self.bot.get_guild.return_value.get_role.return_value.members = [
+            claimant_member,
+            non_claimant_member,
+        ]
+
+        # When
+        await self.cog.sync_cooldown_roles()
+
+        # Then
+        claimant_member.remove_roles.assert_not_called()
+        non_claimant_member.remove_roles.assert_called()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -568,3 +568,12 @@ class MockAsyncWebhook(CustomMockMixin, unittest.mock.MagicMock):
     """
     spec_set = webhook_instance
     additional_spec_asyncs = ("send", "edit", "delete", "execute")
+
+
+class MockRedisCache(unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock RedisCache.
+    """
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.to_dict = unittest.mock.AsyncMock()


### PR DESCRIPTION
Solves the Help Cooldown part of #1903.

Every hour, retrieve all channel claimants from Redis cache,
get all members who currently have the Help Cooldown role,
then remove the role from any such member who is not a
channel claimant as per the cache.