### PR TITLE
setuptools use stdlib distutils over embedded

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -46,6 +46,10 @@ jobs:
       PYTHONUSERBASE: ${{ github.workspace }}/.cache/py-user-base
       PRE_COMMIT_HOME: ${{ github.workspace }}/.cache/pre-commit-cache
 
+      # See https://github.com/pre-commit/pre-commit/issues/2178#issuecomment-1002163763
+      # for why we set this.
+      SETUPTOOLS_USE_DISTUTILS: stdlib
+
     steps:
       - name: Add custom PYTHONUSERBASE to PATH
         run: echo '${{ env.PYTHONUSERBASE }}/bin/' >> $GITHUB_PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
 
   metricity:
     << : *logging
+    << : *restart_policy
     restart: on-failure  # USE_METRICITY=false will stop the container, so this ensures it only restarts on error
     depends_on:
       postgres:


### PR DESCRIPTION
This is caused by an upstream issue with setuptools 60.* (via virtualenv) changeing the default to using the setuptools-embedded distutils rather than the stdlib distutils, which breaks within pip's isolated builds.

This is explained quite well here https://github.com/pre-commit/pre-commit/issues/2178#issuecomment-1002163763

This also fixes a small inconsistency with our docker-compose file.