### PR TITLE
Fix error in help channels cog which assumed an embed would have a description

### DIFF
--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -183,7 +183,8 @@ async def ensure_cached_claimant(channel: discord.TextChannel) -> None:
                 log.info("Hit the dormant message embed before finding a claimant in %s (%d).", channel, channel.id)
                 break
             # Only set the claimant if the first embed matches the claimed channel embed regex
-            if match := CLAIMED_BY_RE.match(message.embeds[0].description):
+            description = message.embeds[0].description
+            if (description is not None) and (match := CLAIMED_BY_RE.match(description)):
                 await _caches.claimants.set(channel.id, int(match.group("user_id")))
                 return
 


### PR DESCRIPTION
Minor bug I noticed locally, embed description can be `None` so we needed to check for it to avoid this error:
```
bot_1          | Traceback (most recent call last):
bot_1          |   File "/usr/local/lib/python3.10/site-packages/discord/ext/commands/bot.py", line 929, in _load_from_module_spec
bot_1          |     await setup(self)
bot_1          |   File "/bot/bot/exts/help_channels/__init__.py", line 40, in setup
bot_1          |     await bot.add_cog(HelpChannels(bot))
bot_1          |   File "/usr/local/lib/python3.10/site-packages/botcore/_bot.py", line 154, in add_cog
bot_1          |     await super().add_cog(cog)
bot_1          |   File "/usr/local/lib/python3.10/site-packages/discord/ext/commands/bot.py", line 765, in add_cog
bot_1          |     cog = await cog._inject(self, override=override, guild=guild, guilds=guilds)
bot_1          |   File "/usr/local/lib/python3.10/site-packages/discord/ext/commands/cog.py", line 562, in _inject
bot_1          |     await maybe_coroutine(self.cog_load)
bot_1          |   File "/usr/local/lib/python3.10/site-packages/discord/utils.py", line 628, in maybe_coroutine
bot_1          |     return await value
bot_1          |   File "/bot/bot/exts/help_channels/_cog.py", line 340, in cog_load
bot_1          |     await _channel.ensure_cached_claimant(channel)
bot_1          |   File "/bot/bot/exts/help_channels/_channel.py", line 186, in ensure_cached_claimant
bot_1          |     if match := CLAIMED_BY_RE.match(message.embeds[0].description):
bot_1          | TypeError: expected string or bytes-like object
bot_1          |
bot_1          | The above exception was the direct cause of the following exception:
bot_1          |
bot_1          | Traceback (most recent call last):
bot_1          |   File "/usr/local/lib/python3.10/site-packages/discord/ext/commands/bot.py", line 995, in load_extension
bot_1          |     await self._load_from_module_spec(spec, name)
bot_1          |   File "/usr/local/lib/python3.10/site-packages/discord/ext/commands/bot.py", line 934, in _load_from_module_spec
bot_1          |     raise errors.ExtensionFailed(key, e) from e
bot_1          | discord.ext.commands.errors.ExtensionFailed: Extension 'bot.exts.help_channels' raised an error: TypeError: expected string or bytes-like object
```