### PR TITLE
Add support for BIG SOLIDUS unicode characters in off topic names

### DIFF
--- a/bot/converters.py
+++ b/bot/converters.py
@@ -382,8 +382,8 @@ class Age(DurationDelta):
 class OffTopicName(Converter):
     """A converter that ensures an added off-topic name is valid."""
 
-    ALLOWED_CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ!?'`-<>"
-    TRANSLATED_CHARACTERS = "𝖠𝖡𝖢𝖣𝖤𝖥𝖦𝖧𝖨𝖩𝖪𝖫𝖬𝖭𝖮𝖯𝖰𝖱𝖲𝖳𝖴𝖵𝖶𝖷𝖸𝖹ǃ？’’-＜＞"
+    ALLOWED_CHARACTERS = r"ABCDEFGHIJKLMNOPQRSTUVWXYZ!?'`-<>\/"
+    TRANSLATED_CHARACTERS = "𝖠𝖡𝖢𝖣𝖤𝖥𝖦𝖧𝖨𝖩𝖪𝖫𝖬𝖭𝖮𝖯𝖰𝖱𝖲𝖳𝖴𝖵𝖶𝖷𝖸𝖹ǃ？’’-＜＞⧹⧸"
 
     @classmethod
     def translate_name(cls, name: str, *, from_unicode: bool = True) -> str:


### PR DESCRIPTION
This PR will allow us to add these unicode characters to off-topic names: 

- ⧸ Big Solidus

- ⧹ Big Reverse Solidus

<img width="407" alt="image" src="https://user-images.githubusercontent.com/75038675/164571522-9961b1c4-5309-4300-9c04-972007fbbe6b.png">

The PR for the site should be merged first: python-discord/site#717