### PR TITLE
Notify helpers without ping when dormant channels are running low

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -619,10 +619,12 @@ class HelpChannels(metaclass=YAMLGetter):
     max_available: int
     max_total_channels: int
     name_prefix: str
-    notify: bool
     notify_channel: int
     notify_minutes: int
-    notify_roles: List[int]
+    notify_none_remaining: bool
+    notify_none_remaining_roles: List[int]
+    notify_running_low: bool
+    notify_running_low_threshold: int
 
 
 class RedirectOutput(metaclass=YAMLGetter):

--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -22,7 +22,7 @@ class ClosingReason(Enum):
     """All possible closing reasons for help channels."""
 
     COMMAND = "command"
-    LATEST_MESSSAGE = "auto.latest_message"
+    LATEST_MESSAGE = "auto.latest_message"
     CLAIMANT_TIMEOUT = "auto.claimant_timeout"
     OTHER_TIMEOUT = "auto.other_timeout"
     DELETED = "auto.deleted"
@@ -75,7 +75,7 @@ async def get_closing_time(channel: discord.TextChannel, init_done: bool) -> t.T
 
         # Use the greatest offset to avoid the possibility of prematurely closing the channel.
         time = Arrow.fromdatetime(msg.created_at) + timedelta(minutes=idle_minutes_claimant)
-        reason = ClosingReason.DELETED if is_empty else ClosingReason.LATEST_MESSSAGE
+        reason = ClosingReason.DELETED if is_empty else ClosingReason.LATEST_MESSAGE
         return time, reason
 
     claimant_time = Arrow.utcfromtimestamp(claimant_time)

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -80,6 +80,7 @@ class HelpChannels(commands.Cog):
 
         # Notifications
         self.notify_interval_seconds = constants.HelpChannels.notify_minutes * 60
+        # Using a very old date so that we don't have to use Optional typing.
         self.last_none_remaining_notification = arrow.get('1815-12-10T18:00:00.00000+00:00')
         self.last_running_low_notification = arrow.get('1815-12-10T18:00:00.00000+00:00')
 

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -79,7 +79,7 @@ class HelpChannels(commands.Cog):
         self.name_queue: t.Deque[str] = None
 
         # Notifications
-        self.notify_interval_seconds = (constants.HelpChannels.notify_minutes * 60)
+        self.notify_interval_seconds = constants.HelpChannels.notify_minutes * 60
         self.last_none_remaining_notification = arrow.get('1815-12-10T18:00:00.00000+00:00')
         self.last_running_low_notification = arrow.get('1815-12-10T18:00:00.00000+00:00')
 

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -246,7 +246,10 @@ class HelpChannels(commands.Cog):
                 channel = await self.wait_for_dormant_channel()  # Blocks until a new channel is available
 
         else:
-            last_notification = await _message.notify_running_low(self.channel_queue.qsize(), self.last_running_low_notification)
+            last_notification = await _message.notify_running_low(
+                self.channel_queue.qsize(),
+                self.last_running_low_notification
+            )
 
             if last_notification:
                 self.last_running_low_notification = last_notification

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -78,7 +78,10 @@ class HelpChannels(commands.Cog):
         self.channel_queue: asyncio.Queue[discord.TextChannel] = None
         self.name_queue: t.Deque[str] = None
 
-        self.last_notification: t.Optional[arrow.Arrow] = None
+        # Notifications
+        self.notify_interval_seconds = (constants.HelpChannels.notify_minutes * 60)
+        self.last_none_remaining_notification = arrow.get('1815-12-10T18:00:00.00000+00:00')
+        self.last_running_low_notification = arrow.get('1815-12-10T18:00:00.00000+00:00')
 
         self.dynamic_message: t.Optional[int] = None
         self.available_help_channels: t.Set[discord.TextChannel] = set()
@@ -229,16 +232,22 @@ class HelpChannels(commands.Cog):
 
         try:
             channel = self.channel_queue.get_nowait()
+
+            within_interval = (arrow.utcnow() - self.last_running_low_notification).seconds >= self.notify_interval_seconds
+            if within_interval and self.channel_queue.qsize() <= constants.HelpChannels.notify_running_low_threshold:
+                await _message.notify_running_low(self.bot.get_channel(constants.HelpChannels.notify_channel), self.channel_queue.qsize())
+                self.last_running_low_notification = arrow.utcnow()
+
         except asyncio.QueueEmpty:
             log.info("No candidate channels in the queue; creating a new channel.")
             channel = await self.create_dormant()
 
             if not channel:
                 log.info("Couldn't create a candidate channel; waiting to get one from the queue.")
