### PR TITLE
Removed "redis_ready" from additional_spec_asyncs in MockBot

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -317,7 +317,7 @@ class MockBot(CustomMockMixin, unittest.mock.MagicMock):
         guild_id=1,
         intents=discord.Intents.all(),
     )
-    additional_spec_asyncs = ("wait_for", "redis_ready")
+    additional_spec_asyncs = ("wait_for",)
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)


### PR DESCRIPTION
"redis_ready" attribute was removed from Bot in fc05849 so it no longer needs to be mocked. It was [suggested](https://discord.com/channels/267624335836053506/635950537262759947/1018530171436937236) that this change was small enough to not warrant creating an issue.