### PR TITLE
Add Resources Command

### DIFF
--- a/bot/exts/info/resources.py
+++ b/bot/exts/info/resources.py
@@ -1,0 +1,70 @@
+import re
+from typing import Optional
+from urllib.parse import quote
+
+from discord import Embed
+from discord.ext import commands
+
+from bot.bot import Bot
+
+REGEX_CONSECUTIVE_NON_LETTERS = r"[^A-Za-z0-9]+"
+RESOURCE_URL = "https://www.pythondiscord.com/resources/"
+
+
+def to_kebabcase(resource_topic: str) -> str:
+    """
+    Convert any string to kebab-case.
+
+    For example, convert
+    "__Favorite FROOT¤#/$?is----LeMON???" to
+    "favorite-froot-is-lemon"
+
+    Code adopted from:
+    https://github.com/python-discord/site/blob/main/pydis_site/apps/resources/templatetags/to_kebabcase.py
+    """
+    # First, make it lowercase, and just remove any apostrophes.
+    # We remove the apostrophes because "wasnt" is better than "wasn-t"
+    resource_topic = resource_topic.casefold()
+    resource_topic = resource_topic.replace("'", '')
+
+    # Now, replace any non-alphanumerics that remains with a dash.
+    # If there are multiple consecutive non-letters, just replace them with a single dash.
+    # my-favorite-class is better than my-favorite------class
+    resource_topic = re.sub(
+        REGEX_CONSECUTIVE_NON_LETTERS,
+        "-",
+        resource_topic,
+    )
+
+    # Now we use strip to get rid of any leading or trailing dashes.
+    resource_topic = resource_topic.strip("-")
+    return resource_topic
+
+
+class Resources(commands.Cog):
+    """Display information about the Python Discord website Resource page."""
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @commands.command(name="resources", aliases=("res",))
+    async def resources_command(self, ctx: commands.Context, *, resource_topic: Optional[str]) -> None:
+        """Display information and a link to the Python Discord website Resources page."""
+        url = RESOURCE_URL
+
+        if resource_topic:
+            # Capture everything prior to new line allowing users to add messages below the command then prep for url
+            url = f"{url}?topics={quote(to_kebabcase(resource_topic.splitlines()[0]))}"
+
+        embed = Embed(
+            title="Resources",
+            description=f"The [Resources page]({url}) on our website contains a list "
+                        f"of hand-selected learning resources that we "
+                        f"regularly recommend to both beginners and experts."
+        )
+        await ctx.send(embed=embed)
+
+
+def setup(bot: Bot) -> None:
+    """Load the Resources cog."""
+    bot.add_cog(Resources(bot))

--- a/bot/resources/tags/resources.md
+++ b/bot/resources/tags/resources.md
@@ -1,6 +1,0 @@
----
-embed:
-    title: "Resources"
----
-
-The [Resources page](https://www.pythondiscord.com/resources/) on our website contains a list of hand-selected learning resources that we regularly recommend to both beginners and experts.


### PR DESCRIPTION
Hi, everyone. 

This pull request is in reference to approved issue #2079.

**Demonstration of new resources command:**


https://user-images.githubusercontent.com/64165327/158717263-de660c4f-8536-4df3-b827-1fbaf33a981d.mp4


**Notes:**

- Edge cases like `!resources data science @iamericfletcher` link the user to the resources page without any filtering applied.
- In the future, I'd like to add in functionality that can accommodate multiple topics such as `!resources data science & discord bots` with URLs utilizing the `%2C` separator - https://www.pythondiscord.com/resources/?topics=data-science%2Cdiscord-bots
