### PR TITLE
Update intents tag to better reflect discord.py's API changes

### DIFF
--- a/bot/resources/tags/intents.md
+++ b/bot/resources/tags/intents.md
@@ -1,19 +1,17 @@
 **Using intents in discord.py**
 
-Intents are a feature of Discord that tells the gateway exactly which events to send your bot. By default discord.py has all intents enabled except for `Members`, `Message Content`, and `Presences`. These are needed for features such as `on_member` events, to get access to message content, and to get members' statuses.
+Intents are a feature of Discord that tells the gateway exactly which events to send your bot. Various features of discord.py rely on having particular intents enabled. Since discord.py v2.0.0, this has become **mandatory** for developers to define in their code.
 
-To enable one of these intents, you need to first go to the [Discord developer portal](https://discord.com/developers/applications), then to the bot page of your bot's application. Scroll down to the `Privileged Gateway Intents` section, then enable the intents that you need.
+There are *standard* intents and *privileged* intents. The current privileged intents are `Presences`, `Server Members`, and `Message Content`. To use one of the privileged intents, you have to first enable them in the [Discord Developer Portal](https://discord.com/developers/applications). Go to the `Bot` page of your application, scroll down to the `Privileged Gateway Intents` section, and enable the privileged intents that you need.
 
-Next, in your bot you need to set the intents you want to connect with in the bot's constructor using the `intents` keyword argument, like this:
-
+Afterwards in your code, you need to set the intents you want to connect with in the bot's constructor using the `intents` keyword argument, like this:
 ```py
 from discord import Intents
 from discord.ext import commands
 
 intents = Intents.default()
-intents.members = True
+intents.message_content = True
 
 bot = commands.Bot(command_prefix="!", intents=intents)
 ```
-
 For more info about using intents, see the [discord.py docs on intents](https://discordpy.readthedocs.io/en/latest/intents.html), and for general information about them, see the [Discord developer documentation on intents](https://discord.com/developers/docs/topics/gateway#gateway-intents).

--- a/bot/resources/tags/intents.md
+++ b/bot/resources/tags/intents.md
@@ -1,17 +1,19 @@
 **Using intents in discord.py**
 
-Intents are a feature of Discord that tells the gateway exactly which events to send your bot. Various features of discord.py rely on having particular intents enabled. Since discord.py v2.0.0, this has become **mandatory** for developers to define in their code.
+Intents are a feature of Discord that tells the gateway exactly which events to send your bot. Various features of discord.py rely on having particular intents enabled, further detailed [in its documentation](https://discordpy.readthedocs.io/en/stable/api.html#intents). Since discord.py v2.0.0, it has become **mandatory** for developers to explicitly define the values of these intents in their code.
 
-There are *standard* intents and *privileged* intents. The current privileged intents are `Presences`, `Server Members`, and `Message Content`. To use one of the privileged intents, you have to first enable them in the [Discord Developer Portal](https://discord.com/developers/applications). Go to the `Bot` page of your application, scroll down to the `Privileged Gateway Intents` section, and enable the privileged intents that you need.
+There are *standard* and *privileged* intents. To use privileged intents like `Presences`, `Server Members`, and `Message Content`, you have to first enable them in the [Discord Developer Portal](https://discord.com/developers/applications). In there, go to the `Bot` page of your application, scroll down to the `Privileged Gateway Intents` section, and enable the privileged intents that you need. Standard intents can be used without any changes in the developer portal.
 
 Afterwards in your code, you need to set the intents you want to connect with in the bot's constructor using the `intents` keyword argument, like this:
 ```py
 from discord import Intents
 from discord.ext import commands
 
+# Enable all standard intents and message content
+# (prefix commands generally require message content)
 intents = Intents.default()
 intents.message_content = True
 
 bot = commands.Bot(command_prefix="!", intents=intents)
 ```
-For more info about using intents, see the [discord.py docs on intents](https://discordpy.readthedocs.io/en/latest/intents.html), and for general information about them, see the [Discord developer documentation on intents](https://discord.com/developers/docs/topics/gateway#gateway-intents).
+For more info about using intents, see [discord.py's related guide](https://discordpy.readthedocs.io/en/latest/intents.html), and for general information about them, see the [Discord developer documentation on intents](https://discord.com/developers/docs/topics/gateway#gateway-intents).


### PR DESCRIPTION
To resolve #2313, this PR adds a short disclaimer near the top of the intents tag indicating that discord.py v2.0.0 requires its users to specify intents.
The starting paragraphs have also been revised to provide a clearer distinction between Discord's standard and privileged intents.
The code snippet now demonstrates the `message_content` intent since it is (generally) a requirement when writing prefix commands, especially with `commands.Bot`.