### PR TITLE
Fix pastebin hyperlink to use correct markdown syntax

### DIFF
--- a/bot/exts/filters/antimalware.py
+++ b/bot/exts/filters/antimalware.py
@@ -19,7 +19,7 @@ PY_EMBED_DESCRIPTION = (
 TXT_LIKE_FILES = {".txt", ".csv", ".json"}
 TXT_EMBED_DESCRIPTION = (
     "You either uploaded a `{blocked_extension}` file or entered a message that was too long. "
-    f"Please use our [{URLs.site_schema}{URLs.site_paste}](paste bin) instead."
+    f"Please use our [paste bin]({URLs.site_schema}{URLs.site_paste}) instead."
 )
 
 DISALLOWED_EMBED_DESCRIPTION = (


### PR DESCRIPTION
PR to fix pastebin hyperlink, it looked like this before. Hyperlink is now formatted to correct format.
<img width="387" alt="image" src="https://user-images.githubusercontent.com/60810623/149739555-7bff860d-b6d3-43b7-8a3b-85c02914546b.png">
