### PR TITLE
commands: add pip as an alias to pypi

### DIFF
--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -29,7 +29,7 @@ class PyPi(Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
 
-    @command(name="pypi", aliases=("package", "pack"))
+    @command(name="pypi", aliases=("package", "pack", "pip"))
     async def get_package_info(self, ctx: Context, package: str) -> None:
         """Provide information about a specific package from PyPI."""
         embed = Embed(title=random.choice(NEGATIVE_REPLIES), colour=Colours.soft_red)


### PR DESCRIPTION
No issue, approved here:
https://canary.discord.com/channels/267624335836053506/635950537262759947/907006875797712896
![image](https://user-images.githubusercontent.com/71233171/140661302-60d72dd1-3cbc-4dd7-ac50-ecc8f4b90d01.png)


In addition to `!pypi`, a user can now also use `!pip` in order to get package information, since pip is the package index. 