### PR TITLE
Redirect subscribe command output to bot commands

### DIFF
--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -165,7 +165,9 @@ class Subscribe(commands.Cog):
                     name=discord_role.name,
                 )
             )
-        # Sort unavailable roles to the end of the list
+
+        # Sort by role name, then shift unavailable roles to the end of the list
+        self.assignable_roles.sort(key=operator.attrgetter("name"))
         self.assignable_roles.sort(key=operator.methodcaller("is_currently_available"), reverse=True)
 
     @commands.cooldown(1, 10, commands.BucketType.member)


### PR DESCRIPTION
Instead of silently failing in channels other than bot commands for non-staff, the bot now instead redirects the command output to bot commands and pings the user.

To facilitate this, I had to change the ctx.reply to a ctx.send since the invocation message may be in a different channel.

This shows the output from the command when ran in bot-commands and then below is the output if the user runs the command from another channel.
![image](https://user-images.githubusercontent.com/9753350/144326713-92884e57-120a-498a-be82-589d65ae5abc.png)
