### PR TITLE
fix: parse whitespace out of pep titles

### DIFF
--- a/bot/exts/info/pep.py
+++ b/bot/exts/info/pep.py
@@ -97,9 +97,12 @@ class PythonEnhancementProposals(Cog):
 
     def generate_pep_embed(self, pep_header: Dict, pep_nr: int) -> Embed:
         """Generate PEP embed based on PEP headers data."""
+        # the parsed header can be wrapped to multiple lines, so we need to make sure that is removed
+        # for an example of a pep with this issue, see pep 500
+        title = " ".join(pep_header["Title"].split())
         # Assemble the embed
         pep_embed = Embed(
-            title=f"**PEP {pep_nr} - {pep_header['Title']}**",
+            title=f"**PEP {pep_nr} - {title}**",
             description=f"[Link]({BASE_PEP_URL}{pep_nr:04})",
         )
 


### PR DESCRIPTION
Remove excess whitespace from pep titles

Approved on discord by lemon: https://canary.discord.com/channels/267624335836053506/635950537262759947/917205865436692541

#### OLD:
![image](https://user-images.githubusercontent.com/71233171/144769878-82760dc4-1d96-4312-b71a-c56c24d9fa8f.png)

#### NEW:
![image](https://user-images.githubusercontent.com/71233171/144769907-3a9a02b1-44cd-4c82-a648-feada7323646.png)
