### PR TITLE
filter out header links in descriptions

### DIFF
--- a/bot/exts/info/doc/_html.py
+++ b/bot/exts/info/doc/_html.py
@@ -1,4 +1,3 @@
-import re
 from functools import partial
 from typing import Callable, Container, Iterable, List, Union
 
@@ -11,7 +10,6 @@ from . import MAX_SIGNATURE_AMOUNT
 
 log = get_logger(__name__)
 
-_UNWANTED_SIGNATURE_SYMBOLS_RE = re.compile(r"\[source]|\\\\|¶")
 _SEARCH_END_TAG_ATTRS = (
     "data",
     "function",
@@ -129,12 +127,23 @@ def get_signatures(start_signature: PageElement) -> List[str]:
             start_signature,
             *_find_next_siblings_until_tag(start_signature, ("dd",), limit=2),
     )[-MAX_SIGNATURE_AMOUNT:]:
-        for tag in element.find_all("a", class_="headerlink", recursive=False):
+        for tag in element.find_all(_filter_signature_links, recursive=False):
             tag.decompose()
 
-        signature = _UNWANTED_SIGNATURE_SYMBOLS_RE.sub("", element.text)
-
+        signature = element.text
         if signature:
             signatures.append(signature)
 
     return signatures
+
+
+def _filter_signature_links(tag: Tag) -> bool:
+    """Return True if `tag` is a headerlink, or a link to source code; False otherwise."""
+    if tag.name == "a":
+        if "headerlink" in tag.get("class", ()):
+            return True
+
+        if tag.find(class_="viewcode-link"):
+            return True
+
+    return False

--- a/bot/exts/info/doc/_parsing.py
+++ b/bot/exts/info/doc/_parsing.py
@@ -256,4 +256,9 @@ def get_symbol_markdown(soup: BeautifulSoup, symbol_data: DocItem) -> Optional[s
         signature = get_signatures(symbol_heading)
         description = get_dd_description(symbol_heading)
 
+    for description_element in description:
+        if isinstance(description_element, Tag):
+            for tag in description_element.find_all("a", class_="headerlink"):
+                tag.decompose()
+
     return _create_markdown(signature, description, symbol_data.url).strip()


### PR DESCRIPTION
Continuation of #2187, spotted the paragraph in a description of `not in` ![](https://i.imgur.com/P0n7WPP.png)
 didn't think of symbols without signatures when doing the last PR.

Adds the filtering to the description tags.
I've also noticed some things were being filtered with a regex that I glossed over last time, I moved over the source filtering to go through html like headerlinks do; not sure what the backslashes were filtering.