### PR TITLE
Removed extra newline in the traceback tag.

### DIFF
--- a/bot/resources/tags/traceback.md
+++ b/bot/resources/tags/traceback.md
@@ -12,5 +12,4 @@ Traceback (most recent call last):
     a = num + 3
 TypeError: can only concatenate str (not "int") to str
 ```
-
 If the traceback is long, use [our pastebin](https://paste.pythondiscord.com/).


### PR DESCRIPTION
[Here](https://github.com/python-discord/bot/blob/main/bot/resources/tags/traceback.md?plain=1) is the tag after #2072 was merged:

![image](https://user-images.githubusercontent.com/15021300/153773412-0d1e991e-4511-4054-bd35-d3374ae7de7d.png)

Here is the updated one:

![image](https://user-images.githubusercontent.com/15021300/153773431-99b053d4-88ca-4bb6-a8fd-1ee0597c0e86.png)
