### PR TITLE
Catch correct exception in clean cog

### DIFF
--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -443,7 +443,7 @@ class Clean(Cog):
         if log_url and is_mod_channel(ctx.channel):
             try:
                 await ctx.reply(success_message)
-            except errors.NotFound:
+            except errors.HTTPException:
                 await ctx.send(success_message)
         elif log_url:
             if mods := self.bot.get_channel(Channels.mods):


### PR DESCRIPTION
When attempted to reply to a message, fi the message is not found, Discord.py does not raise a NotFound error, instead it raises the generic HTTPException.

Due to this, we now except this error when trying to reply to the message.