### PR TITLE
Fix not awaited coroutine warning

### DIFF
--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -52,8 +52,9 @@ class Infractions(InfractionScheduler, commands.Cog):
 
         if active_mutes:
             reason = f"Re-applying active mute: {active_mutes[0]['id']}"
-            action = member.add_roles(self._muted_role, reason=reason)
 
+            async def action() -> None:
+                await member.add_roles(self._muted_role, reason=reason)
             await self.reapply_infraction(active_mutes[0], action)
 
     # region: Permanent infractions
@@ -388,7 +389,7 @@ class Infractions(InfractionScheduler, commands.Cog):
             log.trace(f"Attempting to kick {user} from voice because they've been muted.")
             await user.move_to(None, reason=reason)
 
-        await self.apply_infraction(ctx, infraction, user, action())
+        await self.apply_infraction(ctx, infraction, user, action)
 
     @respect_role_hierarchy(member_arg=2)
     async def apply_kick(self, ctx: Context, user: Member, reason: t.Optional[str], **kwargs) -> None:
@@ -406,7 +407,9 @@ class Infractions(InfractionScheduler, commands.Cog):
         if reason:
             reason = textwrap.shorten(reason, width=512, placeholder="...")
 
-        action = user.kick(reason=reason)
+        async def action() -> None:
+            await user.kick(reason=reason)
+
         await self.apply_infraction(ctx, infraction, user, action)
 
     @respect_role_hierarchy(member_arg=2)
@@ -455,7 +458,9 @@ class Infractions(InfractionScheduler, commands.Cog):
         if reason:
             reason = textwrap.shorten(reason, width=512, placeholder="...")
 
-        action = ctx.guild.ban(user, reason=reason, delete_message_days=purge_days)
+        async def action() -> None:
+            await ctx.guild.ban(user, reason=reason, delete_message_days=purge_days)
+
         await self.apply_infraction(ctx, infraction, user, action)
 
         bb_cog: t.Optional[BigBrother] = self.bot.get_cog("Big Brother")
@@ -493,7 +498,7 @@ class Infractions(InfractionScheduler, commands.Cog):
             await user.move_to(None, reason="Disconnected from voice to apply voice mute.")
             await user.remove_roles(self._voice_verified_role, reason=reason)
 
-        await self.apply_infraction(ctx, infraction, user, action())
+        await self.apply_infraction(ctx, infraction, user, action)
 
     # endregion
     # region: Base pardon functions

--- a/bot/exts/moderation/infraction/superstarify.py
+++ b/bot/exts/moderation/infraction/superstarify.py
@@ -96,11 +96,12 @@ class Superstarify(InfractionScheduler, Cog):
 
         if active_superstarifies:
             infraction = active_superstarifies[0]
-            action = member.edit(
-                nick=self.get_nick(infraction["id"], member.id),
-                reason=f"Superstarified member tried to escape the prison: {infraction['id']}"
-            )
 
+            async def action() -> None:
+                await member.edit(
+                    nick=self.get_nick(infraction["id"], member.id),
+                    reason=f"Superstarified member tried to escape the prison: {infraction['id']}"
+                )
             await self.reapply_infraction(infraction, action)
 
     @command(name="superstarify", aliases=("force_nick", "star", "starify", "superstar"))
@@ -175,7 +176,7 @@ class Superstarify(InfractionScheduler, Cog):
         ).format
 
         successful = await self.apply_infraction(
-            ctx, infraction, member, action(),
+            ctx, infraction, member, action,
             user_reason=user_message(reason=f'**Additional details:** {reason}\n\n' if reason else ''),
             additional_info=nickname_info
         )

--- a/tests/bot/exts/moderation/infraction/test_infractions.py
+++ b/tests/bot/exts/moderation/infraction/test_infractions.py
@@ -35,16 +35,19 @@ class TruncationTests(unittest.IsolatedAsyncioTestCase):
         self.cog.apply_infraction = AsyncMock()
         self.bot.get_cog.return_value = AsyncMock()
         self.cog.mod_log.ignore = Mock()
-        self.ctx.guild.ban = Mock()
+        self.ctx.guild.ban = AsyncMock()
 
         await self.cog.apply_ban(self.ctx, self.target, "foo bar" * 3000)
