### PR TITLE
Check for commands being None in try_get_tag and try_silence

### DIFF
--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -116,9 +116,13 @@ class ErrorHandler(Cog):
         * invoked with `unshh+` unsilence channel
         Return bool depending on success of command.
         """
+        silence_command = self.bot.get_command("silence")
+        if not silence_command:
+            log.debug("Not attempting to parse message as `shh`/`unshh` as could not find `silence` command.")
+            return False
+
         command = ctx.invoked_with.lower()
         args = ctx.message.content.lower().split(" ")
-        silence_command = self.bot.get_command("silence")
         ctx.invoked_from_error_handler = True
 
         try:
@@ -164,6 +168,10 @@ class ErrorHandler(Cog):
         the context to prevent infinite recursion in the case of a CommandNotFound exception.
         """
         tags_get_command = self.bot.get_command("tags get")
+        if not tags_get_command:
+            log.debug("Not attempting to parse message as a tag as could not find `tags get` command.")
+            return False
+
         ctx.invoked_from_error_handler = True
 
         log_msg = "Cancelling attempt to fall back to a tag due to failed checks."

--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -170,7 +170,7 @@ class ErrorHandler(Cog):
         tags_get_command = self.bot.get_command("tags get")
         if not tags_get_command:
             log.debug("Not attempting to parse message as a tag as could not find `tags get` command.")
-            return False
+            return
 
         ctx.invoked_from_error_handler = True
 


### PR DESCRIPTION
Previously, if the commands were not loaded and you attempted to invoke a command that doesn't exist (e.g. `!hello`), an error would be raised:
```
bot_1          | Traceback (most recent call last):
bot_1          |   File "/usr/local/lib/python3.10/site-packages/discord/client.py", line 456, in _run_event
bot_1          |     await coro(*args, **kwargs)
bot_1          |   File "/bot/bot/exts/backend/error_handler.py", line 67, in on_command_error
bot_1          |     if await self.try_silence(ctx):
bot_1          |   File "/bot/bot/exts/backend/error_handler.py", line 125, in try_silence
bot_1          |     args = ctx.message.content.lower().split(" ")
bot_1          | AttributeError: 'NoneType' object has no attribute 'can_run'
```