### PR TITLE
Globally decode binary responses from redis to strings

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -26,6 +26,7 @@ async def _create_redis_session() -> RedisSession:
         max_connections=20,
         use_fakeredis=constants.Redis.use_fakeredis,
         global_namespace="bot",
+        decode_responses=True,
     )
     try:
         return await redis_session.connect()


### PR DESCRIPTION
The latest version of redis returns bytes by default, rather than strings.

This was in the 3.10 PR but must have been removed during a rebase conflict.