### PR TITLE
Make snekbox url an env var

### DIFF
--- a/config-default.yml
+++ b/config-default.yml
@@ -377,7 +377,7 @@ urls:
     site_logs_view:                     !JOIN [*STAFF, "/bot/logs"]
 
     # Snekbox
-    snekbox_eval_api: "http://snekbox.default.svc.cluster.local/eval"
+    snekbox_eval_api: !ENV ["SNEKBOX_EVAL_API", "http://snekbox.default.svc.cluster.local/eval"]
 
     # Discord API URLs
     discord_api:        &DISCORD_API "https://discordapp.com/api/v7/"


### PR DESCRIPTION
An issue with snekbox in our cluster has meant that we want to send requests to an external service temporarily while we get this fixed.

Making this an env var means we can change this whenever needed in future without leaking the external service's url.