### PR TITLE
Add unsubscribe alias to subscribe command

### DIFF
--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -171,7 +171,7 @@ class Subscribe(commands.Cog):
         self.assignable_roles.sort(key=operator.methodcaller("is_currently_available"), reverse=True)
 
     @commands.cooldown(1, 10, commands.BucketType.member)
-    @commands.command(name="subscribe")
+    @commands.command(name="subscribe", aliases=("unsubscribe",))
     @redirect_output(
         destination_channel=constants.Channels.bot_commands,
         bypass_roles=constants.STAFF_PARTNERS_COMMUNITY_ROLES,


### PR DESCRIPTION
In quite a few places, such as #roles, we tell users to run the unsubscribe command to remove roles from them. However, this command no longer exists due to the rework of the subscribe command.

Since the subscribe commands allows you to remove as well as add roles, I have added this as an alias.