### PR TITLE
Check if channel.guild is None

### DIFF
--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -552,7 +552,7 @@ class ModLog(Cog, name="ModLog"):
         channel = self.bot.get_channel(channel_id)
 
         # Ignore not found channels, DMs, and messages outside of the main guild.
-        if not channel or not hasattr(channel, "guild") or channel.guild.id != GuildConstant.id:
+        if not channel or channel.guild is None or channel.guild.id != GuildConstant.id:
             return True
 
         # Look at the parent channel of a thread.


### PR DESCRIPTION
As of discord.py v2, all channel types have the `guild` attribute which means it will occasionaly be `None` and might create an `AttributeError`.
Fixes #2256.