### PR TITLE
Add reported message author's profile picture to unfurl embed

### DIFF
--- a/bot/exts/moderation/incidents.py
+++ b/bot/exts/moderation/incidents.py
@@ -229,6 +229,7 @@ async def make_message_link_embed(ctx: Context, message_link: str) -> Optional[d
             ),
             timestamp=message.created_at
         )
+        embed.set_author(name=message.author, icon_url=message.author.display_avatar.url)
         embed.add_field(
             name="Content",
             value=shorten_text(message.content) if message.content else "[No Message Content]"


### PR DESCRIPTION
Closes https://github.com/python-discord/bot/issues/2070

This PR adds the reported message author's username and profile picture to incident embed.

Before
<img width="500" alt="image" src="https://user-images.githubusercontent.com/75038675/152630252-3c83869d-bd15-4068-afcd-2f8bf9d950ae.png">



After 
<img width="503" alt="image" src="https://user-images.githubusercontent.com/75038675/152630292-b79b7bef-0daa-4357-95d6-99dd300580ff.png">
