### PR TITLE
Disable nose plugin in pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,9 @@ case_sensitive = true
 combine_as_imports = true
 line_length = 120
 atomic = true
+
+[tool.pytest.ini_options]
+# We don't use nose style tests so disable them in pytest.
+# This stops pytest from running functions named `setup` in test files.
+# See https://github.com/python-discord/bot/pull/2229#issuecomment-1204436420
+addopts = "-p no:nose"


### PR DESCRIPTION
This fixes an issue with pytest running functions called `setup` in test files when they shouldn't be run.

The current case is also fixed by https://github.com/python-discord/bot/pull/2229/commits/6217513d7bc5a97afc595af1966dfd722db0084c, but this fix should help prevent future cases.

For more information see https://github.com/python-discord/bot/pull/2229#issuecomment-1204436420.