### PR TITLE
remove default thread archive time 

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -699,11 +699,6 @@ class ThreadArchiveTimes(Enum):
 DEBUG_MODE: bool = _CONFIG_YAML["debug"] == "true"
 FILE_LOGS: bool = _CONFIG_YAML["file_logs"].lower() == "true"
 
-if DEBUG_MODE:
-    DEFAULT_THREAD_ARCHIVE_TIME = ThreadArchiveTimes.HOUR.value
-else:
-    DEFAULT_THREAD_ARCHIVE_TIME = ThreadArchiveTimes.WEEK.value
-
 # Paths
 BOT_DIR = os.path.dirname(__file__)
 PROJECT_ROOT = os.path.abspath(os.path.join(BOT_DIR, os.pardir))

--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -15,7 +15,7 @@ from discord.ext.commands import Context
 
 from bot.api import ResponseCodeError
 from bot.bot import Bot
-from bot.constants import Channels, Colours, DEFAULT_THREAD_ARCHIVE_TIME, Emojis, Guild, Roles
+from bot.constants import Channels, Colours, Emojis, Guild, Roles
 from bot.log import get_logger
 from bot.utils.members import get_or_fetch_member
 from bot.utils.messages import count_unique_users_reaction, pin_no_system_message
@@ -96,7 +96,6 @@ class Reviewer:
 
         thread = await last_message.create_thread(
             name=f"Nomination - {nominee}",
-            auto_archive_duration=DEFAULT_THREAD_ARCHIVE_TIME
         )
         await thread.send(fr"<@&{Roles.mod_team}> <@&{Roles.admins}>")
 


### PR DESCRIPTION
discord.py and discord support this, so future threads will be created with the default of the channel


 *approved on discord by chrisjl https://canary.discord.com/channels/267624335836053506/635950537262759947/916037358334382121*