### PR TITLE
Use async with Messageable.typing() everywhere

### DIFF
--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -431,7 +431,7 @@ class DocCog(commands.Cog):
     async def refresh_command(self, ctx: commands.Context) -> None:
         """Refresh inventories and show the difference."""
         old_inventories = set(self.base_urls)
-        with ctx.typing():
+        async with ctx.typing():
             await self.refresh_inventories()
         new_inventories = set(self.base_urls)
 


### PR DESCRIPTION
Closes BOT-33Z Closes #2154

With the latest version of discord.py support for the with Messageable.typingn() was droped, in favour of only using async with.