### PR TITLE
Use the view clear on timeout feature from bot-core in snekbox

### DIFF
--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -233,19 +233,19 @@ class Snekbox(Cog):
         return code, args
 
     @staticmethod
-    def get_results_message(results: dict, job_name: str) -> Tuple[str, str]:
+    def get_results_message(results: dict, job_name: str, python_version: Literal["3.10", "3.11"]) -> Tuple[str, str]:
         """Return a user-friendly message and error corresponding to the process's return code."""
         stdout, returncode = results["stdout"], results["returncode"]
-        msg = f"Your {job_name} job has completed with return code {returncode}"
+        msg = f"Your {python_version} {job_name} job has completed with return code {returncode}"
         error = ""
 
         if returncode is None:
-            msg = f"Your {job_name} job has failed"
+            msg = f"Your {python_version} {job_name} job has failed"
             error = stdout.strip()
         elif returncode == 128 + SIGKILL:
-            msg = f"Your {job_name} job timed out or ran out of memory"
+            msg = f"Your {python_version} {job_name} job timed out or ran out of memory"
         elif returncode == 255:
-            msg = f"Your {job_name} job has failed"
+            msg = f"Your {python_version} {job_name} job has failed"
             error = "A fatal NsJail error occurred"
         else:
             # Try to append signal's name if one exists
