### PR TITLE
Add special handling for eval command followed by backticks.

### DIFF
--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -1,3 +1,4 @@
+import copy
 import difflib
 
 from botcore.site_api import ResponseCodeError
@@ -189,15 +190,14 @@ class ErrorHandler(Cog):
 
         Return True if command was invoked, else False
         """
-        old_message_content = ctx.message.content
+        msg = copy.copy(ctx.message)
 
-        command, sep, end = ctx.message.content.partition("```")
-        ctx.message.content = command + " " + sep + end
-        new_ctx = await self.bot.get_context(ctx.message)
+        command, sep, end = msg.content.partition("```")
+        msg.content = command + " " + sep + end
+        new_ctx = await self.bot.get_context(msg)
 
         eval_command = self.bot.get_command("eval")
         if eval_command is None or new_ctx.command != eval_command:
-            ctx.message.content = old_message_content
             return False
 
         log.debug("Running fixed eval command.")

--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -65,6 +65,8 @@ class ErrorHandler(Cog):
         if isinstance(e, errors.CommandNotFound) and not getattr(ctx, "invoked_from_error_handler", False):
             if await self.try_silence(ctx):
                 return
+            if await self.try_run_eval(ctx):
+                return
             await self.try_get_tag(ctx)  # Try to look for a tag with the command's name
         elif isinstance(e, errors.UserInputError):
             log.debug(debug_message)
@@ -178,6 +180,31 @@ class ErrorHandler(Cog):
 
         if not any(role.id in MODERATION_ROLES for role in ctx.author.roles):
             await self.send_command_suggestion(ctx, ctx.invoked_with)
+
+    async def try_run_eval(self, ctx: Context) -> bool:
+        """
+        Attempt to run eval command with backticks directly after command.
+
+        For example: !eval```print("hi")```
+
+        Return True if command was invoked, else False
+        """
+        old_message_content = ctx.message.content
+
+        command, sep, end = ctx.message.content.partition("```")
+        ctx.message.content = command + " " + sep + end
+        new_ctx = await self.bot.get_context(ctx.message)
+
+        eval_command = self.bot.get_command("eval")
+        if eval_command is None or new_ctx.command != eval_command:
+            ctx.message.content = old_message_content
+            return False
+
+        log.debug("Running fixed eval command.")
+        new_ctx.invoked_from_error_handler = True
+        await self.bot.invoke(new_ctx)
+
+        return True
 
     async def send_command_suggestion(self, ctx: Context, command_name: str) -> None:
         """Sends user similar commands if any can be found."""

--- a/tests/bot/exts/backend/test_error_handler.py
+++ b/tests/bot/exts/backend/test_error_handler.py
@@ -48,6 +48,7 @@ class ErrorHandlerTests(unittest.IsolatedAsyncioTestCase):
         cog = ErrorHandler(self.bot)
         cog.try_silence = AsyncMock()
         cog.try_get_tag = AsyncMock()
+        cog.try_run_eval = AsyncMock(return_value=False)
 
         for case in test_cases:
             with self.subTest(try_silence_return=case["try_silence_return"], try_get_tag=case["called_try_get_tag"]):
@@ -76,6 +77,7 @@ class ErrorHandlerTests(unittest.IsolatedAsyncioTestCase):
         cog = ErrorHandler(self.bot)
         cog.try_silence = AsyncMock()
         cog.try_get_tag = AsyncMock()
+        cog.try_run_eval = AsyncMock()
 
         error = errors.CommandNotFound()
 
@@ -83,6 +85,7 @@ class ErrorHandlerTests(unittest.IsolatedAsyncioTestCase):
 
         cog.try_silence.assert_not_awaited()
         cog.try_get_tag.assert_not_awaited()
+        cog.try_run_eval.assert_not_awaited()
         self.ctx.send.assert_not_awaited()
 
     async def test_error_handler_user_input_error(self):


### PR DESCRIPTION
Closes #2047

I think this approach should be fairly robust. I figured this wasn't worth extending to inline codeblocks or other commands.