### PR TITLE
Remove discord formatted timestamp from log message

### DIFF
--- a/bot/exts/moderation/stream.py
+++ b/bot/exts/moderation/stream.py
@@ -133,8 +133,12 @@ class Stream(commands.Cog):
         await ctx.send(f"{Emojis.check_mark} {member.mention} can now stream until {time.discord_timestamp(duration)}.")
 
         # Convert here for nicer logging
-        revoke_time = time.format_with_duration(duration)
-        log.debug(f"Successfully gave {member} ({member.id}) permission to stream until {revoke_time}.")
+        humanized_duration = time.humanize_delta(duration, arrow.utcnow(), max_units=2)
+        end_time = duration.strftime("%Y-%m-%d %H:%M:%S")
+        log.debug(
+            f"Successfully gave {member} ({member.id}) permission "
+            f"to stream for {humanized_duration} (until {end_time})."
+        )
 
     @commands.command(aliases=("pstream",))
     @commands.has_any_role(*MODERATION_ROLES)


### PR DESCRIPTION
Closes #1751.

 Changes log message to show humanised duration as well as end timestamp in a `YYYY-mm-dd HH:MM:SS` format instead of a humanised duration and a discord formatted timestamp.
 
 Has been tested as seems to be working perfectly :+1:
 
 Sample log message 
![image](https://user-images.githubusercontent.com/47674925/154841897-e9be5436-0bdb-4520-a234-15898a6e56b9.png)
