### PR TITLE
Infraction mod-log improvements

### DIFF
--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -223,7 +223,7 @@ class InfractionScheduler:
                 failed = True
 
         if failed:
-            log.trace(f"Deleted infraction {infraction['id']} from database because applying infraction failed.")
+            log.trace(f"Trying to delete infraction {id_} from database because applying infraction failed.")
             try:
                 await self.bot.api_client.delete(f"bot/infractions/{id_}")
             except ResponseCodeError as e:
@@ -265,7 +265,7 @@ class InfractionScheduler:
                 {additional_info}
             """),
             content=log_content,
-            footer=f"ID {infraction['id']}"
+            footer=f"ID: {id_}"
         )
 
         log.info(f"Applied {purge}{infr_type} infraction #{id_} to {user}.")

--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -176,7 +176,7 @@ class ModManagement(commands.Cog):
         if 'expires_at' in request_data:
             # A scheduled task should only exist if the old infraction wasn't permanent
             if infraction['expires_at']:
-                self.infractions_cog.scheduler.cancel(new_infraction['id'])
+                self.infractions_cog.scheduler.cancel(infraction_id)
 
             # If the infraction was not marked as permanent, schedule a new expiration task
             if request_data['expires_at']:
@@ -210,7 +210,8 @@ class ModManagement(commands.Cog):
                 Member: {user_text}
                 Actor: <@{new_infraction['actor']}>
                 Edited by: {ctx.message.author.mention}{log_text}
-            """)
+            """),
+            footer=f"ID: {infraction_id}"
         )
 
     # endregion


### PR DESCRIPTION
Closes #2034.

Improvements:
- Updated the text in a `log.trace` to be less misleading
- Infraction edit mod-logs now display the infraction id
- Infraction applied mod-logs now have the previously missing colon (`:`)
- Edited some code to use the defined infraction id variables, rather than re-indexing the dictionary.


The below image shows the mod-logs for applying a mute, editing the mute reason & duration, and finally removing the mute:
![image.png](https://user-images.githubusercontent.com/47674925/147856285-295a35ae-3f92-4b94-9a21-f006c2796fcc.png)
