### PR TITLE
Enhance guild_invite based autobans

### DIFF
--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -55,17 +55,20 @@ class FilterLists(Cog):
         """Add an item to a filterlist."""
         allow_type = "whitelist" if allowed else "blacklist"
 
-        # If this is a server invite, we gotta validate it.
+        # If this is a guild invite, we gotta validate it.
         if list_type == "GUILD_INVITE":
             guild_data = await self._validate_guild_invite(ctx, content)
             content = guild_data.get("id")
 
-            # Unless the user has specified another comment, let's
-            # use the server name as the comment so that the list
-            # of guild IDs will be more easily readable when we
-            # display it.
-            if not comment:
-                comment = guild_data.get("name")
+            # Some guild invites are autoban filters, which require the mod
+            # to set a comment which includes [autoban].
+            # Having the guild name in the comment is still useful when reviewing
+            # filter list, so prepend it to the set comment in case some mod forgets.
+            comment = " - ".join(
+                comment_part
+                for comment_part in (guild_data.get("name", ""), comment)
+                if comment_part
+            )
 
         # If it's a file format, let's make sure it has a leading dot.
         elif list_type == "FILE_FORMAT" and not content.startswith("."):

--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -64,9 +64,11 @@ class FilterLists(Cog):
             # to set a comment which includes [autoban].
             # Having the guild name in the comment is still useful when reviewing
             # filter list, so prepend it to the set comment in case some mod forgets.
+            guild_name_part = f'Guild "{guild_data["name"]}"' if "name" in guild_data else None
+
             comment = " - ".join(
                 comment_part
-                for comment_part in (guild_data.get("name", ""), comment)
+                for comment_part in (guild_name_part, comment)
                 if comment_part
             )
 

--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -118,7 +118,8 @@ class FilterLists(Cog):
         # If it is an autoban trigger we send a warning in #mod-meta
         if comment and "[autoban]" in comment:
             await self.bot.get_channel(Channels.mod_meta).send(
-                f":warning: Heads-up! The new filter `{content}` (`{comment}`) will automatically ban users."
+                f":warning: Heads-up! The new `{list_type}` filter "
+                f"`{content}` (`{comment}`) will automatically ban users."
             )
 
         # Insert the item into the cache

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -428,7 +428,7 @@ class Filtering(Cog):
         reason: Optional[str] = None,
         *,
         is_eval: bool = False,
-        auto_ban: bool = False,
+        autoban: bool = False,
     ) -> None:
         """Send a mod log for a triggered filter."""
         if msg.channel.type is ChannelType.private:
@@ -442,7 +442,7 @@ class Filtering(Cog):
         content = str(msg.author.id)  # quality-of-life improvement for mobile moderators
 
         # If we are going to autoban, we don't want to ping and don't need the user ID
-        if auto_ban:
+        if autoban:
             ping_everyone = False
             content = None
 


### PR DESCRIPTION
This PR includes various improvements to guild_invite based autobans as the strucutre of the filter response is slightly different to other filters, causing bad UX.

In this PR I have auto prepended the guild name to guild invite filters, to ensure the guild name is always present in the reason. This ensures that when looking at the block list, or when notifying users about a new autoban guild_invite filter being added, the guild name is always there.

The message sent when a new autoban filter is added also now includes the filter list type, to make it more obvious at a glance when it would be triggered.

I have also made it so that any type of autoban filter does not ping mods when sending the log to mod-alerts, as they have already been auto-actioned by the bot.