### PR TITLE
New tags relating `module`s

### DIFF
--- a/bot/resources/tags/module-not-found.md
+++ b/bot/resources/tags/module-not-found.md
@@ -1,6 +1,6 @@
 **module-not-found**
 
-A `ModuleNotFoundError` is raised when the python interpreter cannot find a `module` either in the local directory or in the `site-packages` directory. 
+A `ModuleNotFoundError` is raised when the python interpreter cannot find a `module` either in the local directory or in the `site-packages` directory.
 
 If you are expecting to use an `external` module, ie one that is *not* built-in (also know as `std` for `standard`) but cannot figure out why `ModuleNotFoundError` is raised, two things may be happening.
 
@@ -9,7 +9,7 @@ If you are expecting to use an `external` module, ie one that is *not* built-in 
 > First you need to open up the *command prompt*. *Note* that this is *not* the python interpreter.
 >
 > Then, you need to install the library with `pip` in order to add it to use it globally.
-> 
+>
 > ```
 > pip install <library name>
 > ```

--- a/bot/resources/tags/module-not-found.md
+++ b/bot/resources/tags/module-not-found.md
@@ -1,0 +1,28 @@
+**module-not-found**
+
+A `ModuleNotFoundError` is raised when the python interpreter cannot find a `module` either in the local directory or in the `site-packages` directory. 
+
+If you are expecting to use an `external` module, ie one that is *not* built-in (also know as `std` for `standard`) but cannot figure out why `ModuleNotFoundError` is raised, two things may be happening.
+
+**Either, you have not used the python package manager, `pip`, to install the `library` (see below) in which case you need to:**
+
+> First you need to open up the *command prompt*. *Note* that this is *not* the python interpreter.
+>
+> Then, you need to install the library with `pip` in order to add it to use it globally.
+> 
+> ```
+> pip install <library name>
+> ```
+>
+> This then installs the library so that you can `import` it in your program.
+
+**Or, you have multiple python interpreters installed, causing conflicts with the packages.**
+
+In which case, see `!tags multiple-python`
+
+
+> *Note*
+>
+> There is often the mention of the word `library`. A `library` is a *collection* of `modules`.
+
+See `!tags module` for more information about what a `module` is.

--- a/bot/resources/tags/modules.md
+++ b/bot/resources/tags/modules.md
@@ -27,7 +27,7 @@ first_number = add_and_minus.add(1, 2) # 3
 second_number = add_and_minus.minus(first_number, 1) # 2
 ```
 > *Note*
-> 
+>
 > When importing modules, the python interpreter looks in both the local directory and `site-packages` for the `module`. If the module is *not found*, it raises a `ModuleNotFoundError`.
 >
 > See `!tags module-not-found` for more information about this exception.

--- a/bot/resources/tags/modules.md
+++ b/bot/resources/tags/modules.md
@@ -1,0 +1,33 @@
+**modules**
+
+In Python, a `module` is an extension that is `import`ed into another program, typically to either organize code.
+
+**Example**
+
+In our program, we want to organize our `add` and `minus` function into a `module` called `math.py`.
+
+First, we would create our python file called `add_and_minus.py` and put the `add` and `minus` functions into it.
+
+```py
+# add_and_minus.py
+
+def add(a, b):
+    return a + b
+def minus(a, b):
+    return a - b
+```
+From here, we are able to `import` these functions into our `calculator.py` file.
+
+```py
+# calculator.py
+
+import add_and_minus
+
+first_number = add_and_minus.add(1, 2) # 3
+second_number = add_and_minus.minus(first_number, 1) # 2
+```
+> *Note*
+> 
+> When importing modules, the python interpreter looks in both the local directory and `site-packages` for the `module`. If the module is *not found*, it raises a `ModuleNotFoundError`.
+>
+> See `!tags module-not-found` for more information about this exception.

--- a/bot/resources/tags/multiple-python.md
+++ b/bot/resources/tags/multiple-python.md
@@ -1,0 +1,19 @@
+**multiple-python**
+
+If you are experiencing `ModuleNotFoundError` errors, but you have installed the `library` with `pip`, then you have multiple python interpreters installed.
+
+**Example**
+Often, you may have a `python2` *and* a `python3` installed. In this case, the libraries installed may not go to the desired location. You can either install modules with the following syntax to ensure that the *right* python `pip` installs it.
+
+```
+python -m pip install <library>
+```
+Where `python` is the correct python version. This installs the library to that `python`'s location.
+
+<br>
+
+**Or, you can remove all other python versions except for the one that you want.** 
+
+This ensures that only one python `pip` will manage
+
+

--- a/bot/resources/tags/multiple-python.md
+++ b/bot/resources/tags/multiple-python.md
@@ -12,8 +12,6 @@ Where `python` is the correct python version. This installs the library to that 
 
 <br>
 
-**Or, you can remove all other python versions except for the one that you want.** 
+**Or, you can remove all other python versions except for the one that you want.**
 
 This ensures that only one python `pip` will manage
-
-


### PR DESCRIPTION
Creates 3 new tags:
- `Module-not-found`
- `Modules`
- `Multiple-python`

Implements https://github.com/python-discord/meta/issues/191 and https://github.com/python-discord/meta/issues/189 