### PR TITLE
Attempt to fetch un-cached nomination threads on archive

### DIFF
--- a/bot/exts/recruitment/talentpool/_review.py
+++ b/bot/exts/recruitment/talentpool/_review.py
@@ -217,8 +217,11 @@ class Reviewer:
         # Thread channel IDs are the same as the message ID of the parent message.
         nomination_thread = message.guild.get_thread(message.id)
         if not nomination_thread:
-            log.warning(f"Could not find a thread linked to {message.channel.id}-{message.id}")
-            return
+            try:
+                nomination_thread = await message.guild.fetch_channel(message.id)
+            except NotFound:
+                log.warning(f"Could not find a thread linked to {message.channel.id}-{message.id}")
+                return
 
         for message_ in messages:
             with contextlib.suppress(NotFound):


### PR DESCRIPTION
Fixes BOT-1R0
Fixes #1992

The time between a vote passing and the helper being helpered can sometimes be >7 days, meaning the thread may have auto-archived by then.

We should deal with this by trying to fetch the threead from the API if it's not cached.