### PR TITLE
Speed Up Sync Cog Loading

### DIFF
--- a/bot/exts/backend/sync/_cog.py
+++ b/bot/exts/backend/sync/_cog.py
@@ -1,10 +1,11 @@
 import asyncio
+import datetime
 from typing import Any, Dict
 
 from botcore.site_api import ResponseCodeError
 from discord import Member, Role, User
 from discord.ext import commands
-from discord.ext.commands import Cog, Context
+from discord.ext.commands import Cog, Context, errors
 
 from bot import constants
 from bot.bot import Bot
@@ -29,10 +30,17 @@ class Sync(Cog):
             return
 
         log.info("Waiting for guild to be chunked to start syncers.")
+        end = datetime.datetime.now() + datetime.timedelta(minutes=30)
         while not guild.chunked:
             await asyncio.sleep(10)
-        log.info("Starting syncers.")
+            if datetime.datetime.now() > end:
+                # More than 30 minutes have passed while trying, abort
+                raise errors.ExtensionFailed(
+                    self.__class__.__name__,
+                    RuntimeError("The guild was not chunked in time, not loading sync cog.")
+                )
 
+        log.info("Starting syncers.")
         for syncer in (_syncers.RoleSyncer, _syncers.UserSyncer):
             await syncer.sync(guild)
 

--- a/bot/exts/backend/sync/_cog.py
+++ b/bot/exts/backend/sync/_cog.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Dict
 
 from botcore.site_api import ResponseCodeError
@@ -26,6 +27,11 @@ class Sync(Cog):
         guild = self.bot.get_guild(constants.Guild.id)
         if guild is None:
             return
+
+        log.info("Waiting for guild to be chunked to start syncers.")
+        while not guild.chunked:
+            await asyncio.sleep(10)
+        log.info("Starting syncers.")
 
         for syncer in (_syncers.RoleSyncer, _syncers.UserSyncer):
             await syncer.sync(guild)

--- a/bot/exts/backend/sync/_syncers.py
+++ b/bot/exts/backend/sync/_syncers.py
@@ -2,6 +2,7 @@ import abc
 import typing as t
 from collections import namedtuple
 
+import discord.errors
 from botcore.site_api import ResponseCodeError
 from discord import Guild
 from discord.ext.commands import Context
@@ -9,7 +10,6 @@ from more_itertools import chunked
 
 import bot
 from bot.log import get_logger
-from bot.utils.members import get_or_fetch_member
 
 log = get_logger(__name__)
 
@@ -157,7 +157,16 @@ class UserSyncer(Syncer):
                 if db_user[db_field] != guild_value:
                     updated_fields[db_field] = guild_value
 
-            if guild_user := await get_or_fetch_member(guild, db_user["id"]):
+            guild_user = guild.get_member(db_user["id"])
+            if not guild_user and db_user["in_guild"]:
+                # The member was in the guild during the last sync.
+                # We try to fetch them to verify cache integrity.
+                try:
+                    guild_user = await guild.fetch_member(db_user["id"])
+                except discord.errors.NotFound:
+                    guild_user = None
+
+            if guild_user:
                 seen_guild_users.add(guild_user.id)
 
                 maybe_update("name", guild_user.name)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -171,7 +171,7 @@ class MockGuild(CustomMockMixin, unittest.mock.Mock, HashableMixin):
     spec_set = guild_instance
 
     def __init__(self, roles: Optional[Iterable[MockRole]] = None, **kwargs) -> None:
-        default_kwargs = {'id': next(self.discord_id), 'members': []}
+        default_kwargs = {'id': next(self.discord_id), 'members': [], "chunked": True}
         super().__init__(**collections.ChainMap(kwargs, default_kwargs))
 
         self.roles = [MockRole(name="@everyone", position=1, id=0)]


### PR DESCRIPTION
The user syncer was blocking the startup of the sync cog due to having to perform thousands of pointless member fetch requests. This speeds up that process b:
- Increasing the probability that the cache is up-to-date using `Guild.chunked`, and assuming that any found cache data is correct
- Limiting the fetches to members who were in the guild during the previous sync only, meaning we don't fetch a bunch of outdated members
