### PR TITLE
Update to canonical PEP URLs

### DIFF
--- a/bot/exts/info/pep.py
+++ b/bot/exts/info/pep.py
@@ -15,7 +15,7 @@ from bot.utils.caching import AsyncCache
 log = get_logger(__name__)
 
 ICON_URL = "https://www.python.org/static/opengraph-icon-200x200.png"
-BASE_PEP_URL = "http://www.python.org/dev/peps/pep-"
+BASE_PEP_URL = "https://peps.python.org/pep-"
 PEPS_LISTING_API_URL = "https://api.github.com/repos/python/peps/contents?ref=main"
 
 pep_cache = AsyncCache()
@@ -67,7 +67,7 @@ class PythonEnhancementProposals(Cog):
         """Get information embed about PEP 0."""
         pep_embed = Embed(
             title="**PEP 0 - Index of Python Enhancement Proposals (PEPs)**",
-            url="https://www.python.org/dev/peps/"
+            url="https://peps.python.org/"
         )
         pep_embed.set_thumbnail(url=ICON_URL)
         pep_embed.add_field(name="Status", value="Active")

--- a/bot/exts/info/python_news.py
+++ b/bot/exts/info/python_news.py
@@ -14,7 +14,7 @@ from bot.log import get_logger
 from bot.utils import scheduling
 from bot.utils.webhooks import send_webhook
 
-PEPS_RSS_URL = "https://www.python.org/dev/peps/peps.rss/"
+PEPS_RSS_URL = "https://peps.python.org/peps.rss"
 
 RECENT_THREADS_TEMPLATE = "https://mail.python.org/archives/list/{name}@python.org/recent-threads"
 THREAD_TEMPLATE_URL = "https://mail.python.org/archives/api/list/{name}@python.org/thread/{id}/"

--- a/bot/resources/tags/dictcomps.md
+++ b/bot/resources/tags/dictcomps.md
@@ -11,4 +11,4 @@ One can use a dict comp to change an existing dictionary using its `items` metho
 >>> {key.upper(): value * 2 for key, value in first_dict.items()}
 {'I': 2, 'LOVE': 8, 'PYTHON': 12}
 ```
-For more information and examples, check out [PEP 274](https://www.python.org/dev/peps/pep-0274/)
+For more information and examples, check out [PEP 274](https://peps.python.org/pep-0274/)

--- a/bot/resources/tags/docstring.md
+++ b/bot/resources/tags/docstring.md
@@ -15,4 +15,4 @@ You can get the docstring by using the [`inspect.getdoc`](https://docs.python.or
 
 For the last example, you can print it by doing this: `print(inspect.getdoc(greet))`.
 
-For more details about what a docstring is and its usage, check out this guide by [Real Python](https://realpython.com/documenting-python-code/#docstrings-background), or the [official docstring specification](https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring).
+For more details about what a docstring is and its usage, check out this guide by [Real Python](https://realpython.com/documenting-python-code/#docstrings-background), or the [official docstring specification](https://peps.python.org/pep-0257/#what-is-a-docstring).

--- a/bot/resources/tags/enumerate.md
+++ b/bot/resources/tags/enumerate.md
@@ -10,4 +10,4 @@ into beautiful, _pythonic_ code:
 for index, item in enumerate(my_list):
     print(f"{index}: {item}")
 ```
