### PR TITLE
Modpings Improvements

### DIFF
--- a/bot/converters.py
+++ b/bot/converters.py
@@ -576,12 +576,12 @@ class Infraction(Converter):
 
 class DayDuration(Converter):
     """
-    Convert a string representing day time (hours and minutes) to an UTC datetime object.
+    Convert a string representing day time (hours and minutes) to a UTC datetime object.
 
-    The hours and mintues would be combined with UTC day, if no 'am' or 'pm' is passed with
+    The hours and minutes would be combined with UTC day if no 'am' or 'pm' is passed with
     the string, then it is assumed that the time is in 24 hour format.
 
-    The following formats are excepted:
+    The following formats are accepted:
         - H:M
         - H:M am/pm
         - H am/pm

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -641,6 +641,7 @@ if t.TYPE_CHECKING:
     UnambiguousUser = discord.User  # noqa: F811
     UnambiguousMember = discord.Member  # noqa: F811
     Infraction = t.Optional[dict]  # noqa: F811
+    DayDuration = datetime  # noqa: F811
 
 Expiry = t.Union[Duration, ISODateTime]
 MemberOrUser = t.Union[discord.Member, discord.User]

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -578,7 +578,7 @@ class DayDuration(Converter):
     """
     Convert a string representing day time (hours and minutes) to a UTC datetime object.
 
-    The hours and minutes would be combined with UTC day if no 'am' or 'pm' is passed with
+    The hours and minutes would be combined with UTC day. If no 'am' or 'pm' is passed with
     the string, then it is assumed that the time is in 24 hour format.
 
     The following formats are accepted:
@@ -598,7 +598,7 @@ class DayDuration(Converter):
     )
 
     async def convert(self, _ctx: Context, argument: str) -> datetime:
-        """Attempts to converting `argument` to an UTC datetime object."""
+        """Attempts to convert `argument` to a UTC datetime object."""
         match = self.TIME_RE.fullmatch(argument)
         if not match:
             raise BadArgument(f"`{argument}` is not a valid time duration string.")

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -583,8 +583,9 @@ class DayDuration(Converter):
 
     The following formats are accepted:
         - H:M
-        - H:M am/pm
-        - H am/pm
+        - H:Mam/pm
+        - HMam/pm
+        - Ham/pm
         - H
 
     where `H` represents Hours and `M` represents Minutes.
@@ -598,11 +599,11 @@ class DayDuration(Converter):
 
     async def convert(self, _ctx: Context, argument: str) -> datetime:
         """Attempts to converting `argument` to an UTC datetime object."""
-        match = self.TIME_RE.fullmatch(argument).groups()
+        match = self.TIME_RE.fullmatch(argument)
         if not match:
             raise BadArgument(f"`{argument}` is not a valid time duration string.")
 
-        hour_12, minute_12, meridiem, hour_24, minute_24 = match
+        hour_12, minute_12, meridiem, hour_24, minute_24 = match.groups()
         time = None
 
         if hour_12 and meridiem and minute_12:

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -90,7 +90,7 @@ class ModPings(Cog):
             mod = await get_or_fetch_member(guild, mod_id)
             if not mod:
                 log.info(
-                    f"I tried to get moderator with ID `{mod_id}`, but they don't appear to be on the server :pensive:"
+                    f"I tried to get moderator with ID `{mod_id}`, but they don't appear to be on the server 😔"
                 )
                 continue
 
