### PR TITLE
Add user ID in message content for mod-alerts, but not for autobans

### DIFF
--- a/bot/exts/filters/antispam.py
+++ b/bot/exts/filters/antispam.py
@@ -103,6 +103,7 @@ class DeletionContext:
             mod_alert_message += content
 
         await modlog.send_log_message(
+            content=", ".join(str(m.id) for m in self.members),  # quality-of-life improvement for mobile moderators
             icon_url=Icons.filtering,
             colour=Colour(Colours.soft_red),
             title="Spam detected!",

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -256,6 +256,7 @@ class Filtering(Cog):
             )
 
             await self.mod_log.send_log_message(
+                content=str(member.id),  # quality-of-life improvement for mobile moderators
                 icon_url=Icons.token_removed,
                 colour=Colours.soft_red,
                 title="Username filtering alert",
@@ -423,9 +424,12 @@ class Filtering(Cog):
             # Allow specific filters to override ping_everyone
             ping_everyone = Filter.ping_everyone and _filter.get("ping_everyone", True)
 
-        # If we are going to autoban, we don't want to ping
+        content = str(msg.author.id)  # quality-of-life improvement for mobile moderators
+
+        # If we are going to autoban, we don't want to ping and don't need the user ID
         if reason and "[autoban]" in reason:
             ping_everyone = False
+            content = None
 
         eval_msg = "using !eval " if is_eval else ""
         footer = f"Reason: {reason}" if reason else None
@@ -439,7 +443,7 @@ class Filtering(Cog):
 
         # Send pretty mod log embed to mod-alerts
         await self.mod_log.send_log_message(
-            content=str(msg.author.id),  # quality-of-life improvement for mobile moderators to copy & paste
+            content=content,
             icon_url=Icons.filtering,
             colour=Colour(Colours.soft_red),
             title=f"{_filter['type'].title()} triggered!",


### PR DESCRIPTION
Continued work on #2096 
Further closes #2088 

This PR 
- additionally adds the user ID for antispam alerts
- additionally adds the user ID for username filtering alerts
- removes the user ID for autoban alerts

I'll make an additional commit to rename the `content` in the code block below, since it overlaps with the `content` parameter used a little later on.

I didn't quite understand what lines 98-101 were doing though, and need some guidance on good rename suggestions for `content` 😄 
https://github.com/python-discord/bot/blob/389cb815a379feca1122df12b3492144b76e7749/bot/exts/filters/antispam.py#L93-L101