### PR TITLE
Update guild features channels in !server

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -180,8 +180,6 @@ class Information(Cog):
         if ctx.channel.id in (
             *constants.MODERATION_CHANNELS,
             constants.Channels.dev_core,
-            constants.Channels.dev_contrib,
-            constants.Channels.bot_commands
         ):
             features = f"\nFeatures: {', '.join(ctx.guild.features)}"
         else:


### PR DESCRIPTION
This removes public channels since it makes the embed obtuse and the information has little value.