### PR TITLE
Traceback tag: Emphasize reason for sharing traceback

### DIFF
--- a/bot/resources/tags/traceback.md
+++ b/bot/resources/tags/traceback.md
@@ -12,3 +12,5 @@ Traceback (most recent call last):
         a = num + 3
 TypeError: can only concatenate str (not "int") to str
 ```
+
+If the traceback is long, use [our pastebin](https://paste.pythondiscord.com/).

--- a/bot/resources/tags/traceback.md
+++ b/bot/resources/tags/traceback.md
@@ -6,10 +6,10 @@ Please avoid screenshots so we can copy and paste parts of the message.
 A full traceback could look like:
 ```py
 Traceback (most recent call last):
-    File "my_file.py", line 3, in
-        add_three("6")
-    File "tiny", line 2, in do_something
-        a = num + 3
+  File "my_file.py", line 5, in <module>
+    add_three("6")
+  File "my_file.py", line 2, in add_three
+    a = num + 3
 TypeError: can only concatenate str (not "int") to str
 ```
 

--- a/bot/resources/tags/traceback.md
+++ b/bot/resources/tags/traceback.md
@@ -1,18 +1,14 @@
 Please provide the full traceback for your exception in order to help us identify your issue.
+While the last line of the error message tells us what kind of error you got,
+the full traceback will tell us which line, and other critical information to solve your problem.
+Please avoid screenshots so we can copy and paste parts of the message.
 
 A full traceback could look like:
 ```py
 Traceback (most recent call last):
-    File "tiny", line 3, in
-        do_something()
+    File "my_file.py", line 3, in
+        add_three("6")
     File "tiny", line 2, in do_something
-        a = 6 / b
-ZeroDivisionError: division by zero
+        a = num + 3
+TypeError: can only concatenate str (not "int") to str
 ```
-The best way to read your traceback is bottom to top.
-
-• Identify the exception raised (in this case `ZeroDivisionError`)  
-• Make note of the line number (in this case `2`), and navigate there in your program.  
-• Try to understand why the error occurred (in this case because `b` is `0`).
-
-To read more about exceptions and errors, please refer to the [PyDis Wiki](https://pythondiscord.com/pages/guides/pydis-guides/asking-good-questions/#examining-tracebacks) or the [official Python tutorial](https://docs.python.org/3.7/tutorial/errors.html).


### PR DESCRIPTION
The previous version talks about how to read a traceback, but this tag is most often used to help the asker provide the traceback. This version is more brief and emphasizes why they are being asked to provide the traceback, and uses an example that I think is slightly more illustrative.