### PR TITLE
Add user ID to message content for all mod alerts

### DIFF
--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -439,6 +439,7 @@ class Filtering(Cog):
 
         # Send pretty mod log embed to mod-alerts
         await self.mod_log.send_log_message(
+            content=str(msg.author.id),  # quality-of-life improvement for mobile moderators to copy & paste
             icon_url=Icons.filtering,
             colour=Colour(Colours.soft_red),
             title=f"{_filter['type'].title()} triggered!",

--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -116,7 +116,7 @@ class ModLog(Cog, name="ModLog"):
 
         if ping_everyone:
             if content:
-                content = f"<@&{Roles.moderators}>\n{content}"
+                content = f"<@&{Roles.moderators}> {content}"
             else:
                 content = f"<@&{Roles.moderators}>"
 


### PR DESCRIPTION
Closes #2088 

This is a temporary quality of life improvement for moderators on mobile. 

<img width="561" alt="image" src="https://user-images.githubusercontent.com/75038675/154607886-4f7fb630-cfb1-4297-9ec6-6889592d08ad.png">
