### PR TITLE
Updated `purge` to require at least one user

### DIFF
--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from itertools import takewhile
 from typing import Callable, Iterable, Literal, Optional, TYPE_CHECKING, Union
 
-from discord import Colour, Embed, Message, NotFound, TextChannel, Thread, User, errors
+from discord import Colour, Message, NotFound, TextChannel, Thread, User, errors
 from discord.ext.commands import Cog, Context, Converter, Greedy, command, group, has_any_role
 from discord.ext.commands.converter import TextChannelConverter
 from discord.ext.commands.errors import BadArgument

--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from itertools import takewhile
 from typing import Callable, Iterable, Literal, Optional, TYPE_CHECKING, Union
 
-from discord import Colour, Message, NotFound, TextChannel, Thread, User, errors
+from discord import Colour, Embed, Message, NotFound, TextChannel, Thread, User, errors
 from discord.ext.commands import Cog, Context, Converter, Greedy, command, group, has_any_role
 from discord.ext.commands.converter import TextChannelConverter
 from discord.ext.commands.errors import BadArgument
@@ -627,12 +627,18 @@ class Clean(Cog):
     @command()
     async def purge(self, ctx: Context, users: Greedy[User], age: Optional[Union[Age, ISODateTime]] = None) -> None:
         """
-        Clean messages of users from all public channels up to a certain message age (10 minutes by default).
+        Clean messages of `users` from all public channels up to a certain message `age` (10 minutes by default).
 
-        The age is *exclusive*, meaning that `10s` won't delete a message exactly 10 seconds old.
+        Requires 1 or more users to be specified. For channel-based cleaning, use `clean` instead.
+
+        The `age` is *exclusive*, meaning that `10s` won't delete a message exactly 10 seconds old.
         """
+        if not users:
+            raise BadArgument("At least one user must be specified.")
+
         if age is None:
             age = await Age().convert(ctx, "10M")
+
         await self._clean_messages(ctx, channels="*", users=users, first_limit=age)
 
     # endregion

--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -631,7 +631,7 @@ class Clean(Cog):
 
         Requires 1 or more users to be specified. For channel-based cleaning, use `clean` instead.
 
-        The `age` is *exclusive*, meaning that `10s` won't delete a message exactly 10 seconds old.
+        `age` can be a duration or an ISO 8601 timestamp.
         """
         if not users:
             raise BadArgument("At least one user must be specified.")


### PR DESCRIPTION
Closes #2238 

## Summary
- Added raising of `BadArgument` when the greedy match of users returns an empty list
- Updated help message

## Demo
![purge_demo](https://cdn.ionite.io/img/1q0df0.jpg)