### PR TITLE
Don't decode empty content as json in thread bumper

### DIFF
--- a/bot/exts/utils/thread_bumper.py
+++ b/bot/exts/utils/thread_bumper.py
@@ -24,6 +24,23 @@ class ThreadBumper(commands.Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
 
+    async def thread_exists_in_site(self, thread_id: int) -> bool:
+        """Return whether the given thread_id exists in the site api's bump list."""
+        # If the thread exists, site returns a 204 with no content.
+        # Due to this, `api_client.request()` cannot be used, as it always attempts to decode the response as json.
+        # Instead, call the site manually using the api_client's session, to use the auth token logic in the wrapper.
+
+        async with self.bot.api_client.session.get(
+            f"{self.bot.api_client._url_for(THREAD_BUMP_ENDPOINT)}/{thread_id}"
+        ) as response:
+            if response.status == 204:
+                return True
+            elif response.status == 404:
+                return False
+            else:
+                # A status other than 204/404 is undefined behaviour from site. Raise error for investigation.
+                raise ResponseCodeError(response, response.text())
+
     async def unarchive_threads_not_manually_archived(self, threads: list[discord.Thread]) -> None:
         """
         Iterate through and unarchive any threads that weren't manually archived recently.
@@ -89,12 +106,7 @@ class ThreadBumper(commands.Cog):
             else:
                 raise commands.BadArgument("You must provide a thread, or run this command within a thread.")
 
-        try:
-            await self.bot.api_client.get(f"{THREAD_BUMP_ENDPOINT}/{thread.id}")
-        except ResponseCodeError as e:
-            if e.status != 404:
-                raise
-        else:
+        if await self.thread_exists_in_site(thread.id):
             raise commands.BadArgument("This thread is already in the bump list.")
 
         await self.bot.api_client.post(THREAD_BUMP_ENDPOINT, data={"thread_id": thread.id})
@@ -109,9 +121,7 @@ class ThreadBumper(commands.Cog):
             else:
                 raise commands.BadArgument("You must provide a thread, or run this command within a thread.")
 
-        try:
-            await self.bot.api_client.get(f"{THREAD_BUMP_ENDPOINT}/{thread.id}")
-        except ResponseCodeError:
+        if not await self.thread_exists_in_site(thread.id):
             raise commands.BadArgument("This thread is not in the bump list.")
 
         await self.bot.api_client.delete(f"{THREAD_BUMP_ENDPOINT}/{thread.id}")
@@ -137,12 +147,7 @@ class ThreadBumper(commands.Cog):
         if not after.archived:
             return
 
-        try:
-            await self.bot.api_client.get(f"{THREAD_BUMP_ENDPOINT}/{after.id}")
-        except ResponseCodeError as e:
-            if e.status != 404:
-                raise
-        else:
+        if await self.thread_exists_in_site(after.id):
             await self.unarchive_threads_not_manually_archived([after])
 
     async def cog_check(self, ctx: commands.Context) -> bool:


### PR DESCRIPTION
Closes #2162 Closes BOT-343

self.bot.api_client.request can not be used to check if a thread id exists in the bumped thread list on site, as self.bot.api_client.request() always attempts to decode the response as json.

The thread bump viewset in site returns a 204 if the given thread exists with no content, so this does not work.