### PR TITLE
chore: ensure the docs command will look good on later versions of markdownify

### DIFF
--- a/bot/exts/info/doc/_markdown.py
+++ b/bot/exts/info/doc/_markdown.py
@@ -56,3 +56,11 @@ class DocMarkdownConverter(MarkdownConverter):
         if parent is not None and parent.name == "li":
             return f"{text}\n"
         return super().convert_p(el, text, convert_as_inline)
+
+    def convert_hr(self, el: PageElement, text: str, convert_as_inline: bool) -> str:
+        """
+        Convert hr tags to an empty string.
+
+        Later versions of markdownify added this method, but discord markdown does not support headers.
+        """
+        return ""


### PR DESCRIPTION
…rkdownify

as of markdownify 0.7.1 it now converts hr tags natively
however, what it converts to is not supported by discord markdown
to get around this, we just return an empty string, as per current behavior

Current behavior:
![image](https://user-images.githubusercontent.com/71233171/146139623-f9f93b56-1c9d-4c96-a067-85b786068009.png)


Newer version of markdownify
![image](https://user-images.githubusercontent.com/71233171/146139550-f7b89856-5687-428f-9129-12a6fc16775d.png)

With the patch:
![image](https://user-images.githubusercontent.com/71233171/146139670-1527da5d-c36d-43b4-8369-18aa9976e068.png)


Offending diff:
https://github.com/matthewwithanm/python-markdownify/compare/0.7.0...0.7.1