### PR TITLE
Remove allowed_strings in favour of Literal

### DIFF
--- a/bot/converters.py
+++ b/bot/converters.py
@@ -32,25 +32,6 @@ DISCORD_EPOCH_DT = snowflake_time(0)
 RE_USER_MENTION = re.compile(r"<@!?([0-9]+)>$")
 
 
-def allowed_strings(*values, preserve_case: bool = False) -> t.Callable[[str], str]:
-    """
-    Return a converter which only allows arguments equal to one of the given values.
-
-    Unless preserve_case is True, the argument is converted to lowercase. All values are then
-    expected to have already been given in lowercase too.
-    """
-    def converter(arg: str) -> str:
-        if not preserve_case:
-            arg = arg.lower()
-
-        if arg not in values:
-            raise BadArgument(f"Only the following values are allowed:\n```{', '.join(values)}```")
-        else:
-            return arg
-
-    return converter
-
-
 class ValidDiscordServerInvite(Converter):
     """
     A converter that validates whether a given string is a valid Discord server invite.

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -6,7 +6,7 @@ import textwrap
 from collections import defaultdict
 from contextlib import suppress
 from types import SimpleNamespace
-from typing import Dict, NamedTuple, Optional, Tuple, Union
+from typing import Dict, Literal, NamedTuple, Optional, Tuple, Union
 
 import aiohttp
 import discord
@@ -16,7 +16,7 @@ from discord.ext import commands
 
 from bot.bot import Bot
 from bot.constants import MODERATION_ROLES, RedirectOutput
-from bot.converters import Inventory, PackageName, ValidURL, allowed_strings
+from bot.converters import Inventory, PackageName, ValidURL
 from bot.log import get_logger
 from bot.pagination import LinePaginator
 from bot.utils.lock import SharedEvent, lock
@@ -452,7 +452,7 @@ class DocCog(commands.Cog):
     async def clear_cache_command(
         self,
         ctx: commands.Context,
-        package_name: Union[PackageName, allowed_strings("*")]  # noqa: F722
+        package_name: Union[PackageName, Literal["*"]]
     ) -> None:
         """Clear the persistent redis cache for `package`."""
         if await doc_cache.delete(package_name):

--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -9,7 +9,7 @@ from discord.utils import escape_markdown
 
 from bot import constants
 from bot.bot import Bot
-from bot.converters import Expiry, Infraction, MemberOrUser, Snowflake, UnambiguousUser, allowed_strings
+from bot.converters import Expiry, Infraction, MemberOrUser, Snowflake, UnambiguousUser
 from bot.decorators import ensure_future_timestamp
 from bot.errors import InvalidInfraction
 from bot.exts.moderation.infraction import _utils
@@ -89,7 +89,7 @@ class ModManagement(commands.Cog):
         self,
         ctx: Context,
         infraction: Infraction,
-        duration: t.Union[Expiry, allowed_strings("p", "permanent"), None],   # noqa: F821
+        duration: t.Union[Expiry, t.Literal["p", "permanent"], None],
         *,
         reason: str = None
     ) -> None:
@@ -129,7 +129,7 @@ class ModManagement(commands.Cog):
         self,
         ctx: Context,
         infraction: Infraction,
-        duration: t.Union[Expiry, allowed_strings("p", "permanent"), None],   # noqa: F821
+        duration: t.Union[Expiry, t.Literal["p", "permanent"], None],
         *,
         reason: str = None
     ) -> None:

--- a/bot/exts/moderation/metabase.py
+++ b/bot/exts/moderation/metabase.py
@@ -2,7 +2,7 @@ import csv
 import json
 from datetime import timedelta
 from io import StringIO
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional
 
 import arrow
 from aiohttp.client_exceptions import ClientResponseError
@@ -13,7 +13,6 @@ from discord.ext.commands import Cog, Context, group, has_any_role
 
 from bot.bot import Bot
 from bot.constants import Metabase as MetabaseConfig, Roles
-from bot.converters import allowed_strings
 from bot.log import get_logger
 from bot.utils import send_to_paste_service
 from bot.utils.channel import is_mod_channel
@@ -108,7 +107,7 @@ class Metabase(Cog):
         self,
         ctx: Context,
         question_id: int,
-        extension: allowed_strings("csv", "json") = "csv"
+        extension: Literal["csv", "json"] = "csv"
     ) -> None:
         """
         Extract data from a metabase question.


### PR DESCRIPTION
This PR removes the `allowed_strings` converter because we can use `typing.Literal` as a converter to the same effect.

Original PR is #1929