### PR TITLE
Increase watch API call limit to 10,000

### DIFF
--- a/bot/exts/moderation/watchchannels/bigbrother.py
+++ b/bot/exts/moderation/watchchannels/bigbrother.py
@@ -22,7 +22,7 @@ class BigBrother(WatchChannel, Cog, name="Big Brother"):
             destination=Channels.big_brother_logs,
             webhook_id=Webhooks.big_brother,
             api_endpoint='bot/infractions',
-            api_default_params={'active': 'true', 'type': 'watch', 'ordering': '-inserted_at'},
+            api_default_params={'active': 'true', 'type': 'watch', 'ordering': '-inserted_at', 'limit': 10_000},
             logger=log
         )
 


### PR DESCRIPTION
By default, the site infractions query API will only return 100 records,
but we have more active watches than this meaning that the response
truncated active infractions and so the bigbrother cog was not
initialising with all active watches.

This change ensures that up to 10,000 watches are fetched instead meaning no
infractions will be truncated and missed.