### PR TITLE
Clean improvments

### DIFF
--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -182,7 +182,7 @@ class Clean(Cog):
             return first_limit < message.created_at < second_limit
 
         def predicate_after(message: Message) -> bool:
-            """Check if the message is older than the first limit."""
+            """Check if the message is younger than the first limit."""
             return message.created_at > first_limit
 
         predicates = []

--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -621,7 +621,11 @@ class Clean(Cog):
 
     @command()
     async def purge(self, ctx: Context, users: Greedy[User], age: Optional[Union[Age, ISODateTime]] = None) -> None:
-        """Clean messages of users from all public channels up to a certain message age (10 minutes by default)."""
+        """
+        Clean messages of users from all public channels up to a certain message age (10 minutes by default).
+
+        The age is *exclusive*, meaning that `10s` won't delete a message exactly 10 seconds old.
+        """
         if age is None:
             age = await Age().convert(ctx, "10M")
         await self._clean_messages(ctx, channels="*", users=users, first_limit=age)

--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -8,7 +8,7 @@ from itertools import takewhile
 from typing import Callable, Iterable, Literal, Optional, TYPE_CHECKING, Union
 
 from discord import Colour, Message, NotFound, TextChannel, Thread, User, errors
-from discord.ext.commands import Cog, Context, Converter, Greedy, group, has_any_role
+from discord.ext.commands import Cog, Context, Converter, Greedy, command, group, has_any_role
 from discord.ext.commands.converter import TextChannelConverter
 from discord.ext.commands.errors import BadArgument
 
@@ -452,7 +452,7 @@ class Clean(Cog):
 
     # region: Commands
 
-    @group(invoke_without_command=True, name="clean", aliases=["clear", "purge"])
+    @group(invoke_without_command=True, name="clean", aliases=("clear",))
     async def clean_group(
         self,
         ctx: Context,
@@ -618,6 +618,13 @@ class Clean(Cog):
 
         await self._send_expiring_message(ctx, message)
         await self._delete_invocation(ctx)
+
+    @command()
+    async def purge(self, ctx: Context, users: Greedy[User], age: Optional[Union[Age, ISODateTime]] = None) -> None:
+        """Clean messages of users from all public channels up to a certain message age (10 minutes by default)."""
+        if age is None:
+            age = await Age().convert(ctx, "10M")
+        await self._clean_messages(ctx, channels="*", users=users, first_limit=age)
 
     # endregion
 

--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -241,9 +241,14 @@ class Clean(Cog):
         self,
         channels: Iterable[TextChannel],
         to_delete: Predicate,
-        before: datetime,
-        after: Optional[datetime] = None
+        after: datetime,
+        before: Optional[datetime] = None
     ) -> tuple[defaultdict[TextChannel, list], list]:
+        """
+        Collect the messages for deletion by iterating over the histories of the appropriate channels.
+
+        The clean cog enforces an upper limit on message age through `_validate_input`.
+        """
         message_mappings = defaultdict(list)
         message_ids = []
 
@@ -419,8 +424,8 @@ class Clean(Cog):
             message_mappings, message_ids = await self._get_messages_from_channels(
                 channels=deletion_channels,
                 to_delete=predicate,
-                before=second_limit,
-                after=first_limit  # Remember first is the earlier datetime.
+                after=first_limit,  # Remember first is the earlier datetime (the "older" time).
+                before=second_limit
             )
 
         if not self.cleaning:

--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -183,7 +183,7 @@ class Clean(Cog):
 
         def predicate_after(message: Message) -> bool:
             """Check if the message is older than the first limit."""
-            return message.created_at >= first_limit
+            return message.created_at > first_limit
 
         predicates = []
         # Set up the correct predicate

--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -179,7 +179,7 @@ class Clean(Cog):
 
         def predicate_range(message: Message) -> bool:
             """Check if the message age is between the two limits."""
-            return first_limit <= message.created_at <= second_limit
+            return first_limit < message.created_at < second_limit
 
         def predicate_after(message: Message) -> bool:
             """Check if the message is older than the first limit."""
@@ -471,7 +471,7 @@ class Clean(Cog):
 
         \u2003• `users`: A series of user mentions, ID's, or names.
         \u2003• `first_limit` and `second_limit`: A message, a duration delta, or an ISO datetime.
-        At least one limit is required.
+        At least one limit is required. The limits are *exclusive*.
         If a message is provided, cleaning will happen in that channel, and channels cannot be provided.
         If only one of them is provided, acts as `clean until`. If both are provided, acts as `clean between`.
         \u2003• `regex`: A regex pattern the message must contain to be deleted.
@@ -565,6 +565,8 @@ class Clean(Cog):
 
         A limit can be either a message, and ISO date-time string, or a time delta.
 
+        The limit is *exclusive*.
+
         If a message is specified the cleanup will be limited to the channel the message is in.
 
         If a timedelta or an ISO datetime is specified, `channels` can be specified to clean across multiple channels.
@@ -589,6 +591,8 @@ class Clean(Cog):
 
         The range is specified through two limits.
         A limit can be either a message, and ISO date-time string, or a time delta.
+
+        The limits are *exclusive*.
 
         If two messages are specified, they both must be in the same channel.
         The cleanup will be limited to the channel the messages are in.


### PR DESCRIPTION
- Fixed a bug where `clean between` deleted the last message. Clarified in the appropriate command descriptions that the clean limits are exclusive.
- Added a shortcut to a common use case of deleting all recent public messages of a user. Since the `purge` alias was never used for the clean group I repurposed it for this new command.