-For more information, check out [the official docs](https://docs.python.org/3/library/functions.html#enumerate), or [PEP 279](https://www.python.org/dev/peps/pep-0279/).
+For more information, check out [the official docs](https://docs.python.org/3/library/functions.html#enumerate), or [PEP 279](https://peps.python.org/pep-0279/).

--- a/bot/resources/tags/indent.md
+++ b/bot/resources/tags/indent.md
@@ -16,9 +16,9 @@ The first line is not indented. The next two lines are indented to be inside of 
 
 **Indentation is used after:**
 **1.** [Compound statements](https://docs.python.org/3/reference/compound_stmts.html) (eg. `if`, `while`, `for`, `try`, `with`, `def`, `class`, and their counterparts)
-**2.** [Continuation lines](https://www.python.org/dev/peps/pep-0008/#indentation)
+**2.** [Continuation lines](https://peps.python.org/pep-0008/#indentation)
 
 **More Info**
-**1.** [Indentation style guide](https://www.python.org/dev/peps/pep-0008/#indentation)
-**2.** [Tabs or Spaces?](https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces)
+**1.** [Indentation style guide](https://peps.python.org/pep-0008/#indentation)
+**2.** [Tabs or Spaces?](https://peps.python.org/pep-0008/#tabs-or-spaces)
 **3.** [Official docs on indentation](https://docs.python.org/3/reference/lexical_analysis.html#indentation)

--- a/bot/resources/tags/pathlib.md
+++ b/bot/resources/tags/pathlib.md
@@ -18,4 +18,4 @@ Python 3 comes with a new module named `Pathlib`. Since Python 3.6, `pathlib.Pat
 • [**Why you should use pathlib** - Trey Hunner](https://treyhunner.com/2018/12/why-you-should-be-using-pathlib/)  
 • [**Answering concerns about pathlib** - Trey Hunner](https://treyhunner.com/2019/01/no-really-pathlib-is-great/)  
 • [**Official Documentation**](https://docs.python.org/3/library/pathlib.html)  
-• [**PEP 519** - Adding a file system path protocol](https://www.python.org/dev/peps/pep-0519/)  
+• [**PEP 519** - Adding a file system path protocol](https://peps.python.org/pep-0519/)  

--- a/bot/resources/tags/pep8.md
+++ b/bot/resources/tags/pep8.md
@@ -1,5 +1,5 @@
 **PEP 8** is the official style guide for Python. It includes comprehensive guidelines for code formatting, variable naming, and making your code easy to read. Professional Python developers are usually required to follow the guidelines, and will often use code-linters like flake8 to verify that the code they're writing complies with the style guide.
 
 More information:
-• [PEP 8 document](https://www.python.org/dev/peps/pep-0008)
+• [PEP 8 document](https://peps.python.org/pep-0008/)
 • [Our PEP 8 song!](https://www.youtube.com/watch?v=hgI0p1zf31k) :notes:

--- a/bot/resources/tags/positional-keyword.md
+++ b/bot/resources/tags/positional-keyword.md
@@ -19,7 +19,7 @@ def sum(a, b=1):
 sum(1, b=5)
 sum(1, 5) # same as above
 ```
-[Somtimes this is forced](https://www.python.org/dev/peps/pep-0570/#history-of-positional-only-parameter-semantics-in-python), in the case of the `pow()` function.
+[Somtimes this is forced](https://peps.python.org/pep-0570/#history-of-positional-only-parameter-semantics-in-python), in the case of the `pow()` function.
 
 The reverse is also true:
 ```py
@@ -33,6 +33,6 @@ The reverse is also true:
 ```
 
 **More info**  
-• [Keyword only arguments](https://www.python.org/dev/peps/pep-3102/)  
-• [Positional only arguments](https://www.python.org/dev/peps/pep-0570/)  
+• [Keyword only arguments](https://peps.python.org/pep-3102/)  
+• [Positional only arguments](https://peps.python.org/pep-0570/)  
 • `!tags param-arg` (Parameters vs. Arguments)  

--- a/bot/resources/tags/quotes.md
+++ b/bot/resources/tags/quotes.md
@@ -16,5 +16,5 @@ Example:
 If you need both single and double quotes inside your string, use the version that would result in the least amount of escapes. In the case of a tie, use the quotation you use the most.
 
 **References:**  
-• [pep-8 on quotes](https://www.python.org/dev/peps/pep-0008/#string-quotes)  
-• [convention for triple quoted strings](https://www.python.org/dev/peps/pep-0257/)
+• [pep-8 on quotes](https://peps.python.org/pep-0008/#string-quotes)  
+• [convention for triple quoted strings](https://peps.python.org/pep-0257/)

--- a/bot/resources/tags/sql-fstring.md
+++ b/bot/resources/tags/sql-fstring.md
@@ -13,4 +13,4 @@ Note: Different database libraries support different placeholder styles, e.g. `%
 
 **See Also**
 • [Extended Example with SQLite](https://docs.python.org/3/library/sqlite3.html) (search for "Instead, use the DB-API's parameter substitution")
-• [PEP-249](https://www.python.org/dev/peps/pep-0249) - A specification of how database libraries in Python should work
+• [PEP-249](https://peps.python.org/pep-0249/) - A specification of how database libraries in Python should work

--- a/bot/resources/tags/star-imports.md
+++ b/bot/resources/tags/star-imports.md
@@ -36,4 +36,4 @@ Conclusion: Namespaces are one honking great idea -- let's do more of those! *[3
 
 **[1]** If the module defines the variable `__all__`, the names defined in `__all__` will get imported by the wildcard import, otherwise all the names in the module get imported (except for names with a leading underscore)
 **[2]** [Namespaces and scopes](https://www.programiz.com/python-programming/namespace)
-**[3]** [Zen of Python](https://www.python.org/dev/peps/pep-0020/)
+**[3]** [Zen of Python](https://peps.python.org/pep-0020/)

--- a/bot/resources/tags/with.md
+++ b/bot/resources/tags/with.md
@@ -5,4 +5,4 @@ with open("test.txt", "r") as file:
 ```
 The above code automatically closes `file` when the `with` block exits, so you never have to manually do a `file.close()`. Most connection types, including file readers and database connections, support this.
 
-For more information, read [the official docs](https://docs.python.org/3/reference/compound_stmts.html#with), watch [Corey Schafer\'s context manager video](https://www.youtube.com/watch?v=-aKFBoZpiqA), or see [PEP 343](https://www.python.org/dev/peps/pep-0343/).
+For more information, read [the official docs](https://docs.python.org/3/reference/compound_stmts.html#with), watch [Corey Schafer\'s context manager video](https://www.youtube.com/watch?v=-aKFBoZpiqA), or see [PEP 343](https://peps.python.org/pep-0343/).


### PR DESCRIPTION
With the recent implementation of [PEP 676](https://peps.python.org/pep-0676/) the canonical URL for PEPs has changed from, for example:

https://www.python.org/dev/peps/pep-0008/

to:

https://peps.python.org/pep-0008/

Redirects are in place so the old links still work, but let's update to use the new canonical form.

See also:

* [bpo-47126](https://bugs.python.org/issue47126) / https://github.com/python/cpython/pull/32124
* https://github.com/python/devguide/pull/822
* https://github.com/sphinx-doc/sphinx/pull/10267

---

Also the RSS feed:

```python
PEPS_RSS_URL = "https://www.python.org/dev/peps/peps.rss/"
```

Redirects to `https://peps.python.org/peps.rss/` with trailing slash which is a 404.

`https://peps.python.org/peps.rss` without trailing slash works, so let's use this. 

(I've also filed https://github.com/python/peps/issues/2493, because we should keep that old redirect working too.)
