### PR TITLE
feat: command for banning compromised accounts

### DIFF
--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -2,7 +2,7 @@ import asyncio
 import re
 import unicodedata
 import urllib.parse
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Tuple, Union
 
 import arrow
@@ -413,7 +413,7 @@ class Filtering(Cog):
                             await context.invoke(
                                 context.command,
                                 msg.author,
-                                arrow.utcnow() + AUTO_BAN_DURATION,
+                                datetime.utcnow() + AUTO_BAN_DURATION,
                                 reason=AUTO_BAN_REASON
                             )
 

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -2,7 +2,7 @@ import asyncio
 import re
 import unicodedata
 import urllib.parse
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Tuple, Union
 
 import arrow
@@ -413,7 +413,7 @@ class Filtering(Cog):
                             await context.invoke(
                                 context.command,
                                 msg.author,
-                                datetime.utcnow() + AUTO_BAN_DURATION,
+                                (arrow.utcnow() + AUTO_BAN_DURATION).datetime,
                                 reason=AUTO_BAN_REASON
                             )
 

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -1,7 +1,7 @@
 import textwrap
 import typing as t
-from datetime import datetime
 
+import arrow
 import discord
 from discord import Member
 from discord.ext import commands
@@ -156,7 +156,7 @@ class Infractions(InfractionScheduler, commands.Cog):
     @command()
     async def compban(self, ctx: Context, user: UnambiguousMemberOrUser) -> None:
         """Same as cleanban, but specifically with the ban reason and duration used for compromised accounts."""
-        await self.cleanban(ctx, user, duration=datetime.utcnow() + AUTO_BAN_DURATION, reason=AUTO_BAN_REASON)
+        await self.cleanban(ctx, user, duration=(arrow.utcnow() + AUTO_BAN_DURATION).datetime, reason=AUTO_BAN_REASON)
 
     @command(aliases=("vban",))
     async def voiceban(self, ctx: Context) -> None:

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -1,6 +1,7 @@
 import textwrap
 import typing as t
 
+import arrow
 import discord
 from discord import Member
 from discord.ext import commands
@@ -11,6 +12,7 @@ from bot.bot import Bot
 from bot.constants import Event
 from bot.converters import Age, Duration, Expiry, MemberOrUser, UnambiguousMemberOrUser
 from bot.decorators import ensure_future_timestamp, respect_role_hierarchy
+from bot.exts.filters.filtering import AUTO_BAN_DURATION, AUTO_BAN_REASON
 from bot.exts.moderation.infraction import _utils
 from bot.exts.moderation.infraction._scheduler import InfractionScheduler
 from bot.log import get_logger
@@ -150,6 +152,11 @@ class Infractions(InfractionScheduler, commands.Cog):
             pass
         ctx.send = send
         await infr_manage_cog.infraction_append(ctx, infraction, None, reason=f"[Clean log]({log_url})")
+
+    @command()
+    async def compban(self, ctx: Context, user: UnambiguousMemberOrUser) -> None:
+        """Same as cleanban, but specifically for four days and with the ban reason used for compromised accounts."""
+        await self.cleanban(ctx, user, duration=arrow.utcnow() + AUTO_BAN_DURATION, reason=AUTO_BAN_REASON)
 
     @command(aliases=("vban",))
     async def voiceban(self, ctx: Context) -> None:

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -1,7 +1,7 @@
 import textwrap
 import typing as t
+from datetime import datetime
 
-import arrow
 import discord
 from discord import Member
 from discord.ext import commands
@@ -155,8 +155,8 @@ class Infractions(InfractionScheduler, commands.Cog):
 
     @command()
     async def compban(self, ctx: Context, user: UnambiguousMemberOrUser) -> None:
-        """Same as cleanban, but specifically for four days and with the ban reason used for compromised accounts."""
-        await self.cleanban(ctx, user, duration=arrow.utcnow() + AUTO_BAN_DURATION, reason=AUTO_BAN_REASON)
+        """Same as cleanban, but specifically with the ban reason and duration used for compromised accounts."""
+        await self.cleanban(ctx, user, duration=datetime.utcnow() + AUTO_BAN_DURATION, reason=AUTO_BAN_REASON)
 
     @command(aliases=("vban",))
     async def voiceban(self, ctx: Context) -> None:


### PR DESCRIPTION
This PR adds a command to ban compromised users. It is the same as cleanban, but it bans specifically for 4 days and uses the typical ban reason.

Approval was granted [in Discord](https://canary.discord.com/channels/267624335836053506/775412552795947058/1008254956312203314).