### PR TITLE
Add missing `bot` parameter to call

### DIFF
--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -170,7 +170,9 @@ class InfractionScheduler:
             dm_log_text = "\nDM: **Failed**"
 
             # Accordingly update whether the user was successfully notified via DM.
-            if await _utils.notify_infraction(user, infr_type.replace("_", " ").title(), expiry, user_reason, icon):
+            if await _utils.notify_infraction(
+                    ctx.bot, user, infr_type.replace("_", " ").title(), expiry, user_reason, icon
+            ):
                 dm_result = ":incoming_envelope: "
                 dm_log_text = "\nDM: Sent"
 


### PR DESCRIPTION
Fixes a bug in #1951.