### PR TITLE
Add embed message mentioning help channel claimant

### DIFF
--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -105,10 +105,18 @@ class HelpChannels(commands.Cog):
         """
         Claim the channel in which the question `message` was sent.
 
-        Move the channel to the In Use category and pin the `message`. Add a cooldown to the
-        claimant to prevent them from asking another question. Lastly, make a new channel available.
+        Send an embed stating the claimant, move the channel to the In Use category, and pin the `message`.
+        Add a cooldown to the claimant to prevent them from asking another question.
+        Lastly, make a new channel available.
         """
         log.info(f"Channel #{message.channel} was claimed by `{message.author.id}`.")
+
+        embed = discord.Embed(
+            description=f"Channel claimed by {message.author.mention}.",
+            color=constants.Colours.bright_green,
+        )
+        await message.channel.send(embed=embed)
+
         await self.move_to_in_use(message.channel)
 
         # Handle odd edge case of `message.author` not being a `discord.Member` (see bot#1839)


### PR DESCRIPTION
Closes python-discord/bot#2060

This PR adds a message by the bot stating who the help channel claimant is.
![image](https://user-images.githubusercontent.com/75038675/151393105-37b0844f-f744-4631-b442-f390a873386f.png)

This is my first code contribution to Python Discord and my first time working with discord.py so during your review it is safe to assume that I know nothing.

I'm not sure if the embed should be sent before or after the channel is moved. But I would like it to be sent at least before the claimant's message is pinned.

