### PR TITLE
Fixes: Discord Invite converter not recognizing http/https links

### DIFF
--- a/bot/converters.py
+++ b/bot/converters.py
@@ -30,6 +30,7 @@ log = get_logger(__name__)
 
 DISCORD_EPOCH_DT = snowflake_time(0)
 RE_USER_MENTION = re.compile(r"<@!?([0-9]+)>$")
+RE_STRIP_HTTP = re.compile(r"https?://(www\.)?")
 
 
 class ValidDiscordServerInvite(Converter):
@@ -52,6 +53,7 @@ class ValidDiscordServerInvite(Converter):
 
     async def convert(self, ctx: Context, server_invite: str) -> dict:
         """Check whether the string is a valid Discord server invite."""
+        server_invite = RE_STRIP_HTTP.sub("", server_invite)
         invite_code = DISCORD_INVITE.match(server_invite)
         if invite_code:
             response = await ctx.bot.http_session.get(


### PR DESCRIPTION
Closes python-discord/bot-core#123 

## Summary
This adds support for normalizing discord server invite links starting with combinations of `http://` `https://` or `www`

![invalid](https://cdn.ionite.io/img/CdwSgD.jpg)

## Implementation

```py
+ RE_STRIP_HTTP = re.compile(r"https?://(www\.)?")

class ValidDiscordServerInvite(Converter):
    async def convert(self, ctx: Context, server_invite: str) -> dict:
+      server_invite = RE_STRIP_HTTP.sub("", server_invite)
		...
```

## Demo

![valid1](https://cdn.ionite.io/img/4j0DQh.jpg)