### PR TITLE
Resolve poetry venv issues in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ ARG git_sha="development"
 # POETRY_VIRTUALENVS_IN_PROJECT is required to ensure in-projects venvs mounted from the host in dev
 # don't get prioritised by `poetry run`
 ENV POETRY_VERSION=1.2.0 \
-  POETRY_HOME="/opt/poetry" \
+  POETRY_HOME="/opt/poetry/home" \
+  POETRY_CACHE_DIR="/opt/poetry/cache" \
   POETRY_NO_INTERACTION=1 \
   POETRY_VIRTUALENVS_IN_PROJECT=false \
   APP_DIR="/bot" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,12 @@ FROM --platform=linux/amd64 python:3.10-slim
 # Define Git SHA build argument for sentry
 ARG git_sha="development"
 
+# POETRY_VIRTUALENVS_IN_PROJECT is required to ensure in-projects venvs mounted from the host in dev
+# don't get prioritised by `poetry run`
 ENV POETRY_VERSION=1.2.0 \
   POETRY_HOME="/opt/poetry" \
   POETRY_NO_INTERACTION=1 \
+  POETRY_VIRTUALENVS_IN_PROJECT=false \
   APP_DIR="/bot" \
   GIT_SHA=$git_sha
 
@@ -21,7 +24,7 @@ RUN curl -sSL https://install.python-poetry.org | python
 # Install project dependencies
 WORKDIR $APP_DIR
 COPY pyproject.toml poetry.lock ./
-RUN poetry install --no-dev
+RUN poetry install --without dev
 
 # Copy the source code in last to optimize rebuilding the image
 COPY . .


### PR DESCRIPTION
Poetry's virtualenvs.in-project config deafults to None, meaning it will use in-project venvs if it finds one, otherwise it will use the cache dir. In dev we mount the entire root project directory to /bot. This means if the host's venv in in the project dir, this will get mounted and prioritised by poetry run. If the host is on a non-linux OS this will cause poetry to fail to boot.

Specify the path for poetry venvs 
Without this the venv would be created in /root/.cache and the nonn-root user that prod runs under would not have access to it.
