### PR TITLE
Improve reporting on autoban filter lists

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -420,6 +420,7 @@ class Channels(metaclass=YAMLGetter):
     how_to_get_help: int
 
     attachment_log: int
+    filter_log: int
     message_log: int
     mod_log: int
     nomination_archive: int

--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -117,9 +117,9 @@ class FilterLists(Cog):
                 )
             raise
 
-        # If it is an autoban trigger we send a warning in #mod-meta
+        # If it is an autoban trigger we send a warning in #filter-log
         if comment and "[autoban]" in comment:
-            await self.bot.get_channel(Channels.mod_meta).send(
+            await self.bot.get_channel(Channels.filter_log).send(
                 f":warning: Heads-up! The new `{list_type}` filter "
                 f"`{content}` (`{comment}`) will automatically ban users."
             )

--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -1,13 +1,13 @@
 import re
 from typing import Optional
 
+import discord
 from botcore.site_api import ResponseCodeError
-from discord import Colour, Embed
 from discord.ext.commands import BadArgument, Cog, Context, IDConverter, group, has_any_role
 
 from bot import constants
 from bot.bot import Bot
-from bot.constants import Channels
+from bot.constants import Channels, Colours
 from bot.converters import ValidDiscordServerInvite, ValidFilterListType
 from bot.log import get_logger
 from bot.pagination import LinePaginator
@@ -179,9 +179,9 @@ class FilterLists(Cog):
 
         # Build the embed
         list_type_plural = list_type.lower().replace("_", " ").title() + "s"
-        embed = Embed(
+        embed = discord.Embed(
             title=f"{allow_type.title()}ed {list_type_plural} ({len(result)} total)",
-            colour=Colour.blue()
+            colour=Colours.blue
         )
         log.trace(f"Trying to list {len(result)} items from the {list_type.lower()} {allow_type}")
 

--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -295,8 +295,8 @@ class FilterLists(Cog):
 
     @command(name="filter_report")
     async def force_send_weekly_report(self, ctx: Context) -> None:
-        """Send a list of autobans added in the last 7 days to #mod-meta."""
-        await self.send_weekly_autoban_report()
+        """Respond with a list of autobans added in the last 7 days."""
+        await self.send_weekly_autoban_report(ctx.channel)
 
     @tasks.loop(time=datetime.time(hour=18))
     async def weekly_autoban_report_task(self) -> None:
@@ -307,7 +307,11 @@ class FilterLists(Cog):
         await self.send_weekly_autoban_report()
 
     async def send_weekly_autoban_report(self, channel: discord.abc.Messageable = None) -> None:
-        """Send a list of autobans added in the last 7 days to #mod-meta."""
+        """
+        Send a list of autobans added in the last 7 days to the specified channel.
+
+        If chanel is not specified, it is sent to #mod-meta.
+        """
         seven_days_ago = arrow.utcnow().shift(days=-7)
         if not channel:
             channel = self.bot.get_channel(Channels.mod_meta)

--- a/bot/exts/filters/filter_lists.py
+++ b/bot/exts/filters/filter_lists.py
@@ -15,6 +15,7 @@ from bot.constants import Channels, Colours
 from bot.converters import ValidDiscordServerInvite, ValidFilterListType
 from bot.log import get_logger
 from bot.pagination import LinePaginator
+from bot.utils.channel import is_mod_channel
 
 log = get_logger(__name__)
 WEEKLY_REPORT_ISO_DAY = 3  # 1=Monday, 7=Sunday
@@ -315,6 +316,9 @@ class FilterLists(Cog):
         seven_days_ago = arrow.utcnow().shift(days=-7)
         if not channel:
             channel = self.bot.get_channel(Channels.mod_meta)
+        elif not is_mod_channel(channel):
+            # Silently fail if output is going to be a non-mod channel.
+            return
 
         added_autobans = defaultdict(list)
         # Extract all autoban filters added in the past 7 days from each filter type

--- a/config-default.yml
+++ b/config-default.yml
@@ -178,6 +178,7 @@ guild:
 
         # Logs
         attachment_log:     &ATTACH_LOG     649243850006855680
+        filter_log:         &FILTER_LOG     1014943924185473094
         message_log:        &MESSAGE_LOG    467752170159079424
         mod_log:            &MOD_LOG        282638479504965634
         nomination_archive:                 833371042046148738
@@ -257,6 +258,7 @@ guild:
         - *MESSAGE_LOG
         - *MOD_LOG
         - *STAFF_VOICE
+        - *FILTER_LOG
 
     reminder_whitelist:
         - *BOT_CMD


### PR DESCRIPTION
These changes have been discussed within the mod team.

This PR changes autoban filter alerts to be sent to #filter-log instead of #mod-meta. This is with the aim to reduce the amount of spam in #mod-meta.

On top of that, this PR adds a new command to generate a report of all autoban filters added in the past 7 days. This report is also scheduled to be sent to #mod-meta once a week at 6pm UTC.

## Screenshots
Empty state:
![image](https://user-images.githubusercontent.com/9753350/188001748-9f6f125b-1cf6-4f27-b897-d3d4eddd4313.png)

Small number:
![image](https://user-images.githubusercontent.com/9753350/188001782-55a7fa8a-fce7-4f05-b9ee-1477c67794c7.png)

Large number of filters:
![image](https://user-images.githubusercontent.com/9753350/188002338-d0e4760d-fd88-4300-8a9d-a4822860c71c.png)
