### PR TITLE
Add #bot-commands to guild features in !server

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -178,7 +178,10 @@ class Information(Cog):
 
         # Server Features are only useful in certain channels
         if ctx.channel.id in (
-            *constants.MODERATION_CHANNELS, constants.Channels.dev_core, constants.Channels.dev_contrib
+            *constants.MODERATION_CHANNELS,
+            constants.Channels.dev_core,
+            constants.Channels.dev_contrib,
+            constants.Channels.bot_commands
         ):
             features = f"\nFeatures: {', '.join(ctx.guild.features)}"
         else:


### PR DESCRIPTION
This prevents spam in dev-contrib and dev-core from people trying to
find which Discord feature flags are enabled for Python Discord. It's
not ideal that we have to increase output size in #bot-commands but it
prevents spam in #dev-contrib.
