### PR TITLE
Add Aliases for Tags Support

### DIFF
--- a/bot/resources/tags/dashmpip.md
+++ b/bot/resources/tags/dashmpip.md
@@ -1,4 +1,5 @@
 ---
+aliases: ["minusmpip"]
 embed:
     title: "Install packages with `python -m pip`"
 ---

--- a/bot/resources/tags/f-strings.md
+++ b/bot/resources/tags/f-strings.md
@@ -1,3 +1,6 @@
+---
+aliases: ["fstrings", "fstring", "f-string"]
+---
 Creating a Python string with your variables using the `+` operator can be difficult to write and read. F-strings (*format-strings*) make it easy to insert values into a string. If you put an `f` in front of the first quote, you can then put Python expressions between curly braces in the string.
 
 ```py


### PR DESCRIPTION
This PR adds support for adding aliases and alternative names for tags and showcases it with two existing tags.

It uses the metadata functionality and will look for the "aliases" key. It then adds the alias names to the Tags dictionary that gets searched through when trying to match a tag directly.

This doesn't check for duplicate aliases as there wasn't a good way to do that validation ahead of time. It also didn't feel like a good solution to iterate through all TagIdentifiers to find possible duplicate matches. So I'm relying on folks who are PRing things to not add conflicting aliases.

**Example of the alias in action**
![image](https://user-images.githubusercontent.com/20641196/178309218-d53ddd66-635c-48e2-9567-770e8d21cb5c.png)
![image](https://user-images.githubusercontent.com/20641196/178308669-9a4daad4-381e-400b-84e5-354137c79771.png)
