### PR TITLE
Use custom clean cog when purge banning

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -445,6 +445,7 @@ class Channels(metaclass=YAMLGetter):
     incidents_archive: int
     mod_alerts: int
     mod_meta: int
+    mods: int
     nominations: int
     nomination_voting: int
     organisation: int

--- a/bot/decorators.py
+++ b/bot/decorators.py
@@ -188,7 +188,7 @@ def respect_role_hierarchy(member_arg: function.Argument) -> t.Callable:
     """
     def decorator(func: types.FunctionType) -> types.FunctionType:
         @command_wraps(func)
-        async def wrapper(*args, **kwargs) -> None:
+        async def wrapper(*args, **kwargs) -> t.Any:
             log.trace(f"{func.__name__}: respect role hierarchy decorator called")
 
             bound_args = function.get_bound_args(func, args, kwargs)
@@ -196,8 +196,7 @@ def respect_role_hierarchy(member_arg: function.Argument) -> t.Callable:
 
             if not isinstance(target, Member):
                 log.trace("The target is not a discord.Member; skipping role hierarchy check.")
-                await func(*args, **kwargs)
-                return
+                return await func(*args, **kwargs)
 
             ctx = function.get_arg_value(1, bound_args)
             cmd = ctx.command.name
@@ -214,7 +213,7 @@ def respect_role_hierarchy(member_arg: function.Argument) -> t.Callable:
                 )
             else:
                 log.trace(f"{func.__name__}: {target.top_role=} < {actor.top_role=}; calling func")
-                await func(*args, **kwargs)
+                return await func(*args, **kwargs)
         return wrapper
     return decorator
 

--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -380,6 +380,7 @@ class Clean(Cog):
         regex: Optional[re.Pattern] = None,
         first_limit: Optional[CleanLimit] = None,
         second_limit: Optional[CleanLimit] = None,
+        attempt_delete_invocation: bool = True,
     ) -> Optional[str]:
         """A helper function that does the actual message cleaning, returns the log url if logging was successful."""
         self._validate_input(channels, bots_only, users, first_limit, second_limit)
@@ -404,8 +405,9 @@ class Clean(Cog):
         # Needs to be called after standardizing the input.
         predicate = self._build_predicate(first_limit, second_limit, bots_only, users, regex)
 
-        # Delete the invocation first
-        await self._delete_invocation(ctx)
+        if attempt_delete_invocation:
+            # Delete the invocation first
+            await self._delete_invocation(ctx)
 
         if self._use_cache(first_limit):
             log.trace(f"Messages for cleaning by {ctx.author.id} will be searched in the cache.")

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -113,12 +113,14 @@ class Infractions(InfractionScheduler, commands.Cog):
         clean_cog: t.Optional[Clean] = self.bot.get_cog("Clean")
         if clean_cog is None:
             # If we can't get the clean cog, fall back to native purgeban.
-            await self.apply_ban(ctx, user, reason, 1, expires_at=duration)
+            await self.apply_ban(ctx, user, reason, purge_days=1, expires_at=duration)
             return
 
         infraction = await self.apply_ban(ctx, user, reason, expires_at=duration)
         if not infraction or not infraction.get("id"):
             # Ban was unsuccessful, quit early.
+            await ctx.send(":x: Failed to apply ban.")
+            log.error("Failed to apply ban to user %d", user.id)
             return
 
         # Calling commands directly skips Discord.py's convertors, so we need to convert args manually.

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -96,8 +96,8 @@ class Infractions(InfractionScheduler, commands.Cog):
         """
         await self.apply_ban(ctx, user, reason, expires_at=duration)
 
-    @command(aliases=('pban',))
-    async def purgeban(
+    @command(aliases=("cban", "purgeban", "pban"))
+    async def cleanban(
         self,
         ctx: Context,
         user: UnambiguousMemberOrUser,

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -132,6 +132,9 @@ class Infractions(InfractionScheduler, commands.Cog):
             first_limit=clean_time,
             attempt_delete_invocation=False,
         )
+        if not log_url:
+            # Cleaning failed, or there were no messages to clean, exit early.
+            return
 
         infr_manage_cog: t.Optional[ModManagement] = self.bot.get_cog("ModManagement")
         if infr_manage_cog is None:

--- a/tests/bot/exts/moderation/infraction/test_infractions.py
+++ b/tests/bot/exts/moderation/infraction/test_infractions.py
@@ -253,6 +253,7 @@ class CleanBanTests(unittest.IsolatedAsyncioTestCase):
         self.clean_cog._clean_messages = AsyncMock(return_value=self.log_url)
 
     def mock_get_cog(self, enable_clean, enable_manage):
+        """Mock get cog factory that allows the user to specify whether clean and manage cogs are enabled."""
         def inner(name):
             if name == "ModManagement":
                 return self.management_cog if enable_manage else None

--- a/tests/bot/exts/moderation/infraction/test_infractions.py
+++ b/tests/bot/exts/moderation/infraction/test_infractions.py
@@ -271,7 +271,7 @@ class CleanBanTests(unittest.IsolatedAsyncioTestCase):
             self.ctx,
             self.user,
             "FooBar",
-            1,
+            purge_days=1,
             expires_at=None,
         )
 

