### PR TITLE
YTDL tag update

### DIFF
--- a/bot/resources/tags/ytdl.md
+++ b/bot/resources/tags/ytdl.md
@@ -1,4 +1,4 @@
-Per [Python Discord's Rule 5](https://pythondiscord.com/pages/rules), we are unable to assist with questions related to youtube-dl, pytube, or other YouTube video downloaders, as their usage violates YouTube's Terms of Service.
+Per [Python Discord's Rule 5](https://pythondiscord.com/pages/rules), we are unable to assist with projects related to youtube-dl, pytube, or other YouTube video downloaders, as their usage violates YouTube's Terms of Service.
 
 For reference, this usage is covered by the following clauses in [YouTube's TOS](https://www.youtube.com/static?gl=GB&template=terms), as of 2021-03-17:
 ```


### PR DESCRIPTION
As per rule 5:
> Do not provide or request help **on projects** that may break laws, breach terms of services, or are malicious or inappropriate.

The current tag says you should not assist with *questions related to ytdl*. People might ask a simple question about general Python coding within a project breaking YouTube's Terms of Service, and other members provide support for the user, which breaks the rule 5.