### PR TITLE
Add missing arguments to `notify_infraction` call

### DIFF
--- a/bot/exts/moderation/infraction/superstarify.py
+++ b/bot/exts/moderation/infraction/superstarify.py
@@ -57,7 +57,9 @@ class Superstarify(InfractionScheduler, Cog):
             return
 
         infraction = active_superstarifies[0]
-        forced_nick = self.get_nick(infraction["id"], before.id)
+        infr_id = infraction["id"]
+
+        forced_nick = self.get_nick(infr_id, before.id)
         if after.display_name == forced_nick:
             return  # Nick change was triggered by this event. Ignore.
 
@@ -67,11 +69,13 @@ class Superstarify(InfractionScheduler, Cog):
         )
         await after.edit(
             nick=forced_nick,
-            reason=f"Superstarified member tried to escape the prison: {infraction['id']}"
+            reason=f"Superstarified member tried to escape the prison: {infr_id}"
         )
 
         notified = await _utils.notify_infraction(
+            bot=self.bot,
             user=after,
+            infr_id=infr_id,
             infr_type="Superstarify",
             expires_at=time.discord_timestamp(infraction["expires_at"]),
             reason=(


### PR DESCRIPTION
Closes #2053.

Fixes an issue caused by a missed migration in #1951 (if a user attempted to change their nickname when superstarified, an error would raise when trying to notify them that they can't change nickname due to being superstarified).