### PR TITLE
Small changes to invalid rule indices message shortening

### DIFF
--- a/bot/exts/info/site.py
+++ b/bot/exts/info/site.py
@@ -125,11 +125,11 @@ class Site(Cog):
 
         # Remove duplicates and sort the rule indices
         rules = sorted(set(rules))
-        invalid = shorten(', '.join(str(index) for index in rules if index
-                          < 1 or index > len(full_rules)), 50, placeholder=' ...')
+
+        invalid = ', '.join(str(index) for index in rules if index < 1 or index > len(full_rules))
 
         if invalid:
-            await ctx.send(f":x: Invalid rule indices: {invalid}")
+            await ctx.send(shorten(":x: Invalid rule indices: " + invalid, 75, placeholder=' ...'))
             return
 
         for rule in rules:

--- a/bot/exts/info/site.py
+++ b/bot/exts/info/site.py
@@ -126,7 +126,7 @@ class Site(Cog):
         # Remove duplicates and sort the rule indices
         rules = sorted(set(rules))
         invalid = shorten(', '.join(str(index) for index in rules if index
-                          < 1 or index > len(full_rules)), 50, placeholder='...')
+                          < 1 or index > len(full_rules)), 50, placeholder=' ...')
 
         if invalid:
             await ctx.send(f":x: Invalid rule indices: {invalid}")


### PR DESCRIPTION
This is a quick visual fix to add onto #1980. It adds a space before the ellipsis in the placeholder.

![image](https://i.imgur.com/5r7b3c1.png)