### PR TITLE
Bump malformed API response from debug to error log

### DIFF
--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -285,7 +285,7 @@ class ErrorHandler(Cog):
             ctx.bot.stats.incr("errors.api_error_404")
         elif e.status == 400:
             content = await e.response.json()
-            log.debug(f"API responded with 400 for command {ctx.command}: %r.", content)
+            log.error(f"API responded with 400 for command {ctx.command}: %r.", content)
             await ctx.send("According to the API, your request is malformed.")
             ctx.bot.stats.incr("errors.api_error_400")
         elif 500 <= e.status < 600:

--- a/tests/bot/exts/backend/test_error_handler.py
+++ b/tests/bot/exts/backend/test_error_handler.py
@@ -477,11 +477,11 @@ class IndividualErrorHandlerTests(unittest.IsolatedAsyncioTestCase):
 
     @patch("bot.exts.backend.error_handler.log")
     async def test_handle_api_error(self, log_mock):
-        """Should `ctx.send` on HTTP error codes, `log.debug|warning` depends on code."""
+        """Should `ctx.send` on HTTP error codes, and log at correct level."""
         test_cases = (
             {
                 "error": ResponseCodeError(AsyncMock(status=400)),
-                "log_level": "debug"
+                "log_level": "error"
             },
             {
                 "error": ResponseCodeError(AsyncMock(status=404)),
@@ -505,6 +505,8 @@ class IndividualErrorHandlerTests(unittest.IsolatedAsyncioTestCase):
                 self.ctx.send.assert_awaited_once()
                 if case["log_level"] == "warning":
                     log_mock.warning.assert_called_once()
+                elif case["log_level"] == "error":
+                    log_mock.error.assert_called_once()
                 else:
                     log_mock.debug.assert_called_once()
 


### PR DESCRIPTION
If we're getting a malformed request response from the API, something in our code is wrong, so we should log error.