### PR TITLE
Fix: `!raw` can now be used in threads

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -470,7 +470,7 @@ class Information(Cog):
 
         If `json` is True, send the information in a copy-pasteable Python format.
         """
-        if ctx.author not in message.channel.members:
+        if not message.channel.permissions_for(ctx.author).read_messages:
             await ctx.send(":x: You do not have permissions to see the channel this message is in.")
             return
 


### PR DESCRIPTION
Closes #2077.

`!raw` now works for messages inside threads.

Tested w/ help of @LiquidPulsar.