### PR TITLE
feat: add reason argument to pardon commands

### DIFF
--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -444,7 +444,7 @@ class InfractionScheduler:
             # Mark infraction as inactive in the database.
             log.trace(f"Marking infraction #{id_} as inactive in the database.")
 
-            data = {"active": False, "reason": ""}
+            data = {"active": False}
 
             if pardon_reason is not None:
                 # Append pardon reason to infraction in database.

--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -447,6 +447,7 @@ class InfractionScheduler:
             data = {"active": False}
 
             if pardon_reason is not None:
+                data["reason"] = ""
                 # Append pardon reason to infraction in database.
                 if (punish_reason := infraction["reason"]) is not None:
                     data["reason"] = punish_reason + " | "

--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -443,14 +443,14 @@ class InfractionScheduler:
         try:
             # Mark infraction as inactive in the database.
             log.trace(f"Marking infraction #{id_} as inactive in the database.")
-            
+
             data = {"active": False, "reason": ""}
-            
+
             if pardon_reason is not None:
                 # Append pardon reason to infraction in database.
                 if (punish_reason := infraction["reason"]) is not None:
                     data["reason"] = punish_reason + " | "
-                
+
                 data["reason"] += f"Pardoned: {pardon_reason}"
 
             await self.bot.api_client.patch(

--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -372,7 +372,7 @@ class InfractionScheduler:
 
         If `pardon_reason` is None, then the database will not receive
         appended text explaining why the infraction was pardoned.
-        
+
         If `send_log` is True, a mod log is sent for the deactivation of the infraction.
 
         If `notify` is True, notify the user of the pardon via DM where applicable.

--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -443,11 +443,15 @@ class InfractionScheduler:
         try:
             # Mark infraction as inactive in the database.
             log.trace(f"Marking infraction #{id_} as inactive in the database.")
-
-            data = {"active": False}
-
+            
+            data = {"active": False, "reason": ""}
+            
             if pardon_reason is not None:
-                data["reason"] = infraction["reason"] + f" | Pardoned: {pardon_reason}"
+                # Append pardon reason to infraction in database.
+                if (punish_reason := infraction["reason"]) is not None:
+                    data["reason"] = punish_reason + " | "
+                
+                data["reason"] += f"Pardoned: {pardon_reason}"
 
             await self.bot.api_client.patch(
                 f"bot/infractions/{id_}",

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -341,13 +341,7 @@ class Infractions(InfractionScheduler, commands.Cog):
         await self.pardon_infraction(ctx, "mute", user, pardon_reason)
 
     @command()
-    async def unban(
-        self,
-        ctx: Context,
-        user: UnambiguousMemberOrUser,
-        *,
-        pardon_reason: t.Optional[str] = None
-    ) -> None:
+    async def unban(self, ctx: Context, user: UnambiguousMemberOrUser, *, pardon_reason: str) -> None:
         """Prematurely end the active ban infraction for the user."""
         await self.pardon_infraction(ctx, "ban", user, pardon_reason)
 

--- a/tests/bot/exts/moderation/infraction/test_infractions.py
+++ b/tests/bot/exts/moderation/infraction/test_infractions.py
@@ -90,8 +90,14 @@ class VoiceMuteTests(unittest.IsolatedAsyncioTestCase):
     async def test_voice_unmute(self):
         """Should call infraction pardoning function."""
         self.cog.pardon_infraction = AsyncMock()
+        self.assertIsNone(await self.cog.unvoicemute(self.cog, self.ctx, self.user, pardon_reason="foobar"))
+        self.cog.pardon_infraction.assert_awaited_once_with(self.ctx, "voice_mute", self.user, "foobar")
+
+    async def test_voice_unmute_reasonless(self):
+        """Should call infraction pardoning function without a pardon reason."""
+        self.cog.pardon_infraction = AsyncMock()
         self.assertIsNone(await self.cog.unvoicemute(self.cog, self.ctx, self.user))
-        self.cog.pardon_infraction.assert_awaited_once_with(self.ctx, "voice_mute", self.user)
+        self.cog.pardon_infraction.assert_awaited_once_with(self.ctx, "voice_mute", self.user, None)
 
     @patch("bot.exts.moderation.infraction.infractions._utils.post_infraction")
     @patch("bot.exts.moderation.infraction.infractions._utils.get_active_infraction")


### PR DESCRIPTION
Closes issue #1565.

Due to the nature of the bot internals, it would be messy to only change the unban command to take a reason argument. Therefore, all pardon commands that call the method `pardon_infraction()` provided by the `InfractionScheduler` cog will have a reason argument and append the pardon reason to the infraction through `InfractionScheduler.deactivate_infraction()`'s HTTP patch request to the moderation API when the infraction is marked as non-active.

If anyone would like to see a demo of the pardon at work, here's a [video](https://youtu.be/i6iB3nTx-FQ) I've uploaded to YouTube.

The format of the pardoned text is still up for debate, as what I've done was a placeholder.