@@ -330,7 +330,7 @@ class Snekbox(Cog):
         """
         async with ctx.typing():
             results = await self.post_job(code, python_version, args=args)
-            msg, error = self.get_results_message(results, job_name)
+            msg, error = self.get_results_message(results, job_name, python_version)
 
             if error:
                 output, paste_link = error, None

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -359,6 +359,7 @@ class Snekbox(Cog):
                 allowed_mentions = AllowedMentions(everyone=False, roles=False, users=[ctx.author])
                 view = self.build_python_version_switcher_view(job_name, python_version, ctx, code)
                 response = await ctx.send(msg, allowed_mentions=allowed_mentions, view=view)
+                view.message = response
 
             log.info(f"{ctx.author}'s {job_name} job had a return code of {results['returncode']}")
         return response

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
     ports:
      - "127.0.0.1:8060:8060"
     privileged: true
+    profiles:
+      - "3.10"
 
   snekbox-311:
     << : *logging
@@ -71,8 +73,6 @@ services:
     ports:
      - "127.0.0.1:8065:8060"
     privileged: true
-    profiles:
-      - "3.11"
 
   web:
     << : *logging

--- a/poetry.lock
+++ b/poetry.lock
@@ -125,7 +125,7 @@ lxml = ["lxml"]
 
 [[package]]
 name = "bot-core"
-version = "7.3.1"
+version = "7.4.0"
 description = "Bot-Core provides the core functionality and utilities for the bots of the Python Discord community."
 category = "main"
 optional = false
@@ -141,7 +141,7 @@ async-rediscache = ["async-rediscache[fakeredis] (==0.2.0)"]
 
 [package.source]
 type = "url"
-url = "https://github.com/python-discord/bot-core/archive/refs/tags/v7.3.1.zip"
+url = "https://github.com/python-discord/bot-core/archive/refs/tags/v7.4.0.zip"
 [[package]]
 name = "certifi"
 version = "2022.6.15"
@@ -478,7 +478,7 @@ pyreadline3 = {version = "*", markers = "sys_platform == \"win32\" and python_ve
 
 [[package]]
 name = "identify"
-version = "2.5.1"
+version = "2.5.2"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -1151,7 +1151,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.*"
-content-hash = "1152d8ee2e09a6d0283d82be5b1fee21a9d7bd36d206e02fcee5a4ad4ecd9523"
+content-hash = "43b10dbc644c527ce55e01bc555ce98eb00a8e347409c08152668caf5276688c"
 
 [metadata.files]
 aiodns = [
@@ -1563,10 +1563,7 @@ humanfriendly = [
     {file = "humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477"},
     {file = "humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"},
 ]
-identify = [
-    {file = "identify-2.5.1-py2.py3-none-any.whl", hash = "sha256:0dca2ea3e4381c435ef9c33ba100a78a9b40c0bab11189c7cf121f75815efeaa"},
-    {file = "identify-2.5.1.tar.gz", hash = "sha256:3d11b16f3fe19f52039fb7e39c9c884b21cb1b586988114fbe42671f03de3e82"},
-]
+identify = []
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "3.9.*"
 
 "discord.py" = {url = "https://github.com/Rapptz/discord.py/archive/0eb3d26343969a25ffc43ba72eca42538d2e7e7a.zip"}
 # See https://bot-core.pythondiscord.com/ for docs.
-bot-core = {url = "https://github.com/python-discord/bot-core/archive/refs/tags/v7.3.1.zip", extras = ["async-rediscache"]}
+bot-core = {url = "https://github.com/python-discord/bot-core/archive/refs/tags/v7.4.0.zip", extras = ["async-rediscache"]}
 
 aiodns = "3.0.0"
 aiohttp = "3.8.1"

--- a/tests/bot/exts/utils/test_snekbox.py
+++ b/tests/bot/exts/utils/test_snekbox.py
@@ -85,28 +85,28 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
     def test_get_results_message(self):
         """Return error and message according to the eval result."""
         cases = (
-            ('ERROR', None, ('Your eval job has failed', 'ERROR')),
-            ('', 128 + snekbox.SIGKILL, ('Your eval job timed out or ran out of memory', '')),
-            ('', 255, ('Your eval job has failed', 'A fatal NsJail error occurred'))
+            ('ERROR', None, ('Your 3.11 eval job has failed', 'ERROR')),
+            ('', 128 + snekbox.SIGKILL, ('Your 3.11 eval job timed out or ran out of memory', '')),
+            ('', 255, ('Your 3.11 eval job has failed', 'A fatal NsJail error occurred'))
         )
         for stdout, returncode, expected in cases:
             with self.subTest(stdout=stdout, returncode=returncode, expected=expected):
-                actual = self.cog.get_results_message({'stdout': stdout, 'returncode': returncode}, 'eval')
+                actual = self.cog.get_results_message({'stdout': stdout, 'returncode': returncode}, 'eval', '3.11')
                 self.assertEqual(actual, expected)
 
     @patch('bot.exts.utils.snekbox.Signals', side_effect=ValueError)
     def test_get_results_message_invalid_signal(self, mock_signals: Mock):
         self.assertEqual(
-            self.cog.get_results_message({'stdout': '', 'returncode': 127}, 'eval'),
-            ('Your eval job has completed with return code 127', '')
+            self.cog.get_results_message({'stdout': '', 'returncode': 127}, 'eval', '3.11'),
+            ('Your 3.11 eval job has completed with return code 127', '')
         )
 
     @patch('bot.exts.utils.snekbox.Signals')
     def test_get_results_message_valid_signal(self, mock_signals: Mock):
         mock_signals.return_value.name = 'SIGTEST'
         self.assertEqual(
-            self.cog.get_results_message({'stdout': '', 'returncode': 127}, 'eval'),
-            ('Your eval job has completed with return code 127 (SIGTEST)', '')
+            self.cog.get_results_message({'stdout': '', 'returncode': 127}, 'eval', '3.11'),
+            ('Your 3.11 eval job has completed with return code 127 (SIGTEST)', '')
         )
 
     def test_get_status_emoji(self):
@@ -245,7 +245,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
 
         self.cog.post_job.assert_called_once_with('MyAwesomeCode', '3.11', args=None)
         self.cog.get_status_emoji.assert_called_once_with({'stdout': '', 'returncode': 0})
-        self.cog.get_results_message.assert_called_once_with({'stdout': '', 'returncode': 0}, 'eval')
+        self.cog.get_results_message.assert_called_once_with({'stdout': '', 'returncode': 0}, 'eval', '3.11')
         self.cog.format_output.assert_called_once_with('')
 
     async def test_send_job_with_paste_link(self):
@@ -275,7 +275,9 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
 
         self.cog.post_job.assert_called_once_with('MyAwesomeCode', '3.11', args=None)
         self.cog.get_status_emoji.assert_called_once_with({'stdout': 'Way too long beard', 'returncode': 0})
-        self.cog.get_results_message.assert_called_once_with({'stdout': 'Way too long beard', 'returncode': 0}, 'eval')
+        self.cog.get_results_message.assert_called_once_with(
+            {'stdout': 'Way too long beard', 'returncode': 0}, 'eval', '3.11'
+        )
         self.cog.format_output.assert_called_once_with('Way too long beard')
 
     async def test_send_job_with_non_zero_eval(self):
@@ -303,7 +305,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
 
         self.cog.post_job.assert_called_once_with('MyAwesomeCode', '3.11', args=None)
         self.cog.get_status_emoji.assert_called_once_with({'stdout': 'ERROR', 'returncode': 127})
-        self.cog.get_results_message.assert_called_once_with({'stdout': 'ERROR', 'returncode': 127}, 'eval')
+        self.cog.get_results_message.assert_called_once_with({'stdout': 'ERROR', 'returncode': 127}, 'eval', '3.11')
         self.cog.format_output.assert_not_called()
 
     @patch("bot.exts.utils.snekbox.partial")


### PR DESCRIPTION
This will mean the buttons will be cleared from the response on interaction timeout.

This PR also adds the Python version to the output from snekbox.

I have also made the 3.11 snekbox start container by default, since snekbox uses 3.11 by default, it makes sense for this one to be started by default, and the 3.10 container to be opt-in.

Closes #2223