### PR TITLE
Validate regex when adding to the filter_token filter

### DIFF
--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -76,7 +76,7 @@ class FilterLists(Cog):
         # If it's a filter token, validate the passed regex
         elif list_type == "FILTER_TOKEN":
             try:
-                _ = re.compile(content)
+                re.compile(content)
             except re.error as e:
                 await ctx.message.add_reaction("❌")
                 await ctx.send(

--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -1,3 +1,4 @@
+import re
 from typing import Optional
 
 from discord import Colour, Embed
@@ -71,6 +72,18 @@ class FilterLists(Cog):
         # If it's a file format, let's make sure it has a leading dot.
         elif list_type == "FILE_FORMAT" and not content.startswith("."):
             content = f".{content}"
+
+        # If it's a filter token, validate the passed regex
+        elif list_type == "FILTER_TOKEN":
+            try:
+                _ = re.compile(content)
+            except re.error:
+                await ctx.message.add_reaction("❌")
+                await ctx.send(
+                    f"{ctx.author.mention} that's not a valid regex! "
+                    "You may have forgotten to escape part of the regex."
+                )
+                return
 
         # Try to add the item to the database
         log.trace(f"Trying to add the {content} item to the {list_type} {allow_type}")

--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -77,11 +77,11 @@ class FilterLists(Cog):
         elif list_type == "FILTER_TOKEN":
             try:
                 _ = re.compile(content)
-            except re.error:
+            except re.error as e:
                 await ctx.message.add_reaction("❌")
                 await ctx.send(
                     f"{ctx.author.mention} that's not a valid regex! "
-                    "You may have forgotten to escape part of the regex."
+                    f"Regex error message: {e.msg}."
                 )
                 return
 


### PR DESCRIPTION
Closes #2093.

When a user attempts to add a regex to the `filter_token` filter, the regex is now validated before being added to prevent errors when checking if a message matches the regex. If the regex isn't valid, an error message is sent informing the user that an invalid regex was passed, and the regex doesn't get added to the filter list.