@@ -218,7 +218,7 @@ class ModPings(Cog):
     @has_any_role(*MODERATION_ROLES)
     async def schedule_modpings(self, ctx: Context, start: DayDuration, end: DayDuration) -> None:
         """
-        Schedule modpings role to be added at <start> and removed at <end> everyday at UTC time!
+        Schedule modpings role to be added at <start> and removed at <end> every day at UTC!
 
         You can have the modpings role off for a maximum of 16 hours i.e. having the modpings role
         on for a minimum of 8 hours in a day.

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -12,6 +12,7 @@ from bot.constants import Colours, Emojis, Guild, Icons, MODERATION_ROLES, Roles
 from bot.converters import DayDuration, Expiry
 from bot.log import get_logger
 from bot.utils import scheduling
+from bot.utils.members import get_or_fetch_member
 from bot.utils.scheduling import Scheduler
 from bot.utils.time import TimestampFormats, discord_timestamp
 
@@ -85,7 +86,14 @@ class ModPings(Cog):
             start_timestamp, work_time = schedule.split("|")
             start = datetime.datetime.fromtimestamp(float(start_timestamp))
 
-            mod = await self.bot.fetch_user(mod_id)
+            guild = self.bot.get_guild(Guild.id)
+            mod = await get_or_fetch_member(guild, mod_id)
+            if not mod:
+                log.info(
+                    f"I tried to get moderator with ID `{mod_id}`, but they don't appear to be on the server :pensive:"
+                )
+                continue
+
             self._modpings_scheduler.schedule_at(
                 start,
                 mod_id,

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -17,7 +17,7 @@ from bot.utils.time import TimestampFormats, discord_timestamp
 
 log = get_logger(__name__)
 
-MAXIMUM_WORK_LIMIT = 16
+MAXIMUM_WORK_OFF_LIMIT = 16
 
 
 class ModPings(Cog):
@@ -201,15 +201,13 @@ class ModPings(Cog):
     @has_any_role(*MODERATION_ROLES)
     async def schedule_modpings(self, ctx: Context, start: DayDuration, end: DayDuration) -> None:
         """Schedule modpings role to be added at <start> and removed at <end> everyday at UTC time!"""
-        print(start, end)
-
         if end < start:
             end += datetime.timedelta(days=1)
 
-        if (end - start) > datetime.timedelta(hours=MAXIMUM_WORK_LIMIT):
+        if datetime.timedelta(hours=24) - (end - start) > datetime.timedelta(hours=MAXIMUM_WORK_OFF_LIMIT):
             await ctx.send(
-                f":x: {ctx.author.mention} You can't have the modpings role for"
-                f" more than {MAXIMUM_WORK_LIMIT} hours!"
+                f":x: {ctx.author.mention} You can't have the modpings role off for"
+                f" more than {MAXIMUM_WORK_OFF_LIMIT} hours!"
             )
             return
 

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -223,7 +223,7 @@ class ModPings(Cog):
         You can have the modpings role off for a maximum of 16 hours i.e. having the modpings role
         on for a minimum of 8 hours in a day.
 
-        The command excepts two arguments `start` and `end` which represent hour and minute of a day,
+        The command expects two arguments `start` and `end` which represent hour and minute of a day,
         you would get the modpings role at `start` and it would removed from you at `end`. `start` and
         `end` can be in the following formats:
             - H:Mam/pm (10:14pm)
@@ -238,7 +238,9 @@ class ModPings(Cog):
         if end < start:
             end += datetime.timedelta(days=1)
 
-        if datetime.timedelta(hours=24) - (end - start) > datetime.timedelta(hours=MAXIMUM_WORK_OFF_LIMIT):
+        modpings_on_period = end - start
+        # Check if the modpings off period for a day is more than the max
+        if datetime.timedelta(hours=24) - modpings_on_period > datetime.timedelta(hours=MAXIMUM_WORK_OFF_LIMIT):
             await ctx.send(
                 f":x: {ctx.author.mention} You can't have the modpings role off for"
                 f" more than {MAXIMUM_WORK_OFF_LIMIT} hours!"

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -89,9 +89,7 @@ class ModPings(Cog):
             guild = self.bot.get_guild(Guild.id)
             mod = await get_or_fetch_member(guild, mod_id)
             if not mod:
-                log.info(
-                    f"I tried to get moderator with ID `{mod_id}`, but they don't appear to be on the server 😔"
-                )
+                log.warning(f"I tried to get moderator with ID `{mod_id}`, but they don't appear to be on the server 😔")
                 continue
 
             self._modpings_scheduler.schedule_at(

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -3,13 +3,13 @@ import datetime
 
 import arrow
 from async_rediscache import RedisCache
-from dateutil.parser import isoparse, parse as dateutil_parse
+from dateutil.parser import isoparse
 from discord import Embed, Member
 from discord.ext.commands import Cog, Context, group, has_any_role
 
 from bot.bot import Bot
 from bot.constants import Colours, Emojis, Guild, Icons, MODERATION_ROLES, Roles
-from bot.converters import Expiry
+from bot.converters import DayDuration, Expiry
 from bot.log import get_logger
 from bot.utils import scheduling
 from bot.utils.scheduling import Scheduler
@@ -199,9 +199,9 @@ class ModPings(Cog):
         invoke_without_command=True
     )
     @has_any_role(*MODERATION_ROLES)
-    async def schedule_modpings(self, ctx: Context, start: str, end: str) -> None:
+    async def schedule_modpings(self, ctx: Context, start: DayDuration, end: DayDuration) -> None:
         """Schedule modpings role to be added at <start> and removed at <end> everyday at UTC time!"""
-        start, end = dateutil_parse(start), dateutil_parse(end)
+        print(start, end)
 
         if end < start:
             end += datetime.timedelta(days=1)

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -124,6 +124,15 @@ class ModPings(Cog):
 
     async def reapply_role(self, mod: Member) -> None:
         """Reapply the moderator's role to the given moderator."""
