### PR TITLE
Fix all non-awaited bot.remove_cog calls

### DIFF
--- a/bot/exts/filters/antispam.py
+++ b/bot/exts/filters/antispam.py
@@ -156,7 +156,7 @@ class AntiSpam(Cog):
                 colour=Colour.red()
             )
 
-            self.bot.remove_cog(self.__class__.__name__)
+            await self.bot.remove_cog(self.__class__.__name__)
             return
 
     @Cog.listener()

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -315,7 +315,7 @@ class HelpChannels(commands.Cog):
             )
         except discord.HTTPException:
             log.exception("Failed to get a category; cog will be removed")
-            self.bot.remove_cog(self.qualified_name)
+            await self.bot.remove_cog(self.qualified_name)
 
     async def cog_load(self) -> None:
         """Initialise the help channel system."""

--- a/bot/exts/moderation/watchchannels/_watchchannel.py
+++ b/bot/exts/moderation/watchchannels/_watchchannel.py
@@ -128,7 +128,7 @@ class WatchChannel(metaclass=CogABCMeta):
                 colour=Color.red()
             )
 
-            self.bot.remove_cog(self.__class__.__name__)
+            await self.bot.remove_cog(self.__class__.__name__)
             return
 
         if not await self.fetch_user_cache():


### PR DESCRIPTION
closes #2281

We currently have some instances of the bot.remove_cog async function that is not awaited. 
This PR updates all those calls to be awaited