-                notify_channel = self.bot.get_channel(constants.HelpChannels.notify_channel)
-                last_notification = await _message.notify_none_remaining(notify_channel, self.last_notification)
-                if last_notification:
-                    self.last_notification = last_notification
+
+                if (arrow.utcnow() - self.last_none_remaining_notification).seconds >= self.notify_interval_seconds:
+                    await _message.notify_none_remaining(self.bot.get_channel(constants.HelpChannels.notify_channel))
+                    self.last_none_remaining_notification = arrow.utcnow()
                     self.bot.stats.incr("help.out_of_channel_alerts")
 
                 channel = await self.wait_for_dormant_channel()

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -238,10 +238,7 @@ class HelpChannels(commands.Cog):
 
             if not channel:
                 log.info("Couldn't create a candidate channel; waiting to get one from the queue.")
-                last_notification = await _message.notify_none_remaining(
-                    self.bot.get_channel(constants.HelpChannels.notify_channel),
-                    self.last_none_remaining_notification
-                )
+                last_notification = await _message.notify_none_remaining(self.last_none_remaining_notification)
 
                 if last_notification:
                     self.last_none_remaining_notification = last_notification
@@ -249,11 +246,7 @@ class HelpChannels(commands.Cog):
                 channel = await self.wait_for_dormant_channel()  # Blocks until a new channel is available
 
         else:
-            last_notification = await _message.notify_running_low(
-                self.bot.get_channel(constants.HelpChannels.notify_channel),
-                self.channel_queue.qsize(),
-                self.last_running_low_notification
-            )
+            last_notification = await _message.notify_running_low(self.channel_queue.qsize(), self.last_running_low_notification)
 
             if last_notification:
                 self.last_running_low_notification = last_notification

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -236,7 +236,7 @@ class HelpChannels(commands.Cog):
             if not channel:
                 log.info("Couldn't create a candidate channel; waiting to get one from the queue.")
                 notify_channel = self.bot.get_channel(constants.HelpChannels.notify_channel)
-                last_notification = await _message.notify(notify_channel, self.last_notification)
+                last_notification = await _message.notify_none_remaining(notify_channel, self.last_notification)
                 if last_notification:
                     self.last_notification = last_notification
                     self.bot.stats.incr("help.out_of_channel_alerts")

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -233,9 +233,13 @@ class HelpChannels(commands.Cog):
         try:
             channel = self.channel_queue.get_nowait()
 
-            within_interval = (arrow.utcnow() - self.last_running_low_notification).seconds >= self.notify_interval_seconds
+            time_since_last_notify_seconds = (arrow.utcnow() - self.last_running_low_notification).seconds
+            within_interval = time_since_last_notify_seconds >= self.notify_interval_seconds
             if within_interval and self.channel_queue.qsize() <= constants.HelpChannels.notify_running_low_threshold:
-                await _message.notify_running_low(self.bot.get_channel(constants.HelpChannels.notify_channel), self.channel_queue.qsize())
+                await _message.notify_running_low(
+                    self.bot.get_channel(constants.HelpChannels.notify_channel),
+                    self.channel_queue.qsize()
+                )
                 self.last_running_low_notification = arrow.utcnow()
 
         except asyncio.QueueEmpty:

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -161,7 +161,8 @@ async def notify_none_remaining(last_notification: Arrow) -> t.Optional[Arrow]:
         log.exception("Failed to send notification about lack of dormant channels!")
     finally:
         bot.instance.stats.incr("help.out_of_channel_alerts")
-        return arrow.utcnow()
+
+    return arrow.utcnow()
 
 
 async def notify_running_low(number_of_channels_left: int, last_notification: Arrow) -> t.Optional[Arrow]:
