### PR TITLE
1379 tranform urls upon rich embed filter application

### DIFF
--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -23,9 +23,11 @@ from bot.constants import Bot as BotConfig, Channels, Colours, Filter, Guild, Ic
 from bot.exts.events.code_jams._channels import CATEGORY_NAME as JAM_CATEGORY_NAME
 from bot.exts.moderation.modlog import ModLog
 from bot.log import get_logger
+from bot.utils.helpers import remove_subdomain_from_url
 from bot.utils.messages import format_user
 
 log = get_logger(__name__)
+
 
 # Regular expressions
 CODE_BLOCK_RE = re.compile(
@@ -583,7 +585,7 @@ class Filtering(Cog):
         """
         text = self.clean_input(text)
 
-        # Remove backslashes to prevent escape character aroundfuckery like
+        # Remove backslashes to prevent escape character around fuckery like
         # discord\.gg/gdudes-pony-farm
         text = text.replace("\\", "")
 
@@ -648,7 +650,12 @@ class Filtering(Cog):
         if msg.embeds:
             for embed in msg.embeds:
                 if embed.type == "rich":
-                    urls = URL_RE.findall(msg.content)
+                    urls = set(URL_RE.findall(msg.content))
+                    # This is due to way discord renders relative urls in Embdes
+                    # if we send the following url: https://mobile.twitter.com/something
+                    # Discord renders it as https://twitter.com/something
+                    for url in urls:
+                        urls.add(remove_subdomain_from_url(url))
                     if not embed.url or embed.url not in urls:
                         # If `embed.url` does not exist or if `embed.url` is not part of the content
                         # of the message, it's unlikely to be an auto-generated embed by Discord.

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -650,12 +650,13 @@ class Filtering(Cog):
         if msg.embeds:
             for embed in msg.embeds:
                 if embed.type == "rich":
-                    urls = set(URL_RE.findall(msg.content))
+                    urls = URL_RE.findall(msg.content)
+                    final_urls = set(urls)
                     # This is due to way discord renders relative urls in Embdes
                     # if we send the following url: https://mobile.twitter.com/something
                     # Discord renders it as https://twitter.com/something
                     for url in urls:
-                        urls.add(remove_subdomain_from_url(url))
+                        final_urls.add(remove_subdomain_from_url(url))
                     if not embed.url or embed.url not in urls:
                         # If `embed.url` does not exist or if `embed.url` is not part of the content
                         # of the message, it's unlikely to be an auto-generated embed by Discord.

--- a/bot/exts/filters/filtering.py
+++ b/bot/exts/filters/filtering.py
@@ -657,7 +657,7 @@ class Filtering(Cog):
                     # Discord renders it as https://twitter.com/something
                     for url in urls:
                         final_urls.add(remove_subdomain_from_url(url))
-                    if not embed.url or embed.url not in urls:
+                    if not embed.url or embed.url not in final_urls:
                         # If `embed.url` does not exist or if `embed.url` is not part of the content
                         # of the message, it's unlikely to be an auto-generated embed by Discord.
                         return msg.embeds

--- a/bot/utils/helpers.py
+++ b/bot/utils/helpers.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta
 from typing import Optional
+from urllib.parse import urlparse
 
 from discord.ext.commands import CogMeta
 
@@ -30,3 +31,14 @@ def has_lines(string: str, count: int) -> bool:
 def pad_base64(data: str) -> str:
     """Return base64 `data` with padding characters to ensure its length is a multiple of 4."""
     return data + "=" * (-len(data) % 4)
+
+
+def remove_subdomain_from_url(url: str) -> str:
+    """Transforms potential relative urls to absolute ones."""
+    parsed_url = urlparse(url)
+    netloc_components = parsed_url.netloc.split(".")
+    # Eliminate subdomain and use the second level domain and top level domain only
+    netloc_components[:] = netloc_components[-2:]
+    netloc = ".".join(netloc_components)
+    parsed_url = parsed_url._replace(netloc=netloc)
+    return parsed_url.geturl()

--- a/bot/utils/helpers.py
+++ b/bot/utils/helpers.py
@@ -3,6 +3,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 from discord.ext.commands import CogMeta
+from tldextract import extract
 
 
 class CogABCMeta(CogMeta, ABCMeta):
@@ -34,11 +35,10 @@ def pad_base64(data: str) -> str:
 
 
 def remove_subdomain_from_url(url: str) -> str:
-    """Transforms potential relative urls to absolute ones."""
+    """Removes subdomains from a URL whilst preserving the original URL composition."""
     parsed_url = urlparse(url)
-    netloc_components = parsed_url.netloc.split(".")
-    # Eliminate subdomain and use the second level domain and top level domain only
-    netloc_components[:] = netloc_components[-2:]
-    netloc = ".".join(netloc_components)
+    extracted_url = extract(url)
+    # Eliminate subdomain by using the registered domain only
+    netloc = extracted_url.registered_domain
     parsed_url = parsed_url._replace(netloc=netloc)
     return parsed_url.geturl()


### PR DESCRIPTION
closes #1379

The current implementation allows to collect the URLs from the sent messages and then apply a transformation on them.

The transformation here is basically a removal of the subdomain (if it exists) because of the way Discord renders some URLs (Twitter's in particular)
