### PR TITLE
Unfurl Redirects

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -216,6 +216,7 @@ class Redis(metaclass=YAMLGetter):
 class Filter(metaclass=YAMLGetter):
     section = "filter"
 
+    filter_redirects: bool
     filter_domains: bool
     filter_everyone_ping: bool
     filter_invites: bool
@@ -225,6 +226,7 @@ class Filter(metaclass=YAMLGetter):
 
     # Notifications are not expected for "watchlist" type filters
 
+    notify_user_redirects: bool
     notify_user_domains: bool
     notify_user_everyone_ping: bool
     notify_user_invites: bool

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -561,6 +561,9 @@ class URLs(metaclass=YAMLGetter):
     site_logs_view: str
     paste_service: str
 
+    # Cloudflare workers
+    unfurl_worker: str
+
 
 class Metabase(metaclass=YAMLGetter):
     section = "metabase"

--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -72,6 +72,10 @@ class FilterLists(Cog):
         elif list_type == "FILE_FORMAT" and not content.startswith("."):
             content = f".{content}"
 
+        # Remove protocol and trailing slash from URLs
+        elif list_type in ("DOMAIN_NAME", "REDIRECT"):
+            content = content.removeprefix("https://").removeprefix("http://").rstrip("/")
+
         # Try to add the item to the database
         log.trace(f"Trying to add the {content} item to the {list_type} {allow_type}")
         payload = {
@@ -123,6 +127,10 @@ class FilterLists(Cog):
         # If it's a file format, let's make sure it has a leading dot.
         elif list_type == "FILE_FORMAT" and not content.startswith("."):
             content = f".{content}"
+
+        # Remove protocol and trailing slash from URLs
+        elif list_type in ("DOMAIN_NAME", "REDIRECT"):
+            content = content.removeprefix("https://").removeprefix("http://").rstrip("/")
 
         # Find the content and delete it.
         log.trace(f"Trying to delete the {content} item from the {list_type} {allow_type}")

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -601,7 +601,7 @@ class Filtering(Cog):
         return False, None
 
     def _extract_url(self, text: str, blacklisted_urls: list[str]) -> Optional[tuple[str, str]]:
-        """Extract a URL from a message, and return the filer and match."""
+        """Extract a URL from a message, and return the filter and match."""
         text = self.clean_input(text)
         for match in URL_RE.finditer(text):
             url_parsed = tldextract.extract(match.group("url").lower())

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import re
 import unicodedata
 from datetime import timedelta
@@ -285,7 +284,7 @@ class Filtering(Cog):
         Filter the result of an !eval to see if it violates any of our rules, and then respond accordingly.
 
         Also requires the original message, to check whether to filter and for mod logs.
-        Returns whether a filter was triggered or not.
+        Return whether a filter was triggered or not.
         """
         filter_triggered = False
         # Should we filter this message?
@@ -445,7 +444,7 @@ class Filtering(Cog):
 
                             if filter_name == "filter_redirects":
                                 # Redirects delete the message immediately
-                                delete_date = datetime.datetime.now(tz=datetime.timezone.utc) + timedelta(seconds=10)
+                                delete_date = arrow.utcnow() + timedelta(seconds=10)
 
                             delete_date = delete_date.isoformat()
 
@@ -468,7 +467,7 @@ class Filtering(Cog):
 
                         stats = self._add_stats(filter_name, match, msg.content)
                         if filter_name == "filter_redirects":
-                            # The redirect filter processes the content further and sends it's own log message
+                            # The redirect filter processes the content further and sends its own log message
                             task_id = str(msg.id) + "redirect"
                             self.scheduler.schedule(task_id, self._process_redirect(reason, msg, stats))
                         else:
@@ -615,7 +614,7 @@ class Filtering(Cog):
 
     async def _has_redirects(self, text: str) -> tuple[bool, Optional[str]]:
         """
-        Returns True if the text contains a URL from the redirects blacklist.
+        Return True if the text contains a URL from the redirects blacklist.
 
         Second return value is the match that tripped the filter.
         """
@@ -627,7 +626,7 @@ class Filtering(Cog):
 
     async def _has_urls(self, text: str) -> tuple[bool, Optional[str]]:
         """
-        Returns True if the text contains one of the blacklisted URLs from the config file.
+        Return True if the text contains one of the blacklisted URLs from the config file.
 
         Second return value is a reason of URL blacklisting (can be None).
         """
@@ -640,7 +639,7 @@ class Filtering(Cog):
     @staticmethod
     async def _has_zalgo(text: str) -> bool:
         """
-        Returns True if the text contains zalgo characters.
+        Return True if the text contains zalgo characters.
 
         Zalgo range is \u0300 – \u036F and \u0489.
         """

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -345,14 +345,14 @@ class Filtering(Cog):
 
         if result is None:
             log.debug("Failed to unfurl a redirect.")
-            message_override = ". URL could not be unfurled for an unknown reason."
+            message_extend = ". URL could not be unfurled for an unknown reason."
             ping = True
 
         elif result.error is None:
             has_urls = await self._has_urls(result.destination)
             if has_urls[0]:
                 log.debug("Unfurled redirect, and destination was blacklisted.")
-                message_override = (
+                message_extend = (
                     ", and tripped a domain filter.\n\n"
                     f"Destination: `{result.destination}`\n"
                     f"Redirects: {result.depth}\n\n"
@@ -365,11 +365,11 @@ class Filtering(Cog):
 
             else:
                 log.debug("Unfurled redirect, but destination was not blacklisted.")
-                message_override = ". URL unfurled, but destination was not blacklisted. Tripped "
+                message_extend = ". URL unfurled, but destination was not blacklisted. Tripped "
                 ping = False
         else:
             log.debug("Failed to unfurl a redirect.")
-            message_override = (
+            message_extend = (
                 f".\nFailed to unfurl this URL after {result.depth} attempts due to the following error:\n"
                 f"{result.error}\n\n"
                 f"You can try to manually unfurl with `{constants.Bot.prefix}unfurl {url}`.\n"
@@ -378,7 +378,7 @@ class Filtering(Cog):
             ping = True
 
         await self._send_log(
-            filter_data[0], filter_data[1], message, stats, reason, ping=ping, message_override=message_override
+            filter_data[0], filter_data[1], message, stats, reason, ping=ping, message_extend=message_extend
         )
 
     async def _filter_message(self, msg: Message, delta: Optional[int] = None) -> None:
@@ -486,7 +486,7 @@ class Filtering(Cog):
         reason: Optional[str] = None,
         *,
         ping: Optional[bool] = None,
-        message_override: str = "",
+        message_extend: str = "",
         is_eval: bool = False,
     ) -> None:
         """Send a mod log for a triggered filter."""
@@ -508,7 +508,7 @@ class Filtering(Cog):
         eval_msg = "using !eval " if is_eval else ""
         footer = f"Reason: {reason}" if reason else None
         message = (
-            f"The {filter_name} {_filter['type']} was triggered by {format_user(msg.author)}{message_override} "
+            f"The {filter_name} {_filter['type']} was triggered by {format_user(msg.author)}{message_extend} "
             f"{channel_str} {eval_msg}with [the following message]({msg.jump_url}):\n\n"
             f"{stats.message_content}"
         )

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -370,7 +370,7 @@ class Filtering(Cog):
         else:
             log.debug("Failed to unfurl a redirect.")
             message_extend = (
-                f".\nFailed to unfurl this URL after {result.depth} attempts due to the following error:\n"
+                f".\n\nFailed to unfurl this URL after {result.depth} attempts due to the following error: "
                 f"{result.error}\n\n"
                 f"You can try to manually unfurl with `{constants.Bot.prefix}unfurl {url}`.\n"
                 " Tripped "

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -340,7 +340,7 @@ class Filtering(Cog):
         """Unfurl redirect, run the URL filters on it, and check if further punishment is required."""
         log.trace(f"Processing redirects for {message.id} by {message.author}.")
         filter_data = "filter_redirects", self.filters["filter_redirects"]
-        result = await services.unfurl_url(url, max_continues=0, use_cache=True)
+        result = await services.unfurl_url(url, max_per_attempt=3, max_continues=0, use_cache=True)
         reason = None
 
         if result is None:

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -37,7 +37,7 @@ CODE_BLOCK_RE = re.compile(
 )
 EVERYONE_PING_RE = re.compile(rf"@everyone|<@&{Guild.id}>|@here")
 SPOILER_RE = re.compile(r"(\|\|.+?\|\|)", re.DOTALL)
-URL_RE = re.compile(r"(?<url>https?://[^\s]+)", flags=re.IGNORECASE)
+URL_RE = re.compile(r"(?P<url>https?://[^\s]+)", flags=re.IGNORECASE)
 
 # Exclude variation selectors from zalgo because they're actually invisible.
 VARIATION_SELECTORS = r"\uFE00-\uFE0F\U000E0100-\U000E01EF"

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -441,11 +441,13 @@ class Filtering(Cog):
                         # If the message is classed as offensive, we store it in the site db and
                         # it will be deleted after one week.
                         if _filter["schedule_deletion"] and not is_private:
-                            delete_date = (msg.created_at + OFFENSIVE_MSG_DELETE_TIME).isoformat()
+                            delete_date = (msg.created_at + OFFENSIVE_MSG_DELETE_TIME)
 
                             if filter_name == "filter_redirects":
                                 # Redirects delete the message immediately
-                                delete_date = (datetime.datetime.utcnow() + timedelta(seconds=10)).isoformat()
+                                delete_date = datetime.datetime.now(tz=datetime.timezone.utc) + timedelta(seconds=10)
+
+                            delete_date = delete_date.isoformat()
 
                             data = {
                                 'id': msg.id,

--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -210,14 +210,12 @@ class Utils(Cog):
     @command(aliases=("unfurl",))
     async def unfurl_url(self, ctx: Context, url: str, max_redirects: int = 5, use_cache: bool = True) -> None:
         """
-        Unfurl `url` to find where it redirects to.
+        Unfurl `url` to find where it redirects to, to a maximum depth of `max_redirects`.
 
-        We unfurl to a maximum depth of `max_redirects`.
+        Colour the embed green if the final destination of the url is found correctly.
+        Otherwise, colour it red.
 
-        The color of the embed will indicate if we managed to correctly find the final destination of the url.
-        If it's red, we did not reach the bottom, or there isn't one.
-
-        Setting `use_cache` to False will skip the cache and make a new request.
+        Skip the cache and make a new request if `use_case` is False.
         """
         if not 0 < max_redirects <= services.MAX_UNFURLS * 5:
             raise BadArgument(f"Max redirects has to be a number between {0} and {services.MAX_UNFURLS * 5}.")
@@ -264,9 +262,9 @@ class Utils(Cog):
             # Wrap the URL in backticks to prevent hyperlinking and accidental clicks
             _dest = f"`{result.destination}`"
             if len(_dest) > 1024:
-                # URL is too long for an embed field, send to the pastebin
+                # URL is too long for an embed field; send to the pastebin
                 paste = await services.send_to_paste_service(result.destination, extension="txt")
-                dest = f"Result was too long to display, you can find it [here]({paste})."
+                dest = f"Result was too long to display. You can find it [here]({paste})."
             else:
                 dest = _dest
 

--- a/bot/utils/services.py
+++ b/bot/utils/services.py
@@ -1,8 +1,12 @@
+import dataclasses
+import datetime
+import json
 import typing
 from typing import Optional
 
 import aiohttp
 from aiohttp import ClientConnectorError
+from async_rediscache import RedisCache
 
 import bot
 from bot.constants import URLs
@@ -12,6 +16,23 @@ log = get_logger(__name__)
 T = typing.TypeVar("T")
 
 FAILED_REQUEST_ATTEMPTS = 3
+
+UNFURL_CACHE = RedisCache(namespace="UnfurledRedirects")
+CACHE_LENGTH = datetime.timedelta(days=1)
+
+
+@dataclasses.dataclass()
+class _UnfurlReturn:
+    """The return value for the URL unfurling utility."""
+
+    destination: Optional[str] = None
+    depth: Optional[int] = None
+    error: Optional[str] = None
+    created_at: Optional[datetime.datetime] = None
+
+
+_CONTINUE_RETURN = tuple[str, int]
+_JOIN_RETURNS = typing.Union[tuple[_UnfurlReturn, int], _CONTINUE_RETURN, None]
 
 
 async def _attempt_request(
@@ -95,3 +116,138 @@ async def send_to_paste_service(contents: str, *, extension: str = "") -> Option
         )
 
     return await _attempt_request(paste_url, FAILED_REQUEST_ATTEMPTS, data=contents, callback=_callback)
+
+
+async def _get_url_from_cache(url: str) -> Optional[_UnfurlReturn]:
+    """Return an unfurled URL from cache, or None if it doesn't exist or is expired."""
+    cached = await UNFURL_CACHE.get(url)
+
+    if cached is not None:
+        log.trace(f"Found hit for URL ({log}) in unfurl cache.")
+        data = json.loads(cached)
+        expiry = datetime.datetime.fromisoformat(data["expiry"])
+
+        if expiry < datetime.datetime.utcnow():
+            # Cache expired, remove it and continue normally
+            log.debug(f"Cache entry for ({url}) expired, deleting.")
+            await UNFURL_CACHE.delete(url)
+        else:
+            # Found unexpired hit
+            return _UnfurlReturn(data["destination"], data["depth"], None, expiry - CACHE_LENGTH)
+
+
+async def _unfurl_url(url: str, redirects: int, continues: int, max_continues: int) -> _JOIN_RETURNS:
+    """
+    The actual core logic of the unfurling.
+
+    Unlike the public utility, this will only follow one redirect, and parse the results.
+    The handling of the results is managed by the public function.
+
+    Returns a tuple with a final UnfurlReturn and response status,
+    or a tuple containing data to allow the caller to continue, or None.
+    """
+    # See link for documentation on how to use the worker
+    # https://github.com/python-discord/workers/tree/main/url-unfurler
+    response = await _attempt_request(URLs.unfurl_worker, 3, json={"url": url}, raise_for_status=False)
+
+    if response is None:
+        return
+
+    if response.status == 200:
+        # Success, return the destination
+        content = await response.json()
+        now = datetime.datetime.utcnow()
+        return _UnfurlReturn(content["destination"], redirects + content["depth"], None, now), response.status
+
+    elif response.status == 400:
+        # Unrecoverable error with the URL used for this unfurling
+        error_message = (await response.json())["error"]
+        log.warning(f"Failed to unfurl URL ({url}) with error message: {error_message}")
+        return _UnfurlReturn(error=error_message), response.status
+
+    elif response.status == 416:
+        # Max depth reached by the worker, try again or exit
+        data = await response.json()
+
+        if continues < max_continues:
+            # Try again (the caller will make a new call with the next URL)
+            log.debug(
+                f"Hit maximum depth while unfurling URL ({url}) after {data['depth']} attempts. "
+                f"Last request was made to ({data['final']}), and next request will be made to {data['next']}. "
+                f"{continues + 1}/{max_continues} failures."
+            )
+
+            return data["next"], data["depth"]
+
+        else:
+            # Give up
+            redirects += data["depth"]
+            log.info(f"Failed to unfurl URL ({url}) after {redirects} redirects.")
+            return _UnfurlReturn(data["next"], redirects, data["error"]), response.status
+
+    elif response.status == 418:
+        # The redirect chain has a broken link, can not continue
+        data = await response.json()
+        redirects += data["depth"]
+
+        log.warning(
+            f"Failed to unfurl URL ({url}) due to a broken link in the chain. "
+            f"Followed {redirects} redirects, and stopped at ({data['final']})."
+        )
+        return _UnfurlReturn(data["final"], redirects, data["error"]), response.status
+
+    else:
+        response.raise_for_status()
+
+
+async def unfurl_url(url: str, *, max_continues: int = 0, use_cache: bool = True) -> Optional[_UnfurlReturn]:
+    """
+    Follow all redirects of a URL, and return the final address.
+
+    Returns an object containing the final URL, number of redirects, error text, and date of last fetch.
+    Returns None if we couldn't resolve the URL for any reason.
+
+    The error in the return is only set if the operation failed.
+    If false, the final destination might not be accurate, and the date will be None.
+
+    If the worker errors out due to too many redirects,
+    we'll attempt to continue from the last URL `max_continues` times.
+    """
+    next_url = url
+    redirects = 0
+    continues = 0
+
+    if not use_cache:
+        log.info(f"Skipping cache for URL unfurling ({url})")
+
+    while True:
+        # Check if we can just use the cache
+        if use_cache and (hit := await _get_url_from_cache(next_url)) is not None:
+            return hit
+
+        response = await _unfurl_url(next_url, redirects, continues, max_continues)
+
+        if response is None:
+            # We couldn't resolve this URL
+            return response
+
+        elif isinstance(response[0], _UnfurlReturn):
+            # We reached a final conclusion for this URL
+            if response[1] == 200:
+                # Success, write to cache and return
+                data = {
+                    "destination": response[0].destination,
+                    "depth": response[0].depth,
+                    "expiry": (response[0].created_at + CACHE_LENGTH).isoformat()
+                }
+
+                # Write to cache and return results
+                log.trace(f"Writing URL ({url}) to unfurl CACHE.")
+                await UNFURL_CACHE.set(url, json.dumps(data))
+
+            return response[0]
+
+        else:
+            next_url = response[0]
+            redirects += response[1] + 1
+            continues += 1

--- a/bot/utils/services.py
+++ b/bot/utils/services.py
@@ -21,7 +21,7 @@ UNFURL_CACHE = RedisCache(namespace="UnfurledRedirects")
 CACHE_LENGTH = datetime.timedelta(days=1)
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass(frozen=True, eq=True)
 class _UnfurlReturn:
     """The return value for the URL unfurling utility."""
 

--- a/bot/utils/services.py
+++ b/bot/utils/services.py
@@ -1,5 +1,7 @@
+import typing
 from typing import Optional
 
+import aiohttp
 from aiohttp import ClientConnectorError
 
 import bot
@@ -7,8 +9,52 @@ from bot.constants import URLs
 from bot.log import get_logger
 
 log = get_logger(__name__)
+T = typing.TypeVar("T")
 
 FAILED_REQUEST_ATTEMPTS = 3
+
+
+async def _attempt_request(
+    url: str,
+    attempts: int,
+    *,
+    method: str = aiohttp.hdrs.METH_POST,
+    callback: Optional[typing.Callable[[aiohttp.ClientResponse, int, int], typing.Awaitable[T]]] = None,
+    **kw_data,
+) -> Optional[typing.Union[aiohttp.ClientResponse, T]]:
+    """
+    Attempt to perform a request to `url`, `attempt` times, and return the response.
+
+    Make sure to close
+
+    `data` and `kw_data` are passed to the request as is.
+    Return None for failures.
+
+    If callback is not None, return the result of calling that instead.
+    Callbacks that return None will also be reattempted in the same fashion as the request.
+    Callback is called with (response, current_attempt, max_attempts)
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            response = await bot.instance.http_session.request(method, url, **kw_data)
+
+            if callback is None:
+                return response
+            elif (result := await callback(response, attempt, attempts)) is not None:
+                return result
+
+        except ClientConnectorError:
+            log.warning(
+                f"Failed to connect to service at url {url}, "
+                f"trying again ({attempt}/{attempts})."
+            )
+            continue
+        except Exception:
+            log.exception(
+                f"An unexpected error has occurred during handling of the request, "
+                f"trying again ({attempt}/{attempts})."
+            )
+            continue
 
 
 async def send_to_paste_service(contents: str, *, extension: str = "") -> Optional[str]:
@@ -22,29 +68,17 @@ async def send_to_paste_service(contents: str, *, extension: str = "") -> Option
     extension = extension and f".{extension}"
     log.debug(f"Sending contents of size {len(contents.encode())} bytes to paste service.")
     paste_url = URLs.paste_service.format(key="documents")
-    for attempt in range(1, FAILED_REQUEST_ATTEMPTS + 1):
-        try:
-            async with bot.instance.http_session.post(paste_url, data=contents) as response:
-                response_json = await response.json()
-        except ClientConnectorError:
-            log.warning(
-                f"Failed to connect to paste service at url {paste_url}, "
-                f"trying again ({attempt}/{FAILED_REQUEST_ATTEMPTS})."
-            )
-            continue
-        except Exception:
-            log.exception(
-                f"An unexpected error has occurred during handling of the request, "
-                f"trying again ({attempt}/{FAILED_REQUEST_ATTEMPTS})."
-            )
-            continue
+
+    async def _callback(_response: aiohttp.ClientResponse, _attempt: int, _attempts: int) -> Optional[str]:
+        response_json = await _response.json()
 
         if "message" in response_json:
             log.warning(
-                f"Paste service returned error {response_json['message']} with status code {response.status}, "
-                f"trying again ({attempt}/{FAILED_REQUEST_ATTEMPTS})."
+                f"Paste service returned error {response_json['message']} with status code {_response.status}, "
+                f"trying again ({_attempt}/{_attempts})."
             )
-            continue
+            return
+
         elif "key" in response_json:
             log.info(f"Successfully uploaded contents to paste service behind key {response_json['key']}.")
 
@@ -57,5 +91,7 @@ async def send_to_paste_service(contents: str, *, extension: str = "") -> Option
 
         log.warning(
             f"Got unexpected JSON response from paste service: {response_json}\n"
-            f"trying again ({attempt}/{FAILED_REQUEST_ATTEMPTS})."
+            f"trying again ({_attempt}/{_attempts})."
         )
+
+    return await _attempt_request(paste_url, FAILED_REQUEST_ATTEMPTS, data=contents, callback=_callback)

--- a/bot/utils/services.py
+++ b/bot/utils/services.py
@@ -127,7 +127,7 @@ async def _get_url_from_cache(url: str) -> Optional[_UnfurlReturn]:
         data = json.loads(cached)
         expiry = datetime.datetime.fromisoformat(data["expiry"])
 
-        if expiry < datetime.datetime.utcnow():
+        if expiry < datetime.datetime.now(tz=datetime.timezone.utc):
             # Cache expired, remove it and continue normally
             log.debug(f"Cache entry for ({url}) expired, deleting.")
             await UNFURL_CACHE.delete(url)
@@ -156,7 +156,7 @@ async def _unfurl_url(url: str, redirects: int, continues: int, max_continues: i
     if response.status == 200:
         # Success, return the destination
         content = await response.json()
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
         return _UnfurlReturn(content["destination"], redirects + content["depth"], None, now), response.status
 
     elif response.status == 400:

--- a/config-default.yml
+++ b/config-default.yml
@@ -320,6 +320,7 @@ guild:
 
 filter:
     # What do we filter?
+    filter_redirects:        true
     filter_domains:        true
     filter_everyone_ping:  true
     filter_invites:        true
@@ -329,6 +330,7 @@ filter:
 
     # Notify user on filter?
     # Notifications are not expected for "watchlist" type filters
+    notify_user_redirects:        false
     notify_user_domains:        false
     notify_user_everyone_ping:  true
     notify_user_invites:        true

--- a/config-default.yml
+++ b/config-default.yml
@@ -376,6 +376,10 @@ urls:
     paste_service:                      !JOIN [*SCHEMA, *PASTE, "/{key}"]
     site_logs_view:                     !JOIN [*STAFF, "/bot/logs"]
 
+    # Cloudflare workers
+    worker_domain: &WORKER_DOMAIN "python-discord.workers.dev"
+    unfurl_worker:                !JOIN ["https://url-unfurler.", *WORKER_DOMAIN]
+
     # Snekbox
     snekbox_eval_api: !ENV ["SNEKBOX_EVAL_API", "http://snekbox.default.svc.cluster.local/eval"]
 
@@ -383,7 +387,7 @@ urls:
     discord_api:        &DISCORD_API "https://discordapp.com/api/v7/"
     discord_invite_api: !JOIN [*DISCORD_API, "invites"]
 
-    # Misc URLsw
+    # Misc URLs
     bot_avatar:      "https://raw.githubusercontent.com/python-discord/branding/main/logos/logo_circle/logo_circle.png"
     github_bot_repo: "https://github.com/python-discord/bot"
 

--- a/tests/bot/utils/test_services.py
+++ b/tests/bot/utils/test_services.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import unittest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -5,11 +6,124 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import aiohttp.hdrs
 from aiohttp import ClientConnectorError
 
-from bot.utils.services import FAILED_REQUEST_ATTEMPTS, send_to_paste_service
-from tests.helpers import MockBot
+from bot.utils import services
+from tests.helpers import MockBot, autospec
+
+
+class RequestTests(unittest.IsolatedAsyncioTestCase):
+    """Test the attempt_request utility function."""
+
+    def setUp(self) -> None:
+        patcher = patch("bot.instance", new=MockBot())
+        self.bot = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.bot.http_session.request = AsyncMock()
+
+    async def test_successful_post(self):
+        """The utility makes one request, and returns the response object when successful."""
+        response = MagicMock()
+        self.bot.http_session.request.return_value = response
+        self.bot.http_session.reset_mock()
+
+        url = "url"
+        actual_response = await services._attempt_request(url, 1)
+        self.bot.http_session.request.assert_called_once_with(aiohttp.hdrs.METH_POST, url)
+        self.assertEqual(response, actual_response)
+
+    async def test_callback_called(self):
+        """If callback is passed, it's called upon success, and it's value returned."""
+        return_value = "Callback return"
+        callback = AsyncMock(return_value=return_value)
+
+        response = MagicMock()
+        self.bot.http_session.request.return_value = response
+
+        actual_response = await services._attempt_request("url", 1, callback=callback)
+        self.assertEqual(
+            return_value,
+            actual_response,
+            "The function was expected to return the result of the callback."
+        )
+
+        callback.assert_called_once_with(response, 1, 1)
+
+    async def test_repeat_request(self):
+        """Test that requests are repeated on failure."""
+        # Use ClientConnectorError here to avoid swallowing actual errors
+        responses: list[AsyncMock] = [
+            AsyncMock(side_effect=ClientConnectorError(Mock(), Mock())),
+            AsyncMock(side_effect=ClientConnectorError(Mock(), Mock())),
+            AsyncMock(return_value="Success"),
+        ]
+
+        for attempts in range(1, len(responses) + 1):
+            final_mock = responses[attempts - 1]
+            expected_failure = final_mock.side_effect is not None
+            final_mock.reset_mock()
+
+            with self.subTest(attempts=attempts, expected_failure=expected_failure):
+                # Call the mocks to get a coroutine, and return each coroutine in subsequent calls to `request`
+                wrapped_responses = [mock.__call__() for mock in responses[0:attempts]]
+                self.bot.http_session.request = Mock(side_effect=wrapped_responses)
+
+                # Ensure we didn't swallow any exceptions
+                try:
+                    with self.assertLogs(services.log, logging.ERROR) as logs:
+                        response = await services._attempt_request("url", attempts)
+                except AssertionError:
+                    # assertLogs raised an exception because no logs existed, as expected
+                    pass
+                else:
+                    # assertLogs did not raise an exception, because it found logs
+                    output = "\n\n".join(logs.output)
+                    raise Exception(f"Unexpected exceptions raised during this run:\n{output}")
+
+                self.assertEqual(None if expected_failure else "Success", response)
+                self.assertEqual(attempts, self.bot.http_session.request.call_count)
+
+    async def test_repeat_callback(self):
+        """Test that `callback` is repeated with a new request if it returns None."""
+        async def callback(_response, *_):
+            return _response
+
+        self.bot.http_session.request = AsyncMock(side_effect=(None, "Valid response"))
+        response = await services._attempt_request("url", 2, callback=callback)
+
+        self.assertEqual("Valid response", response)
+        self.assertEqual(2, self.bot.http_session.request.call_count)
+
+    async def test_catch_exceptions(self):
+        """Test that all exceptions are caught and return None."""
+        self.bot.http_session.request = AsyncMock(side_effect=Exception("Mock exception"))
+
+        with self.assertLogs(services.log, logging.ERROR):
+            response = await services._attempt_request("url", 1)
+            self.assertIsNone(response)
+
+    async def test_callback_error(self):
+        """Test that callback is repeated with a new request if it raises an error."""
+        async def callback(_response, *_):
+            return _response()
+
+        responses = (
+            MagicMock(side_effect=Exception("Mock exception")),
+            MagicMock(return_value="Valid return"),
+        )
+        self.bot.http_session.request = AsyncMock(side_effect=responses)
+
+        response = await services._attempt_request("url", len(responses), callback=callback)
+
+        self.assertEqual(len(responses), self.bot.http_session.request.call_count)
+
+        self.assertEqual("Valid return", response, "The function did not return the correct output from the callback.")
+        for request_response in responses:
+            request_response.assert_called_once()
 
 
 class PasteTests(unittest.IsolatedAsyncioTestCase):
+    """Test the core logic of the paste service."""
+
     def setUp(self) -> None:
         patcher = patch("bot.instance", new=MockBot())
         self.bot = patcher.start()
@@ -18,18 +132,20 @@ class PasteTests(unittest.IsolatedAsyncioTestCase):
         self.bot.http_session.request = AsyncMock()
 
     @patch("bot.utils.services.URLs.paste_service", "https://paste_service.com/{key}")
-    async def test_url_and_sent_contents(self):
+    @autospec(services, "_attempt_request", pass_mocks=True)
+    async def test_url_and_sent_contents(self, attempt_request: MagicMock):
         """Correct url was used and post was called with expected data."""
-        response = MagicMock(
-            json=AsyncMock(return_value={"key": ""})
-        )
-        self.bot.http_session.request.return_value = response
-        self.bot.http_session.request.reset_mock()
-        await send_to_paste_service("Content")
-        self.bot.http_session.request.assert_called_once_with(
-            aiohttp.hdrs.METH_POST,
-            "https://paste_service.com/documents",
-            data="Content"
+        await services.send_to_paste_service("Content")
+
+        attempt_request.assert_called_once()
+        call = attempt_request.mock_calls[0]
+
+        args = ("https://paste_service.com/documents", services.FAILED_REQUEST_ATTEMPTS)
+        self.assertEqual(args, call.args, "Request function called with incorrect arguments.")
+        self.assertEqual("Content", call.kwargs["data"], "Expected data kwargs to be set to `Content`.")
+        self.assertTrue(
+            asyncio.iscoroutinefunction(call.kwargs["callback"]),
+            "Callback was expected to be an async function."
         )
 
     @patch("bot.utils.services.URLs.paste_service", "https://paste_service.com/{key}")
@@ -41,44 +157,29 @@ class PasteTests(unittest.IsolatedAsyncioTestCase):
             (f"https://paste_service.com/{key}.py", "py"),
             (f"https://paste_service.com/{key}?noredirect", ""),
         )
-        response = AsyncMock(
-            json=AsyncMock(return_value={"key": key})
-        )
-        self.bot.http_session.request.return_value = response
+        self.bot.http_session.request.return_value = AsyncMock(json=AsyncMock(return_value={"key": key}))
 
         for expected_output, extension in test_cases:
             with self.subTest(msg=f"Send contents with extension {repr(extension)}"):
                 self.assertEqual(
-                    await send_to_paste_service("", extension=extension),
+                    await services.send_to_paste_service("", extension=extension),
                     expected_output
                 )
 
-    async def test_request_repeated_on_json_errors(self):
-        """Json with error message and invalid json are handled as errors and requests repeated."""
+    @autospec(services, "_attempt_request", pass_mocks=True)
+    async def test_request_repeated_on_json_errors(self, attempt_request: MagicMock):
+        """If the paste service returns an error, the callback will return None to repeat the request."""
+        # Get the callback which contains the logic that handles the responses
+        await services.send_to_paste_service("")
+        callback = attempt_request.mock_calls[0].kwargs["callback"]
+
         test_cases = ({"message": "error"}, {"unexpected_key": None}, {})
-        self.bot.http_session.request.return_value = response = AsyncMock()
-        self.bot.http_session.request.reset_mock()
 
         for error_json in test_cases:
             with self.subTest(error_json=error_json):
-                response.json = AsyncMock(return_value=error_json)
-                result = await send_to_paste_service("")
-                self.assertEqual(self.bot.http_session.request.call_count, FAILED_REQUEST_ATTEMPTS)
-                self.assertIsNone(result)
-
-            self.bot.http_session.request.reset_mock()
-
-    async def test_request_repeated_on_connection_errors(self):
-        """Requests are repeated in the case of connection errors."""
-        self.bot.http_session.request = MagicMock(side_effect=ClientConnectorError(Mock(), Mock()))
-        result = await send_to_paste_service("")
-        self.assertEqual(self.bot.http_session.request.call_count, FAILED_REQUEST_ATTEMPTS)
-        self.assertIsNone(result)
-
-    async def test_general_error_handled_and_request_repeated(self):
-        """All `Exception`s are handled, logged and request repeated."""
-        self.bot.http_session.request = MagicMock(side_effect=Exception)
-        result = await send_to_paste_service("")
-        self.assertEqual(self.bot.http_session.request.call_count, FAILED_REQUEST_ATTEMPTS)
-        self.assertLogs("bot.utils", logging.ERROR)
-        self.assertIsNone(result)
+                with self.assertLogs(services.log, logging.WARNING):
+                    response = AsyncMock(json=AsyncMock(return_value=error_json))
+                    self.assertIsNone(
+                        await callback(response, Mock(), Mock()),
+                        "Callback expected to return None on failure, to repeat request."
+                    )

--- a/tests/bot/utils/test_services.py
+++ b/tests/bot/utils/test_services.py
@@ -327,7 +327,7 @@ class UnfurlTests(unittest.IsolatedAsyncioTestCase):
         data = {
             "destination": "",
             "depth": 1,
-            "expiry": (datetime.datetime.utcnow() + datetime.timedelta(hours=1)).isoformat()
+            "expiry": (datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(hours=1)).isoformat()
         }
         await services.UNFURL_CACHE.set("url", json.dumps(data))
         result = await services.unfurl_url("url", use_cache=True)
@@ -342,7 +342,7 @@ class UnfurlTests(unittest.IsolatedAsyncioTestCase):
             "depth": 1,
         }
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
         expired_hit = (now - datetime.timedelta(minutes=10)).isoformat()  # 10 minutes ago
         unexpired_hit = (now + datetime.timedelta(minutes=10)).isoformat()  # 10 minutes from now
 

--- a/tests/bot/utils/test_services.py
+++ b/tests/bot/utils/test_services.py
@@ -2,6 +2,7 @@ import logging
 import unittest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+import aiohttp.hdrs
 from aiohttp import ClientConnectorError
 
 from bot.utils.services import FAILED_REQUEST_ATTEMPTS, send_to_paste_service
@@ -14,16 +15,22 @@ class PasteTests(unittest.IsolatedAsyncioTestCase):
         self.bot = patcher.start()
         self.addCleanup(patcher.stop)
 
+        self.bot.http_session.request = AsyncMock()
+
     @patch("bot.utils.services.URLs.paste_service", "https://paste_service.com/{key}")
     async def test_url_and_sent_contents(self):
         """Correct url was used and post was called with expected data."""
         response = MagicMock(
             json=AsyncMock(return_value={"key": ""})
         )
-        self.bot.http_session.post.return_value.__aenter__.return_value = response
-        self.bot.http_session.post.reset_mock()
+        self.bot.http_session.request.return_value = response
+        self.bot.http_session.request.reset_mock()
         await send_to_paste_service("Content")
-        self.bot.http_session.post.assert_called_once_with("https://paste_service.com/documents", data="Content")
+        self.bot.http_session.request.assert_called_once_with(
+            aiohttp.hdrs.METH_POST,
+            "https://paste_service.com/documents",
+            data="Content"
+        )
 
     @patch("bot.utils.services.URLs.paste_service", "https://paste_service.com/{key}")
     async def test_paste_returns_correct_url_on_success(self):
@@ -34,10 +41,10 @@ class PasteTests(unittest.IsolatedAsyncioTestCase):
             (f"https://paste_service.com/{key}.py", "py"),
             (f"https://paste_service.com/{key}?noredirect", ""),
         )
-        response = MagicMock(
+        response = AsyncMock(
             json=AsyncMock(return_value={"key": key})
         )
-        self.bot.http_session.post.return_value.__aenter__.return_value = response
+        self.bot.http_session.request.return_value = response
 
         for expected_output, extension in test_cases:
             with self.subTest(msg=f"Send contents with extension {repr(extension)}"):
@@ -49,29 +56,29 @@ class PasteTests(unittest.IsolatedAsyncioTestCase):
     async def test_request_repeated_on_json_errors(self):
         """Json with error message and invalid json are handled as errors and requests repeated."""
         test_cases = ({"message": "error"}, {"unexpected_key": None}, {})
-        self.bot.http_session.post.return_value.__aenter__.return_value = response = MagicMock()
-        self.bot.http_session.post.reset_mock()
+        self.bot.http_session.request.return_value = response = AsyncMock()
+        self.bot.http_session.request.reset_mock()
 
         for error_json in test_cases:
             with self.subTest(error_json=error_json):
                 response.json = AsyncMock(return_value=error_json)
                 result = await send_to_paste_service("")
-                self.assertEqual(self.bot.http_session.post.call_count, FAILED_REQUEST_ATTEMPTS)
+                self.assertEqual(self.bot.http_session.request.call_count, FAILED_REQUEST_ATTEMPTS)
                 self.assertIsNone(result)
 
-            self.bot.http_session.post.reset_mock()
+            self.bot.http_session.request.reset_mock()
 
     async def test_request_repeated_on_connection_errors(self):
         """Requests are repeated in the case of connection errors."""
-        self.bot.http_session.post = MagicMock(side_effect=ClientConnectorError(Mock(), Mock()))
+        self.bot.http_session.request = MagicMock(side_effect=ClientConnectorError(Mock(), Mock()))
         result = await send_to_paste_service("")
-        self.assertEqual(self.bot.http_session.post.call_count, FAILED_REQUEST_ATTEMPTS)
+        self.assertEqual(self.bot.http_session.request.call_count, FAILED_REQUEST_ATTEMPTS)
         self.assertIsNone(result)
 
     async def test_general_error_handled_and_request_repeated(self):
         """All `Exception`s are handled, logged and request repeated."""
-        self.bot.http_session.post = MagicMock(side_effect=Exception)
+        self.bot.http_session.request = MagicMock(side_effect=Exception)
         result = await send_to_paste_service("")
-        self.assertEqual(self.bot.http_session.post.call_count, FAILED_REQUEST_ATTEMPTS)
+        self.assertEqual(self.bot.http_session.request.call_count, FAILED_REQUEST_ATTEMPTS)
         self.assertLogs("bot.utils", logging.ERROR)
         self.assertIsNone(result)


### PR DESCRIPTION
Closes #1933.
- [x] Blocked by python-discord/workers#20.
- [x] Blocked by python-discord/site#625.

# Description
This PR implements the URL unfurling filter feature described in #1933. It adds a service to do so, the filtering logic, and a command. To prevent the filtering logic from being slow, and to handle the fact that this filter calls another filter, I've had to make modifications to the core filtering logic to allow for delayed processing and modified the alert logic to allow customization of the output.

I've also kaizened in a small change to remove `http` and `https` from URLs when being added to the filter lists, after a brief discussion in mod-meta.

See the next comment for the output of the command.