### PR TITLE
Improve help of eval and timeit

### DIFF
--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -418,6 +418,9 @@ class Snekbox(Cog):
         block. Code can be re-evaluated by editing the original message within 10 seconds and
         clicking the reaction that subsequently appears.
 
+        If multiple codeblocks are in a message, all of them will be joined and evaluated,
+        ignoring the text outside of them.
+
         We've done our best to make this sandboxed, but do let us know if you manage to find an
         issue with it!
         """

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -401,7 +401,7 @@ class Snekbox(Cog):
                 break
             log.info(f"Re-evaluating code from message {ctx.message.id}:\n{code}")
 
-    @command(name="eval", aliases=("e",))
+    @command(name="eval", aliases=("e",), usage="<code, ...>")
     @guild_only()
     @redirect_output(
         destination_channel=Channels.bot_commands,
@@ -423,7 +423,7 @@ class Snekbox(Cog):
         """
         await self.run_job("eval", ctx, "\n".join(code))
 
-    @command(name="timeit", aliases=("ti",))
+    @command(name="timeit", aliases=("ti",), usage="[setup_code] <code, ...>")
     @guild_only()
     @redirect_output(
         destination_channel=Channels.bot_commands,


### PR DESCRIPTION
Documents the eval command accepting multiple codeblocks in a message and adds custom usage to the commands which shows that timeit takes a setup codeblock, and that both can take multiple codeblocks.