+        mod_schedule = self.modpings_schedule.get(mod.id)
+        if (
+            mod_schedule
+            and datetime.datetime.utcnow()
+            < datetime.datetime.utcfromtimestamp(mod_schedule.split("|")[0])
+        ):
+            log.trace(f"Skipping re-applying role to mod with ID {mod.id} as their modpings schedule is over.")
+            return
+
         log.trace(f"Re-applying role to mod with ID {mod.id}.")
         await mod.add_roles(self.moderators_role, reason="Pings off period expired.")
         await self.pings_off_mods.delete(mod.id)

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -200,7 +200,24 @@ class ModPings(Cog):
     )
     @has_any_role(*MODERATION_ROLES)
     async def schedule_modpings(self, ctx: Context, start: DayDuration, end: DayDuration) -> None:
-        """Schedule modpings role to be added at <start> and removed at <end> everyday at UTC time!"""
+        """
+        Schedule modpings role to be added at <start> and removed at <end> everyday at UTC time!
+
+        You can have the modpings role off for a maximum of 16 hours i.e. having the modpings role
+        on for a minimum of 8 hours in a day.
+
+        The command excepts two arguments `start` and `end` which represent hour and minute of a day,
+        you would get the modpings role at `start` and it would removed from you at `end`. `start` and
+        `end` can be in the following formats:
+            - H:Mam/pm (10:14pm)
+            - HMam/pm (1014pm)
+            - Ham/pm (10pm)
+            - H (22 - 24hour format as no meridiem is specified)
+            - HM (2214 - 24hour format as no meridiem is specified)
+
+        If a moderator has scheduled temporarily removed modpings role and its time for their modpings
+        schedule start, the off would take higher priority and the modpings role won't be added for them.
+        """
         if end < start:
             end += datetime.timedelta(days=1)
 

--- a/bot/exts/moderation/modpings.py
+++ b/bot/exts/moderation/modpings.py
@@ -218,22 +218,20 @@ class ModPings(Cog):
     @has_any_role(*MODERATION_ROLES)
     async def schedule_modpings(self, ctx: Context, start: DayDuration, end: DayDuration) -> None:
         """
-        Schedule modpings role to be added at <start> and removed at <end> every day at UTC!
+        Schedule modpings role to be added at <start> and removed at <end> every day (UTC time)!
 
-        You can have the modpings role off for a maximum of 16 hours i.e. having the modpings role
-        on for a minimum of 8 hours in a day.
+        You must have the pingable Moderators role for a minimum of 8 hours a day,
+        meaning the schedule removing this role has a maximum duration of 16 hours.
+         The command expects two arguments, `start` and `end`, which are when the role is removed and re-added.
 
-        The command expects two arguments `start` and `end` which represent hour and minute of a day,
-        you would get the modpings role at `start` and it would removed from you at `end`. `start` and
-        `end` can be in the following formats:
+        The following formats are accepted for `start` and `end`:
             - H:Mam/pm (10:14pm)
             - HMam/pm (1014pm)
             - Ham/pm (10pm)
             - H (22 - 24hour format as no meridiem is specified)
             - HM (2214 - 24hour format as no meridiem is specified)
 
-        If a moderator has scheduled temporarily removed modpings role and its time for their modpings
-        schedule start, the off would take higher priority and the modpings role won't be added for them.
+        The pingable Moderators role won't be re-added until the scheduled time has finished.
         """
         if end < start:
             end += datetime.timedelta(days=1)


### PR DESCRIPTION
Fixes BOT-1RG
Fixes BOT-1RD

Closes #2002 
Closes #2003 

### Changes:

- Add a better datetime converter that allows passing time in 12/24 hour format, the previous method of parsing `start` and `end` time is removed (`8h`, `16h`, etc).
- If your modpings schedule is over and you even had a modpings off which got over in modpings off time period, the role won't be added to you as your schedule is over.
- Make `modpings schedule` message more verbose.

### Fixes:

- Make `16` hours as the max off time i.e. make `8` hours the minimum on time.
- Since discord.py moved to timezone aware datetimes, the discord timestamp converter failed, therefore giving no confirmation message, this has now been fixed.
- `add_roles` is a method on a member object, thus calling `add_roles` on a user object would fail, this has now been fixed and it uses `get_or_fetch_member` utility function.