### PR TITLE
Disable File Logging By Default

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -685,6 +685,7 @@ class VideoPermission(metaclass=YAMLGetter):
 
 # Debug mode
 DEBUG_MODE: bool = _CONFIG_YAML["debug"] == "true"
+FILE_LOGS: bool = _CONFIG_YAML["file_logs"].lower() == "true"
 
 # Paths
 BOT_DIR = os.path.dirname(__file__)

--- a/bot/log.py
+++ b/bot/log.py
@@ -48,16 +48,17 @@ def setup() -> None:
     logging.addLevelName(TRACE_LEVEL, "TRACE")
     logging.setLoggerClass(CustomLogger)
 
+    root_log = get_logger()
+
     format_string = "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
     log_format = logging.Formatter(format_string)
 
-    log_file = Path("logs", "bot.log")
-    log_file.parent.mkdir(exist_ok=True)
-    file_handler = handlers.RotatingFileHandler(log_file, maxBytes=5242880, backupCount=7, encoding="utf8")
-    file_handler.setFormatter(log_format)
-
-    root_log = get_logger()
-    root_log.addHandler(file_handler)
+    if constants.FILE_LOGS:
+        log_file = Path("logs", "bot.log")
+        log_file.parent.mkdir(exist_ok=True)
+        file_handler = handlers.RotatingFileHandler(log_file, maxBytes=5242880, backupCount=7, encoding="utf8")
+        file_handler.setFormatter(log_format)
+        root_log.addHandler(file_handler)
 
     if "COLOREDLOGS_LEVEL_STYLES" not in os.environ:
         coloredlogs.DEFAULT_LEVEL_STYLES = {

--- a/config-default.yml
+++ b/config-default.yml
@@ -1,4 +1,5 @@
-debug: !ENV ["BOT_DEBUG", "true"]
+debug:     !ENV ["BOT_DEBUG", "true"]
+file_logs: !ENV ["FILE_LOGS", "false"]
 
 
 bot:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,6 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ./logs:/bot/logs
       - .:/bot:ro
     tty: true
     depends_on:


### PR DESCRIPTION
After a vote on discord, it appears almost no one uses file logging, except in exceptional circumstances. I changed the settings so file logging would be disabled by default, and remove the volume from the docker-compose to avoid any problems, and reduce the maintenance burden. I added an environment variable to enable it.

If someone really wants to use file logging, they still can, but it will no longer be the default, nor particularly convenient.