### PR TITLE
feat: add created at field for message deleted log

### DIFF
--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -11,7 +11,7 @@ from deepdiff import DeepDiff
 from discord import Colour, Message, Thread
 from discord.abc import GuildChannel
 from discord.ext.commands import Cog, Context
-from discord.utils import escape_markdown, format_dt
+from discord.utils import escape_markdown, format_dt, snowflake_time
 
 from bot.bot import Bot
 from bot.constants import Categories, Channels, Colours, Emojis, Event, Guild as GuildConstant, Icons, Roles, URLs
@@ -631,6 +631,7 @@ class ModLog(Cog, name="ModLog"):
             response = (
                 f"**Channel:** {channel.category}/#{channel.name} (`{channel.id}`)\n"
                 f"**Message ID:** `{event.message_id}`\n"
+                f"**Sent at:** `{format_dt(snowflake_time(event.message_id))}`\n"
                 "\n"
                 "This message was not cached, so the message content cannot be displayed."
             )
@@ -638,6 +639,7 @@ class ModLog(Cog, name="ModLog"):
             response = (
                 f"**Channel:** #{channel.name} (`{channel.id}`)\n"
                 f"**Message ID:** `{event.message_id}`\n"
+                f"**Sent at:** `{format_dt(snowflake_time(event.message_id))}`\n"
                 "\n"
                 "This message was not cached, so the message content cannot be displayed."
             )

--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -573,7 +573,7 @@ class ModLog(Cog, name="ModLog"):
                 f"**Author:** {format_user(author)}\n"
                 f"**Channel:** {channel.category}/#{channel.name} (`{channel.id}`)\n"
                 f"**Message ID:** `{message.id}`\n"
-                f"**Sent at:** {format_dt(message.created_at, style='F')}\n"
+                f"**Sent at:** {format_dt(message.created_at)}\n"
                 f"[Jump to message]({message.jump_url})\n"
                 "\n"
             )
@@ -582,7 +582,7 @@ class ModLog(Cog, name="ModLog"):
                 f"**Author:** {format_user(author)}\n"
                 f"**Channel:** #{channel.name} (`{channel.id}`)\n"
                 f"**Message ID:** `{message.id}`\n"
-                f"**Sent at:** {format_dt(message.created_at, style='F')}\n"
+                f"**Sent at:** {format_dt(message.created_at)}\n"
                 f"[Jump to message]({message.jump_url})\n"
                 "\n"
             )
@@ -631,7 +631,7 @@ class ModLog(Cog, name="ModLog"):
             response = (
                 f"**Channel:** {channel.category}/#{channel.name} (`{channel.id}`)\n"
                 f"**Message ID:** `{event.message_id}`\n"
-                f"**Sent at:** `{format_dt(snowflake_time(event.message_id), style='f')}`\n"
+                f"**Sent at:** {format_dt(snowflake_time(event.message_id))}\n"
                 "\n"
                 "This message was not cached, so the message content cannot be displayed."
             )
@@ -639,7 +639,7 @@ class ModLog(Cog, name="ModLog"):
             response = (
                 f"**Channel:** #{channel.name} (`{channel.id}`)\n"
                 f"**Message ID:** `{event.message_id}`\n"
-                f"**Sent at:** `{format_dt(snowflake_time(event.message_id), style='F')}`\n"
+                f"**Sent at:** {format_dt(snowflake_time(event.message_id))}\n"
                 "\n"
                 "This message was not cached, so the message content cannot be displayed."
             )

--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -631,7 +631,7 @@ class ModLog(Cog, name="ModLog"):
             response = (
                 f"**Channel:** {channel.category}/#{channel.name} (`{channel.id}`)\n"
                 f"**Message ID:** `{event.message_id}`\n"
-                f"**Sent at:** `{format_dt(snowflake_time(event.message_id))}`\n"
+                f"**Sent at:** `{format_dt(snowflake_time(event.message_id), style='f')}`\n"
                 "\n"
                 "This message was not cached, so the message content cannot be displayed."
             )
@@ -639,7 +639,7 @@ class ModLog(Cog, name="ModLog"):
             response = (
                 f"**Channel:** #{channel.name} (`{channel.id}`)\n"
                 f"**Message ID:** `{event.message_id}`\n"
-                f"**Sent at:** `{format_dt(snowflake_time(event.message_id))}`\n"
+                f"**Sent at:** `{format_dt(snowflake_time(event.message_id), style='F')}`\n"
                 "\n"
                 "This message was not cached, so the message content cannot be displayed."
             )

--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -11,7 +11,7 @@ from deepdiff import DeepDiff
 from discord import Colour, Message, Thread
 from discord.abc import GuildChannel
 from discord.ext.commands import Cog, Context
-from discord.utils import escape_markdown
+from discord.utils import escape_markdown, format_dt
 
 from bot.bot import Bot
 from bot.constants import Categories, Channels, Colours, Emojis, Event, Guild as GuildConstant, Icons, Roles, URLs
@@ -573,6 +573,7 @@ class ModLog(Cog, name="ModLog"):
                 f"**Author:** {format_user(author)}\n"
                 f"**Channel:** {channel.category}/#{channel.name} (`{channel.id}`)\n"
                 f"**Message ID:** `{message.id}`\n"
+                f"**Sent at:** {format_dt(message.created_at, style='F')}\n"
                 f"[Jump to message]({message.jump_url})\n"
                 "\n"
             )
@@ -581,6 +582,7 @@ class ModLog(Cog, name="ModLog"):
                 f"**Author:** {format_user(author)}\n"
                 f"**Channel:** #{channel.name} (`{channel.id}`)\n"
                 f"**Message ID:** `{message.id}`\n"
+                f"**Sent at:** {format_dt(message.created_at, style='F')}\n"
                 f"[Jump to message]({message.jump_url})\n"
                 "\n"
             )


### PR DESCRIPTION
close #2120.
[this issue have been approved by a core dev but since they can't add the approve label, they said on discord that feel free to treat it as approved. click me for more info.](https://canary.discord.com/channels/267624335836053506/635950537262759947/958598485937127454)
~~due to `discord.RawMessageDeleteEvent` doesn't provide the message object we can't get the message create time.~~