### PR TITLE
Shorten the `TXT_EMBED_DESCRIPTION` message

### DIFF
--- a/bot/exts/filters/antimalware.py
+++ b/bot/exts/filters/antimalware.py
@@ -18,14 +18,8 @@ PY_EMBED_DESCRIPTION = (
 
 TXT_LIKE_FILES = {".txt", ".csv", ".json"}
 TXT_EMBED_DESCRIPTION = (
-    "**Uh-oh!** It looks like your message got zapped by our spam filter. "
-    "We currently don't allow `{blocked_extension}` attachments, "
-    "so here are some tips to help you travel safely: \n\n"
-    "• If you attempted to send a message longer than 2000 characters, try shortening your message "
-    "to fit within the character limit or use a pasting service (see below) \n\n"
-    "• If you tried to show someone your code, you can use codeblocks \n(run `!code-blocks` in "
-    "{cmd_channel_mention} for more information) or use a pasting service like: "
-    f"\n\n{URLs.site_schema}{URLs.site_paste}"
+    "You either uploaded a `{blocked_extension}` file or entered a message that was too long. "
+    f"Please use our [{URLs.site_schema}{URLs.site_paste}](paste bin) instead."
 )
 
 DISALLOWED_EMBED_DESCRIPTION = (


### PR DESCRIPTION
The previous version of the message gave different instructions for each possible reason that their message was deleted, which was rarely read in entirety and was sometimes confusing. This version simply instructs the user to use the paste bin.