### PR TITLE
Fix ignoring of raw DM edits

### DIFF
--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -729,6 +729,9 @@ class ModLog(Cog, name="ModLog"):
     @Cog.listener()
     async def on_raw_message_edit(self, event: discord.RawMessageUpdateEvent) -> None:
         """Log raw message edit event to message change log."""
+        if event.guild_id is None:
+            return  # ignore DM edits
+
         await self.bot.wait_until_guild_available()
         try:
             channel = self.bot.get_channel(int(event.data["channel_id"]))


### PR DESCRIPTION
Closes #2010.

Returns early when the `event.guild_id is None`, in order to prevent the `channel` from being `None`.

The initial plan of moving up the `self.is_message_blacklisted(message)` wouldn't work since we don't have access to the `message` variable until after we have the `channel`.

*NB: Currently untested.*