### PR TITLE
Add tag to use `python -m pip` to install packages

### DIFF
--- a/bot/resources/tags/dashmpip.md
+++ b/bot/resources/tags/dashmpip.md
@@ -1,0 +1,11 @@
+---
+embed:
+    title: "Install packages with `python -m pip`"
+---
+When trying to install a package via `pip`, it's recommended to invoke pip as a module: `python -m pip install your_package`.
+
+**Why would we use `python -m pip` instead of `pip`?**
+Invoking pip as a module ensures you know *which* pip you're using. This is helpful if you have multiple Python versions. You always know which Python version you're installing packages to.
+
+**Note**
+The exact `python` command you invoke can vary. It may be `python3` or `py`, ensure it's correct for your system.


### PR DESCRIPTION
In the wild west of `#python-general`, we see a lot of issues where folks will use `pip` to install a package. Unfortunately, the `pip` they're using to install the package is not in the same version of Python that's used to actually run their code (we're going to specifically not talk about cases where a venv is created automatically for them and they don't realize for this PR and tag). This could be for a variety of reasons and will often lead down a rabbit hole of altering what's on PATH. This can be a lot of work for seemingly little gain for a beginner. 

I am firmly in team "run pip as a module so you always know which Python version you're installing to". No need to futz around with PATH or shims or who knows what else, and now there's no ambiguity for which python you're installing packages to. So this tag will help (hopefully) succinctly explain what to do and why.

![image](https://user-images.githubusercontent.com/20641196/178081739-560ba40a-f856-461e-8015-76b1160d0613.png)
