### PR TITLE
Fix DM handling for code snippets.

### DIFF
--- a/bot/exts/info/code_snippets.py
+++ b/bot/exts/info/code_snippets.py
@@ -262,7 +262,7 @@ class CodeSnippets(Cog):
                     raise e
 
             # If we're in a guild, then check if we need to redirect to #bot-commands
-            if destination.guild:
+            if message.guild:
                 if len(message_to_send) > 1000 and message.channel.id != Channels.bot_commands:
                     # Redirects to #bot-commands if the snippet contents are too long
                     await self.bot.wait_until_guild_available()
@@ -273,10 +273,12 @@ class CodeSnippets(Cog):
                         f'Please see {destination.mention} for the full snippet.'
                     )
 
-            await wait_for_deletion(
-                await destination.send(message_to_send),
-                (message.author.id,)
-            )
+                await wait_for_deletion(
+                    await destination.send(message_to_send),
+                    (message.author.id,)
+                )
+            else:
+                await destination.send(message_to_send)
 
 
 def setup(bot: Bot) -> None:

--- a/bot/exts/info/code_snippets.py
+++ b/bot/exts/info/code_snippets.py
@@ -246,6 +246,9 @@ class CodeSnippets(Cog):
         if message.author.bot:
             return
 
+        if message.guild is None:
+            return
+
         message_to_send = await self._parse_snippets(message.content)
         destination = message.channel
 
@@ -255,30 +258,21 @@ class CodeSnippets(Cog):
             except discord.NotFound:
                 # Don't send snippets if the original message was deleted.
                 return
-            except discord.Forbidden as e:
-                # We still want to send snippets when in DMs, but if we're in guild then
-                # reraise error since that means there's a permissions issue with the bot.
-                if message.guild:
-                    raise e
 
-            # If we're in a guild, then check if we need to redirect to #bot-commands
-            if message.guild:
-                if len(message_to_send) > 1000 and message.channel.id != Channels.bot_commands:
-                    # Redirects to #bot-commands if the snippet contents are too long
-                    await self.bot.wait_until_guild_available()
-                    destination = self.bot.get_channel(Channels.bot_commands)
+            if len(message_to_send) > 1000 and message.channel.id != Channels.bot_commands:
+                # Redirects to #bot-commands if the snippet contents are too long
+                await self.bot.wait_until_guild_available()
+                destination = self.bot.get_channel(Channels.bot_commands)
 
-                    await message.channel.send(
-                        'The snippet you tried to send was too long. '
-                        f'Please see {destination.mention} for the full snippet.'
-                    )
-
-                await wait_for_deletion(
-                    await destination.send(message_to_send),
-                    (message.author.id,)
+                await message.channel.send(
+                    'The snippet you tried to send was too long. '
+                    f'Please see {destination.mention} for the full snippet.'
                 )
-            else:
-                await destination.send(message_to_send)
+
+            await wait_for_deletion(
+                await destination.send(message_to_send),
+                (message.author.id,)
+            )
 
 
 def setup(bot: Bot) -> None:


### PR DESCRIPTION
Closes #2081.

Catches error raised when trying to edit message in DM fails (we still try to edit so we can ensure the message hasn't been deleted).

If the error was raised by a message inside the guild, then we reraise the error since that's unexpected behaviour (would mean that the bot has missing permissions).

Also only checks if we need to send to #bot-commands when the message was sent in the guild.

*NB: Currently untested.*