### PR TITLE
Patch d.py's message convertor to infer channelID from the given context

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -18,6 +18,11 @@ if os.name == "nt":
 
 monkey_patches.patch_typing()
 
+# This patches any convertors that use PartialMessage, but not the PartialMessageConverter itself
+# as library objects are made by this mapping.
+# https://github.com/Rapptz/discord.py/blob/1a4e73d59932cdbe7bf2c281f25e32529fc7ae1f/discord/ext/commands/converter.py#L984-L1004
+commands.converter.PartialMessageConverter = monkey_patches.FixedPartialMessageConverter
+
 # Monkey-patch discord.py decorators to use the Command subclass which supports root aliases.
 # Must be patched before any cogs are added.
 commands.command = partial(commands.command, cls=monkey_patches.Command)

--- a/bot/utils/regex.py
+++ b/bot/utils/regex.py
@@ -12,3 +12,4 @@ INVITE_RE = re.compile(
     r"(?P<invite>[a-zA-Z0-9\-]+)",                # the invite code itself
     flags=re.IGNORECASE
 )
+MESSAGE_ID_RE = re.compile(r'(?P<message_id>[0-9]{15,20})$')


### PR DESCRIPTION
Discord.py's Message convertor is supposed to infer channelID based on ctx.channel if only a messageID is given. A 'refactor' (linked below) a few weeks before d.py's archival broke this, so that if only a messageID is given to the convertor, it will only find that message if it's in the bot's cache.