### PR TITLE
Deal with activity_blocks not being returned by site

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -422,7 +422,12 @@ class Information(Cog):
                 activity_output = "No activity"
         else:
             activity_output.append(user_activity["total_messages"] or "No messages")
-            activity_output.append(user_activity["activity_blocks"] or "No activity")
+
+            if (activity_blocks := user_activity.get("activity_blocks")) is not None:
+                # activity_blocks is not included in the response if the user has a lot of messages
+                activity_output.append(activity_blocks or "No activity")  # Special case when activity_blocks is 0.
+            else:
+                activity_output.append("Too many to count!")
 
             activity_output = "\n".join(
                 f"{name}: {metric}" for name, metric in zip(["Messages", "Activity blocks"], activity_output)

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -171,8 +171,12 @@ class VoiceGate(Cog):
             ),
             "total_messages": data["total_messages"] < GateConf.minimum_messages,
             "voice_banned": data["voice_banned"],
-            "activity_blocks": data["activity_blocks"] < GateConf.minimum_activity_blocks
         }
+        if activity_blocks := data.get("activity_blocks"):
+            # activity_blocks is not included in the response if the user has a lot of messages.
+            # Only check if the user has enough activity blocks if it is included.
+            checks["activity_blocks"] = activity_blocks < GateConf.minimum_activity_blocks
+
         failed = any(checks.values())
         failed_reasons = [MESSAGE_FIELD_MAP[key] for key, value in checks.items() if value is True]
         [self.bot.stats.incr(f"voice_gate.failed.{key}") for key, value in checks.items() if value is True]


### PR DESCRIPTION
We are planning to change metricity endpoints on site so that activcity_blocks are not returned if the user has more than 1000 messages. This is because the query to calculate those blocks can get expensive at a high message count.

To deal with this, both places activity_blocks are used has been changed to reflect this planned behaviour.

# Screenshots
0 activity
![image](https://user-images.githubusercontent.com/9753350/142915008-4931e214-d2e5-454f-b02d-731e1302fd2d.png)
Minimal activity
![image](https://user-images.githubusercontent.com/9753350/142915024-b57a89b9-8d54-46fe-a973-87f0e80e94c9.png)
Mocked no activity returned from site
![image](https://user-images.githubusercontent.com/9753350/142915086-38e75ec2-44cb-495b-9d8e-36118b620d6f.png)

