### PR TITLE
Limit the length of the invalid rule indices message

### DIFF
--- a/bot/exts/info/site.py
+++ b/bot/exts/info/site.py
@@ -125,7 +125,8 @@ class Site(Cog):
 
         # Remove duplicates and sort the rule indices
         rules = sorted(set(rules))
-        invalid = shorten(', '.join(str(index) for index in rules if index < 1 or index > len(full_rules)), 50)
+        invalid = shorten(', '.join(str(index) for index in rules if index
+                          < 1 or index > len(full_rules)), 50, placeholder='...')
 
         if invalid:
             await ctx.send(f":x: Invalid rule indices: {invalid}")

--- a/bot/exts/info/site.py
+++ b/bot/exts/info/site.py
@@ -1,3 +1,5 @@
+from textwrap import shorten
+
 from discord import Colour, Embed
 from discord.ext.commands import Cog, Context, Greedy, group
 
@@ -123,7 +125,7 @@ class Site(Cog):
 
         # Remove duplicates and sort the rule indices
         rules = sorted(set(rules))
-        invalid = ', '.join(str(index) for index in rules if index < 1 or index > len(full_rules))
+        invalid = shorten(', '.join(str(index) for index in rules if index < 1 or index > len(full_rules)), 50)
 
         if invalid:
             await ctx.send(f":x: Invalid rule indices: {invalid}")


### PR DESCRIPTION
This closes #1975, which shows that extremely long invalid rule indices errors, as shown below, throw an error if the message is long enough.

![image](https://i.imgur.com/vYbwLlF.png)

This PR limits the length of the invalid indices string to 50 characters to avoid errors like the one shown in Sentry.

![image](https://i.imgur.com/D6Tbu8o.png)