-        self.ctx.guild.ban.assert_called_once_with(
+        self.cog.apply_infraction.assert_awaited_once_with(
+            self.ctx, {"foo": "bar", "purge": ""}, self.target, ANY
+        )
+
+        action = self.cog.apply_infraction.call_args.args[-1]
+        await action()
+        self.ctx.guild.ban.assert_awaited_once_with(
             self.target,
             reason=textwrap.shorten("foo bar" * 3000, 512, placeholder="..."),
             delete_message_days=0
-        )
-        self.cog.apply_infraction.assert_awaited_once_with(
-            self.ctx, {"foo": "bar", "purge": ""}, self.target, self.ctx.guild.ban.return_value
         )
 
     @patch("bot.exts.moderation.infraction._utils.post_infraction")
@@ -54,13 +57,16 @@ class TruncationTests(unittest.IsolatedAsyncioTestCase):
 
         self.cog.apply_infraction = AsyncMock()
         self.cog.mod_log.ignore = Mock()
-        self.target.kick = Mock()
+        self.target.kick = AsyncMock()
 
         await self.cog.apply_kick(self.ctx, self.target, "foo bar" * 3000)
-        self.target.kick.assert_called_once_with(reason=textwrap.shorten("foo bar" * 3000, 512, placeholder="..."))
         self.cog.apply_infraction.assert_awaited_once_with(
-            self.ctx, {"foo": "bar"}, self.target, self.target.kick.return_value
+            self.ctx, {"foo": "bar"}, self.target, ANY
         )
+
+        action = self.cog.apply_infraction.call_args.args[-1]
+        await action()
+        self.target.kick.assert_awaited_once_with(reason=textwrap.shorten("foo bar" * 3000, 512, placeholder="..."))
 
 
 @patch("bot.exts.moderation.infraction.infractions.constants.Roles.voice_verified", new=123456)
@@ -141,8 +147,8 @@ class VoiceMuteTests(unittest.IsolatedAsyncioTestCase):
 
     async def action_tester(self, action, reason: str) -> None:
         """Helper method to test voice mute action."""
-        self.assertTrue(inspect.iscoroutine(action))
-        await action
+        self.assertTrue(inspect.iscoroutinefunction(action))
+        await action()
 
         self.user.move_to.assert_called_once_with(None, reason=ANY)
         self.user.remove_roles.assert_called_once_with(self.cog._voice_verified_role, reason=reason)
@@ -194,8 +200,8 @@ class VoiceMuteTests(unittest.IsolatedAsyncioTestCase):
 
         # Test action
         action = self.cog.apply_infraction.call_args[0][-1]
-        self.assertTrue(inspect.iscoroutine(action))
-        await action
+        self.assertTrue(inspect.iscoroutinefunction(action))
+        await action()
 
     async def test_voice_unmute_user_not_found(self):
         """Should include info to return dict when user was not found from guild."""


### PR DESCRIPTION
Fixes this warning in the tests:
```
tests/bot/exts/moderation/infraction/test_infractions.py::VoiceMuteTests::test_voice_mute_truncate_reason
  c:\users\wookie\appdata\local\programs\python\python39\lib\enum.py:384: RuntimeWarning: coroutine 'Infractions.apply_voice_mute.<locals>.action' was never awaited
  Coroutine created at (most recent call last)
    File "c:\users\wookie\appdata\local\programs\python\python39\lib\unittest\async_case.py", line 87, in _callMaybeAsync
      return self._asyncioTestLoop.run_until_complete(fut)
    File "c:\users\wookie\appdata\local\programs\python\python39\lib\asyncio\base_events.py", line 634, in run_until_complete
      self.run_forever()
    File "c:\users\wookie\appdata\local\programs\python\python39\lib\asyncio\base_events.py", line 601, in run_forever
      self._run_once()
    File "c:\users\wookie\appdata\local\programs\python\python39\lib\asyncio\base_events.py", line 1897, in _run_once
      handle._run()
    File "c:\users\wookie\appdata\local\programs\python\python39\lib\asyncio\events.py", line 80, in _run
      self._context.run(self._callback, *self._args)
    File "c:\users\wookie\appdata\local\programs\python\python39\lib\unittest\async_case.py", line 101, in _asyncioLoopRunner
      ret = await awaitable
    File "c:\users\wookie\appdata\local\programs\python\python39\lib\unittest\mock.py", line 1353, in patched
      return await func(*newargs, **newkeywargs)
    File "C:\Users\wookie\Documents\GitHub\bot\tests\bot\exts\moderation\infraction\test_infractions.py", line 139, in test_voice_mute_mod_log_ignore
      self.assertIsNone(await self.cog.apply_voice_mute(self.ctx, self.user, "foobar"))
    File "C:\Users\wookie\Documents\GitHub\bot\bot\decorators.py", line 218, in wrapper
      return await func(*args, **kwargs)
    File "C:\Users\wookie\Documents\GitHub\bot\bot\exts\moderation\infraction\infractions.py", line 496, in apply_voice_mute
      await self.apply_infraction(ctx, infraction, user, action())
    return cls.__new__(cls, value)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

Passing coroutines around is not ideal, so I changed it so a coroutine function is passed instead. Some changes in the tests were also required.