### PR TITLE
Refactor ModLog

### DIFF
--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -613,7 +613,7 @@ class ModLog(Cog, name="ModLog"):
     @Cog.listener()
     async def on_raw_message_delete(self, event: discord.RawMessageDeleteEvent) -> None:
         """Log raw message delete event to message change log."""
-        if self.is_message_blacklisted(event.channel_id):
+        if self.is_channel_ignored(event.channel_id):
             return
 
         await asyncio.sleep(1)  # Wait here in case the normal event was fired


### PR DESCRIPTION
Closes #1945
Closes BOT-1Q3

This PR also removes the need to cache message deletions by only listening to `on_raw_message_delete`.