--- a/tests/bot/exts/moderation/test_clean.py
+++ b/tests/bot/exts/moderation/test_clean.py
@@ -1,0 +1,104 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bot.exts.moderation.clean import Clean
+from tests.helpers import MockBot, MockContext, MockGuild, MockMember, MockMessage, MockRole, MockTextChannel
+
+
+class CleanTests(unittest.IsolatedAsyncioTestCase):
+    """Tests for clean cog functionality."""
+
+    def setUp(self):
+        self.bot = MockBot()
+        self.mod = MockMember(roles=[MockRole(id=7890123, position=10)])
+        self.user = MockMember(roles=[MockRole(id=123456, position=1)])
+        self.guild = MockGuild()
+        self.ctx = MockContext(bot=self.bot, author=self.mod)
+        self.cog = Clean(self.bot)
+
+        self.log_url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+        self.cog._modlog_cleaned_messages = AsyncMock(return_value=self.log_url)
+
+        self.cog._use_cache = MagicMock(return_value=True)
+        self.cog._delete_found = AsyncMock(return_value=[42, 84])
+
+    @patch("bot.exts.moderation.clean.is_mod_channel")
+    async def test_clean_deletes_invocation_in_non_mod_channel(self, mod_channel_check):
+        """Clean command should delete the invocation message if ran in a non mod channel."""
+        mod_channel_check.return_value = False
+        self.ctx.message.delete = AsyncMock()
+
+        self.assertIsNone(await self.cog._delete_invocation(self.ctx))
+
+        self.ctx.message.delete.assert_awaited_once()
+
+    @patch("bot.exts.moderation.clean.is_mod_channel")
+    async def test_clean_doesnt_delete_invocation_in_mod_channel(self, mod_channel_check):
+        """Clean command should not delete the invocation message if ran in a mod channel."""
+        mod_channel_check.return_value = True
+        self.ctx.message.delete = AsyncMock()
+
+        self.assertIsNone(await self.cog._delete_invocation(self.ctx))
+
+        self.ctx.message.delete.assert_not_awaited()
+
+    async def test_clean_doesnt_attempt_deletion_when_attempt_delete_invocation_is_false(self):
+        """Clean command should not attempt to delete the invocation message if attempt_delete_invocation is false."""
+        self.cog._delete_invocation = AsyncMock()
+        self.bot.get_channel = MagicMock(return_value=False)
+
+        self.assertEqual(
+            await self.cog._clean_messages(
+                self.ctx,
+                None,
+                first_limit=MockMessage(),
+                attempt_delete_invocation=False,
+            ),
+            self.log_url,
+        )
+
+        self.cog._delete_invocation.assert_not_awaited()
+
+    @patch("bot.exts.moderation.clean.is_mod_channel")
+    async def test_clean_replies_with_success_message_when_ran_in_mod_channel(self, mod_channel_check):
+        """Clean command should reply to the message with a confirmation message if invoked in a mod channel."""
+        mod_channel_check.return_value = True
+        self.ctx.reply = AsyncMock()
+
+        self.assertEqual(
+            await self.cog._clean_messages(
+                self.ctx,
+                None,
+                first_limit=MockMessage(),
+                attempt_delete_invocation=False,
+            ),
+            self.log_url,
+        )
+
+        self.ctx.reply.assert_awaited_once()
+        sent_message = self.ctx.reply.await_args[0][0]
+        self.assertIn(self.log_url, sent_message)
+        self.assertIn("2 messages", sent_message)
+
+    @patch("bot.exts.moderation.clean.is_mod_channel")
+    async def test_clean_send_success_message__to_mods_when_ran_in_non_mod_channel(self, mod_channel_check):
+        """Clean command should send a confirmation message to #mods if invoked in a non-mod channel."""
+        mod_channel_check.return_value = False
+        mocked_mods = MockTextChannel(id=1234567)
+        mocked_mods.send = AsyncMock()
+        self.bot.get_channel = MagicMock(return_value=mocked_mods)
+
+        self.assertEqual(
+            await self.cog._clean_messages(
+                self.ctx,
+                None,
+                first_limit=MockMessage(),
+                attempt_delete_invocation=False,
+            ),
+            self.log_url,
+        )
+
+        mocked_mods.send.assert_awaited_once()
+        sent_message = mocked_mods.send.await_args[0][0]
+        self.assertIn(self.log_url, sent_message)
+        self.assertIn("2 messages", sent_message)

--- a/tests/bot/exts/moderation/test_clean.py
+++ b/tests/bot/exts/moderation/test_clean.py
@@ -81,7 +81,7 @@ class CleanTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("2 messages", sent_message)
 
     @patch("bot.exts.moderation.clean.is_mod_channel")
-    async def test_clean_send_success_message__to_mods_when_ran_in_non_mod_channel(self, mod_channel_check):
+    async def test_clean_send_success_message_to_mods_when_ran_in_non_mod_channel(self, mod_channel_check):
         """Clean command should send a confirmation message to #mods if invoked in a non-mod channel."""
         mod_channel_check.return_value = False
         mocked_mods = MockTextChannel(id=1234567)


### PR DESCRIPTION
This PR migrates our purgeban command away from Discord's native purgeban in favour of our custom logic.

Discord's native purgeban does not leave us with any evidence or context of what messages were deleted. So when mods reference the infraction at a later date, as example for an appeal, they are lacking required information.

Instead, we can use our custom clean cog to delete all messages from the user in question for the last hour, and automatically append the link to that clean log to the infraction reason.