@@ -202,7 +203,8 @@ async def notify_running_low(number_of_channels_left: int, last_notification: Ar
         log.exception("Failed to send notification about running low of dormant channels!")
     finally:
         bot.instance.stats.incr("help.running_low_alerts")
-        return arrow.utcnow()
+
+    return arrow.utcnow()
 
 
 async def pin(message: discord.Message) -> None:

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -137,7 +137,7 @@ async def notify(channel: discord.TextChannel, last_notification: t.Optional[Arr
     * `HelpChannels.notify_minutes` - minimum interval between notifications
     * `HelpChannels.notify_roles` - roles mentioned in notifications
     """
-    if not constants.HelpChannels.notify:
+    if not constants.HelpChannels.notify_none_remaining:
         return
 
     log.trace("Notifying about lack of channels.")
@@ -156,8 +156,8 @@ async def notify(channel: discord.TextChannel, last_notification: t.Optional[Arr
     try:
         log.trace("Sending notification message.")
 
-        mentions = " ".join(f"<@&{role}>" for role in constants.HelpChannels.notify_roles)
-        allowed_roles = [discord.Object(id_) for id_ in constants.HelpChannels.notify_roles]
+        mentions = " ".join(f"<@&{role}>" for role in constants.HelpChannels.notify_none_remaining_roles)
+        allowed_roles = [discord.Object(id_) for id_ in constants.HelpChannels.notify_none_remaining_roles]
 
         message = await channel.send(
             f"{mentions} A new available help channel is needed but there "

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -162,10 +162,9 @@ async def notify_none_remaining(last_notification: Arrow) -> t.Optional[Arrow]:
     except Exception:
         # Handle it here cause this feature isn't critical for the functionality of the system.
         log.exception("Failed to send notification about lack of dormant channels!")
-    finally:
+    else:
         bot.instance.stats.incr("help.out_of_channel_alerts")
-
-    return arrow.utcnow()
+        return arrow.utcnow()
 
 
 async def notify_running_low(number_of_channels_left: int, last_notification: Arrow) -> t.Optional[Arrow]:
@@ -210,10 +209,9 @@ async def notify_running_low(number_of_channels_left: int, last_notification: Ar
     except Exception:
         # Handle it here cause this feature isn't critical for the functionality of the system.
         log.exception("Failed to send notification about running low of dormant channels!")
-    finally:
+    else:
         bot.instance.stats.incr("help.running_low_alerts")
-
-    return arrow.utcnow()
+        return arrow.utcnow()
 
 
 async def pin(message: discord.Message) -> None:

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -124,7 +124,7 @@ async def dm_on_open(message: discord.Message) -> None:
         )
 
 
-async def notify_none_remaining(channel: discord.TextChannel, last_notification: Arrow) -> t.Optional[Arrow]:
+async def notify_none_remaining(last_notification: Arrow) -> t.Optional[Arrow]:
     """
     Send a pinging message in `channel` notifying about there being no dormant channels remaining.
 
@@ -145,6 +145,10 @@ async def notify_none_remaining(channel: discord.TextChannel, last_notification:
     mentions = " ".join(f"<@&{role}>" for role in constants.HelpChannels.notify_none_remaining_roles)
     allowed_roles = [discord.Object(id_) for id_ in constants.HelpChannels.notify_none_remaining_roles]
 
+    channel = bot.instance.get_channel(constants.HelpChannels.notify_channel)
+    if channel is None:
+        log.trace("Did not send none_remaining notification as the notification channel couldn't be gathered.")
+
     try:
         await channel.send(
             f"{mentions} A new available help channel is needed but there "
@@ -160,11 +164,7 @@ async def notify_none_remaining(channel: discord.TextChannel, last_notification:
         return arrow.utcnow()
 
 
-async def notify_running_low(
-    channel: discord.TextChannel,
-    number_of_channels_left: int,
-    last_notification: Arrow
-) -> t.Optional[Arrow]:
+async def notify_running_low(number_of_channels_left: int, last_notification: Arrow) -> t.Optional[Arrow]:
     """
     Send a non-pinging message in `channel` notifying about there being a low amount of dormant channels.
 
@@ -187,6 +187,11 @@ async def notify_running_low(
         return None
 
     log.trace("Notifying about getting close to no dormant channels.")
+
+    channel = bot.instance.get_channel(constants.HelpChannels.notify_channel)
+    if channel is None:
+        log.trace("Did not send notify_running notification as the notification channel couldn't be gathered.")
+
     try:
         await channel.send(
             f"There are only {number_of_channels_left} dormant channels left. "

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -128,6 +128,9 @@ async def notify_none_remaining(last_notification: Arrow) -> t.Optional[Arrow]:
     """
     Send a pinging message in `channel` notifying about there being no dormant channels remaining.
 
+     If a notification was sent, return the time at which the message was sent.
+        Otherwise, return None.
+
     Configuration:
         * `HelpChannels.notify_minutes`              - minimum interval between notifications
         * `HelpChannels.notify_none_remaining`       - toggle none_remaining notifications
@@ -170,6 +173,9 @@ async def notify_running_low(number_of_channels_left: int, last_notification: Ar
     Send a non-pinging message in `channel` notifying about there being a low amount of dormant channels.
 
     This will include the number of dormant channels left `number_of_channels_left`
+
+    If a notification was sent, return the time at which the message was sent.
+        Otherwise, return None.
 
     Configuration:
         * `HelpChannels.notify_minutes`               - minimum interval between notifications

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -133,7 +133,7 @@ async def notify_none_remaining(channel: discord.TextChannel, last_notification:
 
     Configuration:
         * `HelpChannels.notify_minutes`              - minimum interval between notifications
-        * `HelpChannels.notify_none_remaining`       - toggle notifications
+        * `HelpChannels.notify_none_remaining`       - toggle none_remaining notifications
         * `HelpChannels.notify_none_remaining_roles` - roles mentioned in notifications
     """
     if not constants.HelpChannels.notify_none_remaining:
@@ -169,6 +169,21 @@ async def notify_none_remaining(channel: discord.TextChannel, last_notification:
     except Exception:
         # Handle it here cause this feature isn't critical for the functionality of the system.
         log.exception("Failed to send notification about lack of dormant channels!")
+
+
+async def notify_running_low():
+    """
+    Send a non-pinging message in `channel` notifying about there being a low amount of dormant channels.
+
+    If a notification was sent, return the time at which the message was sent.
+    Otherwise, return None.
+
+    Configuration:
+        * `HelpChannels.notify_minutes`               - minimum interval between notifications
+        * `HelpChannels.notify_running_low`           - toggle running_low notifications
+        * `HelpChannels.notify_running_low_threshold` - minimum amount of channels to trigger running_low notifications
+    """
+    ...
 
 
 async def pin(message: discord.Message) -> None:

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -205,7 +205,6 @@ async def notify_running_low(number_of_channels_left: int, last_notification: Ar
             message = f"There are only {number_of_channels_left} dormant channels left. "
         message += "Consider participating in some help channels so that we don't run out."
         await channel.send(message)
-
     except Exception:
         # Handle it here cause this feature isn't critical for the functionality of the system.
         log.exception("Failed to send notification about running low of dormant channels!")

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -1,7 +1,6 @@
 import textwrap
 import typing as t
 
-import arrow
 import discord
 from arrow import Arrow
 
@@ -158,7 +157,8 @@ async def notify_none_remaining(channel: discord.TextChannel) -> None:
 async def notify_running_low(channel: discord.TextChannel, number_of_channels_left: int) -> None:
     """
     Send a non-pinging message in `channel` notifying about there being a low amount of dormant channels.
-        Including the amount of channels left in dormant.
+
+    This will include the number of dormant channels left `number_of_channels_left`
 
     Configuration:
         * `HelpChannels.notify_minutes`               - minimum interval between notifications

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -124,7 +124,7 @@ async def dm_on_open(message: discord.Message) -> None:
         )
 
 
-async def notify(channel: discord.TextChannel, last_notification: t.Optional[Arrow]) -> t.Optional[Arrow]:
+async def notify_none_remaining(channel: discord.TextChannel, last_notification: t.Optional[Arrow]) -> t.Optional[Arrow]:
     """
     Send a message in `channel` notifying about a lack of available help channels.
 

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -126,16 +126,15 @@ async def dm_on_open(message: discord.Message) -> None:
 
 async def notify_none_remaining(channel: discord.TextChannel, last_notification: t.Optional[Arrow]) -> t.Optional[Arrow]:
     """
-    Send a message in `channel` notifying about a lack of available help channels.
+    Send a pinging message in `channel` notifying about there being no dormant channels remaining.
 
     If a notification was sent, return the time at which the message was sent.
     Otherwise, return None.
 
     Configuration:
-
-    * `HelpChannels.notify` - toggle notifications
-    * `HelpChannels.notify_minutes` - minimum interval between notifications
-    * `HelpChannels.notify_roles` - roles mentioned in notifications
+        * `HelpChannels.notify_minutes`              - minimum interval between notifications
+        * `HelpChannels.notify_none_remaining`       - toggle notifications
+        * `HelpChannels.notify_none_remaining_roles` - roles mentioned in notifications
     """
     if not constants.HelpChannels.notify_none_remaining:
         return

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -139,7 +139,7 @@ async def notify_none_remaining(last_notification: Arrow) -> t.Optional[Arrow]:
     if not constants.HelpChannels.notify_none_remaining:
         return None
 
-    if (arrow.utcnow() - last_notification).seconds < (constants.HelpChannels.notify_minutes * 60):
+    if (arrow.utcnow() - last_notification).total_seconds() < (constants.HelpChannels.notify_minutes * 60):
         log.trace("Did not send none_remaining notification as it hasn't been enough time since the last one.")
         return None
 
@@ -188,7 +188,7 @@ async def notify_running_low(number_of_channels_left: int, last_notification: Ar
         log.trace("Did not send notify_running_low notification as the threshold was not met.")
         return None
 
-    if (arrow.utcnow() - last_notification).seconds < (constants.HelpChannels.notify_minutes * 60):
+    if (arrow.utcnow() - last_notification).total_seconds() < (constants.HelpChannels.notify_minutes * 60):
         log.trace("Did not send notify_running_low notification as it hasn't been enough time since the last one.")
         return None
 

--- a/bot/exts/help_channels/_message.py
+++ b/bot/exts/help_channels/_message.py
@@ -128,8 +128,8 @@ async def notify_none_remaining(last_notification: Arrow) -> t.Optional[Arrow]:
     """
     Send a pinging message in `channel` notifying about there being no dormant channels remaining.
 
-     If a notification was sent, return the time at which the message was sent.
-        Otherwise, return None.
+    If a notification was sent, return the time at which the message was sent.
+    Otherwise, return None.
 
     Configuration:
         * `HelpChannels.notify_minutes`              - minimum interval between notifications
@@ -175,7 +175,7 @@ async def notify_running_low(number_of_channels_left: int, last_notification: Ar
     This will include the number of dormant channels left `number_of_channels_left`
 
     If a notification was sent, return the time at which the message was sent.
-        Otherwise, return None.
+    Otherwise, return None.
 
     Configuration:
         * `HelpChannels.notify_minutes`               - minimum interval between notifications
@@ -200,10 +200,13 @@ async def notify_running_low(number_of_channels_left: int, last_notification: Ar
         log.trace("Did not send notify_running notification as the notification channel couldn't be gathered.")
 
     try:
-        await channel.send(
-            f"There are only {number_of_channels_left} dormant channels left. "
-            "Consider participating in some help channels so that we don't run out."
-        )
+        if number_of_channels_left == 1:
+            message = f"There is only {number_of_channels_left} dormant channel left. "
+        else:
+            message = f"There are only {number_of_channels_left} dormant channels left. "
+        message += "Consider participating in some help channels so that we don't run out."
+        await channel.send(message)
+
     except Exception:
         # Handle it here cause this feature isn't critical for the functionality of the system.
         log.exception("Failed to send notification about running low of dormant channels!")

--- a/config-default.yml
+++ b/config-default.yml
@@ -513,18 +513,15 @@ help_channels:
     # Prefix for help channel names
     name_prefix: 'help-'
 
-    # Notify if more available channels are needed but there are no more dormant ones
-    notify: true
+    notify_channel:                *HELPERS  # Channel in which to send notifications messages
+    notify_minutes:                15        # Minimum interval between helper notifications, used by both none_remaining and running_low
 
-    # Channel in which to send notifications
-    notify_channel: *HELPERS
-
-    # Minimum interval between helper notifications
-    notify_minutes: 15
-
-    # Mention these roles in notifications
-    notify_roles:
+    notify_none_remaining:         true      # Pinging notification for the Helper role when no dormant channels remain
+    notify_none_remaining_roles:             # Mention these roles in the non_remaining notification
         - *HELPERS_ROLE
+
+    notify_running_low:            true      # Non-pinging notification which is triggered when the channel count is equal or less than the threshold
+    notify_running_low_threshold:  4         # The amount of channels at which a running_low notification will be sent
 
 
 redirect_output:

--- a/config-default.yml
+++ b/config-default.yml
@@ -514,7 +514,7 @@ help_channels:
     name_prefix: 'help-'
 
     notify_channel:                *HELPERS  # Channel in which to send notifications messages
-    notify_minutes:                15        # Minimum interval between helper notifications, used by both none_remaining and running_low
+    notify_minutes:                15        # Minimum interval between none_remaining or running_low notifications
 
     notify_none_remaining:         true      # Pinging notification for the Helper role when no dormant channels remain
     notify_none_remaining_roles:             # Mention these roles in the non_remaining notification

--- a/config-default.yml
+++ b/config-default.yml
@@ -517,7 +517,7 @@ help_channels:
     notify_minutes:                15        # Minimum interval between none_remaining or running_low notifications
 
     notify_none_remaining:         true      # Pinging notification for the Helper role when no dormant channels remain
-    notify_none_remaining_roles:             # Mention these roles in the non_remaining notification
+    notify_none_remaining_roles:             # Mention these roles in the none_remaining notification
         - *HELPERS_ROLE
 
     notify_running_low:            true      # Non-pinging notification which is triggered when the channel count is equal or less than the threshold


### PR DESCRIPTION
Closes #2051 

This PR adds a non-pinging notification to `#helpers` to alert staff when we are running low on dormant channels. The threshold for when this notification is triggered is added as a configurable.

<img width="747" alt="image" src="https://user-images.githubusercontent.com/75038675/152253985-d6bfb2c5-7e19-4cb4-b062-f6d941d48fb3.png">
