### PR TITLE
Update discord.py tags to refer to the stable version of the documentation

### DIFF
--- a/bot/resources/tags/customcooldown.md
+++ b/bot/resources/tags/customcooldown.md
@@ -17,4 +17,4 @@ async def on_message(message):
         await message.channel.send("Not ratelimited!")
 ```
 
-`from_cooldown` takes the amount of `update_rate_limit()`s needed to trigger the cooldown, the time in which the cooldown is triggered, and a [`BucketType`](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.discord.ext.commands.BucketType).
+`from_cooldown` takes the amount of `update_rate_limit()`s needed to trigger the cooldown, the time in which the cooldown is triggered, and a [`BucketType`](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.ext.commands.BucketType).

--- a/bot/resources/tags/customcooldown.md
+++ b/bot/resources/tags/customcooldown.md
@@ -17,4 +17,4 @@ async def on_message(message):
         await message.channel.send("Not ratelimited!")
 ```
 
-`from_cooldown` takes the amount of `update_rate_limit()`s needed to trigger the cooldown, the time in which the cooldown is triggered, and a [`BucketType`](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.discord.ext.commands.BucketType).
+`from_cooldown` takes the amount of `update_rate_limit()`s needed to trigger the cooldown, the time in which the cooldown is triggered, and a [`BucketType`](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#discord.discord.ext.commands.BucketType).

--- a/bot/resources/tags/intents.md
+++ b/bot/resources/tags/intents.md
@@ -16,4 +16,4 @@ intents.members = True
 bot = commands.Bot(command_prefix="!", intents=intents)
 ```
 
-For more info about using intents, see the [discord.py docs on intents](https://discordpy.readthedocs.io/en/latest/intents.html), and for general information about them, see the [Discord developer documentation on intents](https://discord.com/developers/docs/topics/gateway#gateway-intents).
+For more info about using intents, see the [discord.py docs on intents](https://discordpy.readthedocs.io/en/stable/intents.html), and for general information about them, see the [Discord developer documentation on intents](https://discord.com/developers/docs/topics/gateway#gateway-intents).

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -1,4 +1,4 @@
-Thanks to discord.py, sending local files as embed images is simple. You have to create an instance of [`discord.File`](https://discordpy.readthedocs.io/en/latest/api.html#discord.File) class:
+Thanks to discord.py, sending local files as embed images is simple. You have to create an instance of [`discord.File`](https://discordpy.readthedocs.io/en/stable/api.html#discord.File) class:
 ```py
 # When you know the file exact path, you can pass it.
 file = discord.File("/this/is/path/to/my/file.png", filename="file.png")
@@ -10,7 +10,7 @@ with open("/this/is/path/to/my/file.png", "rb") as f:
 When using the file-like object, you have to open it in `rb` mode. Also, in this case, passing `filename` to it is not necessary.
 Please note that `filename` can't contain underscores. This is a Discord limitation.
 
-[`discord.Embed`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed) instances have a [`set_image`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed.set_image) method which can be used to set an attachment as an image:
+[`discord.Embed`](https://discordpy.readthedocs.io/en/stable/api.html#discord.Embed) instances have a [`set_image`](https://discordpy.readthedocs.io/en/stable/api.html#discord.Embed.set_image) method which can be used to set an attachment as an image:
 ```py
 embed = discord.Embed()
 # Set other fields
@@ -20,4 +20,4 @@ After this, you can send an embed with an attachment to Discord:
 ```py
 await channel.send(file=file, embed=embed)
 ```
-This example uses [`discord.TextChannel`](https://discordpy.readthedocs.io/en/latest/api.html#discord.TextChannel) for sending, but any instance of [`discord.abc.Messageable`](https://discordpy.readthedocs.io/en/latest/api.html#discord.abc.Messageable) can be used for sending.
+This example uses [`discord.TextChannel`](https://discordpy.readthedocs.io/en/stable/api.html#discord.TextChannel) for sending, but any instance of [`discord.abc.Messageable`](https://discordpy.readthedocs.io/en/stable/api.html#discord.abc.Messageable) can be used for sending.


### PR DESCRIPTION
Currently the `latest` version of discord.py's documentation is referenced, which is being synchronized to the development branch of discord.py (i.e. master branch). Their branch may introduce changes to the documentation that are irrelevant / inaccessible to users that installed discord.py from PyPI. To avoid potential confusion with those links, this PR changes them to use the `stable` version of the docs instead.

This also fixes the link to `BucketType` in the [customcooldown](https://github.com/python-discord/bot/blob/efd27cf29f726627b9ba630e257a2e3e89d3a286/bot/resources/tags/customcooldown.md) tag not jumping to the corresponding section of the page.