### PR TITLE
Try an exact match with only the name when a tag with a group is searched

### DIFF
--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -275,6 +275,11 @@ class Tags(Cog):
         ]
 
         tag = self.tags.get(tag_identifier)
+
+        if tag is None and tag_identifier.group is not None:
+            # Try exact match with only the name
+            tag = self.tags.get(TagIdentifier(None, tag_identifier.group))
+
         if tag is None and len(filtered_tags) == 1:
             tag_identifier = filtered_tags[0][0]
             tag = filtered_tags[0][1]


### PR DESCRIPTION
Currently, a tag is directly returned when it has an exact match even when there are matched fuzzy alternatives, but this does not attempt the exact match on only the name if the tag has a group.  This causes issues if the user invokes a tag with some text after it which is considered as the tag's name.

The PR adds an additional search with only the tag's name without a group when the first lookup of the original identifier fails