### PR TITLE
Change log level from `WARNING` to `DEBUG`.

### DIFF
--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -128,9 +128,7 @@ class HelpChannels(commands.Cog):
 
         # Handle odd edge case of `message.author` not being a `discord.Member` (see bot#1839)
         if not isinstance(message.author, discord.Member):
-            log.warning(
-                f"{message.author} ({message.author.id}) isn't a member. Not giving cooldown role or sending DM."
-            )
+            log.debug(f"{message.author} ({message.author.id}) isn't a member. Not giving cooldown role or sending DM.")
         else:
             await self._handle_role_change(message.author, message.author.add_roles)
 


### PR DESCRIPTION
Closes #1949.

As was stated in #1845 the WARNING was only to trigger a sentry issue to see if we could find a cause for the issue (`message.author` being a `discord.User`).

We have now discovered today from the warning triggering that it's caused by the member being banned. Since we now know the cause this can be downgraded to a `log.debug`.