### PR TITLE
Fix help embed views

### DIFF
--- a/bot/exts/info/help.py
+++ b/bot/exts/info/help.py
@@ -57,16 +57,13 @@ class SubcommandButton(ui.Button):
 
     async def callback(self, interaction: Interaction) -> None:
         """Edits the help embed to that of the subcommand."""
-        message = interaction.message
-        if not message:
-            return
-
         subcommand = self.command
         if isinstance(subcommand, Group):
             embed, subcommand_view = await self.help_command.format_group_help(subcommand)
         else:
             embed, subcommand_view = await self.help_command.command_formatting(subcommand)
-        await message.edit(embed=embed, view=subcommand_view)
+
+        await interaction.response.edit_message(embed=embed, view=subcommand_view)
 
 
 class GroupButton(ui.Button):
@@ -98,12 +95,8 @@ class GroupButton(ui.Button):
 
     async def callback(self, interaction: Interaction) -> None:
         """Edits the help embed to that of the parent."""
-        message = interaction.message
-        if not message:
-            return
-
         embed, group_view = await self.help_command.format_group_help(self.command.parent)
-        await message.edit(embed=embed, view=group_view)
+        await interaction.response.edit_message(embed=embed, view=group_view)
 
 
 class CommandView(ui.View):
@@ -118,7 +111,7 @@ class CommandView(ui.View):
         super().__init__()
 
         if command.parent:
-            self.children.append(GroupButton(help_command, command, emoji="↩️"))
+            self.add_item(GroupButton(help_command, command, emoji="↩️"))
 
     async def interaction_check(self, interaction: Interaction) -> bool:
         """


### PR DESCRIPTION
Due to various breaking changes in the discord.py library the views of the help embed stopped working properly.

- Use `add_item` in `CommandView`. This was done in GroupView but was apparently missed in `CommandView`, and the former (hacky) method no longer works.
- Instead of editing the help message normally (which required to then defer the response), the message edit is made to be the response itself. It seems like the callback would automatically defer the response if none was made, but that no longer happens. Thanks to @onerandomusername for pointing me to the right method.