### PR TITLE
Remove unnecessary Infraction conversion in clean ban

### DIFF
--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -9,7 +9,7 @@ from discord.ext.commands import Context, command
 from bot import constants
 from bot.bot import Bot
 from bot.constants import Event
-from bot.converters import Age, Duration, Expiry, Infraction, MemberOrUser, UnambiguousMemberOrUser
+from bot.converters import Age, Duration, Expiry, MemberOrUser, UnambiguousMemberOrUser
 from bot.decorators import respect_role_hierarchy
 from bot.exts.moderation.infraction import _utils
 from bot.exts.moderation.infraction._scheduler import InfractionScheduler
@@ -125,7 +125,6 @@ class Infractions(InfractionScheduler, commands.Cog):
 
         # Calling commands directly skips Discord.py's convertors, so we need to convert args manually.
         clean_time = await Age().convert(ctx, "1h")
-        infraction = await Infraction().convert(ctx, infraction["id"])
 
         log_url = await clean_cog._clean_messages(
             ctx,

--- a/tests/bot/exts/moderation/infraction/test_infractions.py
+++ b/tests/bot/exts/moderation/infraction/test_infractions.py
@@ -305,18 +305,16 @@ class CleanBanTests(unittest.IsolatedAsyncioTestCase):
             attempt_delete_invocation=False,
         )
 
-    @patch("bot.exts.moderation.infraction.infractions.Infraction")
-    async def test_cleanban_edits_infraction_reason(self, mocked_infraction_converter):
+    async def test_cleanban_edits_infraction_reason(self):
         """Ensure cleanban edits the ban reason with a link to the clean log."""
         self.bot.get_cog.side_effect = self.mock_get_cog(True, True)
 
         self.management_cog.infraction_append = AsyncMock()
-        mocked_infraction_converter.return_value.convert = AsyncMock(return_value=42)
         self.assertIsNone(await self.cog.cleanban(self.cog, self.ctx, self.user, None, reason="FooBar"))
 
         self.management_cog.infraction_append.assert_awaited_once_with(
             self.ctx,
-            42,
+            {"id": 42},
             None,
             reason=f"[Clean log]({self.log_url})"
         )


### PR DESCRIPTION
apply_ban already returns the data exactly how it's needed, so we don't need to call the infraction convertor and use an API call to site.