### PR TITLE
Remove Coveralls completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Lint & Test][1]][2]
 [![Build][3]][4]
 [![Deploy][5]][6]
-[![Coverage Status](https://coveralls.io/repos/github/python-discord/bot/badge.svg)](https://coveralls.io/github/python-discord/bot)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
 This project is a Discord bot specifically for use with the Python Discord server. It provides numerous utilities

--- a/poetry.lock
+++ b/poetry.lock
@@ -155,6 +155,7 @@ python-versions = "3.9.*"
 [package.source]
 type = "url"
 url = "https://github.com/python-discord/bot-core/archive/511bcba1b0196cd498c707a525ea56921bd971db.zip"
+
 [[package]]
 name = "certifi"
 version = "2021.10.8"
@@ -235,22 +236,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 toml = ["toml"]
 
 [[package]]
-name = "coveralls"
-version = "2.2.0"
-description = "Show coverage stats online via coveralls.io"
-category = "dev"
-optional = false
-python-versions = ">= 3.5"
-
-[package.dependencies]
-coverage = ">=4.1,<6.0"
-docopt = ">=0.6.1"
-requests = ">=1.0.0"
-
-[package.extras]
-yaml = ["PyYAML (>=3.10)"]
-
-[[package]]
 name = "deepdiff"
 version = "4.3.2"
 description = "Deep Difference and Search of any Python object/data."
@@ -302,14 +287,6 @@ url = "https://github.com/Rapptz/discord.py/archive/45d498c1b76deaf3b394d17ccf56
 name = "distlib"
 version = "0.3.4"
 description = "Distribution utilities"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "docopt"
-version = "0.6.2"
-description = "Pythonic argument parser, that will make you smile"
 category = "dev"
 optional = false
 python-versions = "*"
@@ -1170,7 +1147,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.*"
-content-hash = "d625aaae916c07c21080bf504831f5bf4d2bf4f0e3696e404448b43719eff201"
+content-hash = "0248fc7488c79af0cdb3a6db9528f4c3129db50b3a8d1dd3ba57dbc31b381c31"
 
 [metadata.files]
 aio-pika = [
@@ -1383,10 +1360,6 @@ coverage = [
     {file = "coverage-5.5-pp37-none-any.whl", hash = "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4"},
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
-coveralls = [
-    {file = "coveralls-2.2.0-py2.py3-none-any.whl", hash = "sha256:2301a19500b06649d2ec4f2858f9c69638d7699a4c63027c5d53daba666147cc"},
-    {file = "coveralls-2.2.0.tar.gz", hash = "sha256:b990ba1f7bc4288e63340be0433698c1efe8217f78c689d254c2540af3d38617"},
-]
 deepdiff = [
     {file = "deepdiff-4.3.2-py3-none-any.whl", hash = "sha256:59fc1e3e7a28dd0147b0f2b00e3e27181f0f0ef4286b251d5f214a5bcd9a9bc4"},
     {file = "deepdiff-4.3.2.tar.gz", hash = "sha256:91360be1d9d93b1d9c13ae9c5048fa83d9cff17a88eb30afaa0d7ff2d0fee17d"},
@@ -1399,9 +1372,6 @@ deprecated = [
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
-]
-docopt = [
-    {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
 emoji = [
     {file = "emoji-0.6.0.tar.gz", hash = "sha256:e42da4f8d648f8ef10691bc246f682a1ec6b18373abfd9be10ec0b398823bd11"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ tldextract = "^3.1.2"
 
 [tool.poetry.dev-dependencies]
 coverage = "~=5.0"
-coveralls = "~=2.1"
 flake8 = "~=3.8"
 flake8-annotations = "~=2.0"
 flake8-bugbear = "~=20.1"


### PR DESCRIPTION
Publishing to Coveralls was removed in https://github.com/python-discord/bot/commit/802fa0dd29f35d4cf02c7be88dcec01d9ab67729, and the `coveralls` dependency was left behind.

This PR removes that dependency and the Coveralls badge in the readme.