### PR TITLE
Remove deprecated server voice region

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -174,7 +174,6 @@ class Information(Cog):
         embed = Embed(colour=Colour.og_blurple(), title="Server Information")
 
         created = discord_timestamp(ctx.guild.created_at, TimestampFormats.RELATIVE)
-        region = ctx.guild.region
         num_roles = len(ctx.guild.roles) - 1  # Exclude @everyone
 
         # Server Features are only useful in certain channels
@@ -199,7 +198,6 @@ class Information(Cog):
 
         embed.description = (
             f"Created: {created}"
-            f"\nVoice region: {region}"
             f"{features}"
             f"\nRoles: {num_roles}"
             f"\nMember status: {member_status}"


### PR DESCRIPTION
Discord's current model for voice regions is setting it per server. Hence, the "Voice region" section in the server info tag will always display as "deprecated". This pull request removes it.