### PR TITLE
Fix `!infractions by me`

### DIFF
--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -272,7 +272,7 @@ class ModManagement(commands.Cog):
     async def search_by_actor(
         self,
         ctx: Context,
-        actor: t.Union[discord.Member, t.Literal["m", "me"]],
+        actor: t.Union[t.Literal["m", "me"], UnambiguousUser],
         oldest_first: bool = False
     ) -> None:
         """


### PR DESCRIPTION
Extension to #1926.

The literal converter is now before the Member converter so that "me"/"m" isn't attempted to be converted to a Member.

Also swaps from `discord.Member` to `UnambiguousMember`.