### PR TITLE
Use bright_green for "Currently Helping" DMs

### DIFF
--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -590,7 +590,7 @@ class HelpChannels(commands.Cog):
             embed = discord.Embed(
                 title="Currently Helping",
                 description=f"You're currently helping in {message.channel.mention}",
-                color=constants.Colours.soft_green,
+                color=constants.Colours.bright_green,
                 timestamp=message.created_at
             )
             embed.add_field(name="Conversation", value=f"[Jump to message]({message.jump_url})")


### PR DESCRIPTION
Closes #1977 by using the `bright_green` color for "Currently Helping" DM embeds.

(This is a replacement to #1978 after discussion in #dev-contrib.)