### PR TITLE
Filter out all header links in signatures for docs

### DIFF
--- a/bot/exts/info/doc/_html.py
+++ b/bot/exts/info/doc/_html.py
@@ -129,6 +129,9 @@ def get_signatures(start_signature: PageElement) -> List[str]:
             start_signature,
             *_find_next_siblings_until_tag(start_signature, ("dd",), limit=2),
     )[-MAX_SIGNATURE_AMOUNT:]:
+        for tag in element.find_all("a", class_="headerlink", recursive=False):
+            tag.decompose()
+
         signature = _UNWANTED_SIGNATURE_SYMBOLS_RE.sub("", element.text)
 
         if signature:

--- a/bot/exts/info/doc/_parsing.py
+++ b/bot/exts/info/doc/_parsing.py
@@ -255,4 +255,5 @@ def get_symbol_markdown(soup: BeautifulSoup, symbol_data: DocItem) -> Optional[s
     else:
         signature = get_signatures(symbol_heading)
         description = get_dd_description(symbol_heading)
-    return _create_markdown(signature, description, symbol_data.url).replace("¶", "").strip()
+
+    return _create_markdown(signature, description, symbol_data.url).strip()


### PR DESCRIPTION
Replacing the paragraph sign on the embed string, which was used previously, missed some other symbols that were used for permalinks, like the # here 
![](https://i.imgur.com/xLZmDlD.png)

The replace was previously done on the description too, but from a quick look I haven't found anything that'd use that in the description, may have been left over from when other definitions were also sent in the description. If it pops up somewhere the same filtering can be added to the description tags