### PR TITLE
Edited several tags

### DIFF
--- a/bot/resources/tags/environments.md
+++ b/bot/resources/tags/environments.md
@@ -5,8 +5,8 @@ The main purpose of Python [virtual environments](https://docs.Python.org/3/libr
 To see the current environment in use by Python, you can run:
 ```py
 >>> import sys
->>> print(sys.executable)
-/usr/bin/python3
+>>> sys.executable
+'/usr/bin/python3'
 ```
 
 To see the environment in use by pip, you can do `pip debug` (`pip3 debug` for Linux/macOS). The 3rd line of the output will contain the path in use e.g. `sys.executable: /usr/bin/python3`.

--- a/bot/resources/tags/environments.md
+++ b/bot/resources/tags/environments.md
@@ -1,4 +1,8 @@
-**Python Environments**
+---
+aliases: ["envs"]
+embed:
+    title: "Python Environments"
+---
 
 The main purpose of Python [virtual environments](https://docs.Python.org/3/library/venv.html#venv-def) is to create an isolated environment for Python projects. This means that each project can have its own dependencies, such as third party packages installed using pip, regardless of what dependencies every other project has.
 

--- a/bot/resources/tags/identity.md
+++ b/bot/resources/tags/identity.md
@@ -13,12 +13,14 @@ if x == 3:
 ```
 To check if two objects are actually the same thing in memory, use the identity comparison operator (`is`).
 ```py
-list_1 = [1, 2, 3]
-list_2 = [1, 2, 3]
-if list_1 is [1, 2, 3]:
-    print("list_1 is list_2")
-reference_to_list_1 = list_1
-if list_1 is reference_to_list_1:
-    print("list_1 is reference_to_list_1")
-# Prints 'list_1 is reference_to_list_1'
+>>> list_1 = [1, 2, 3]
+>>> list_2 = [1, 2, 3]
+>>> if list_1 is [1, 2, 3]:
+...    print("list_1 is list_2")
+...
+>>> reference_to_list_1 = list_1
+>>> if list_1 is reference_to_list_1:
+...    print("list_1 is reference_to_list_1")
+...
+list_1 is reference_to_list_1
 ```

--- a/bot/resources/tags/inline.md
+++ b/bot/resources/tags/inline.md
@@ -4,4 +4,6 @@ Inline codeblocks look `like this`. To create them you surround text with single
 
 Note that backticks are not quotes, see [this](https://superuser.com/questions/254076/how-do-i-type-the-tick-and-backtick-characters-on-windows/254077#254077) if you are struggling to find the backtick key.
 
+If the wrapped code itself has a backtick, wrap it with two backticks from each side: \`\`back \` tick\`\` would become ``back ` tick``.
+
 For how to make multiline codeblocks see the `!codeblock` tag.

--- a/bot/resources/tags/listcomps.md
+++ b/bot/resources/tags/listcomps.md
@@ -10,7 +10,7 @@ Using list comprehensions can make this both shorter and more readable. As a lis
 >>> [n ** 2 for n in range(5)]
 [0, 1, 4, 9, 16]
 ```
-List comprehensions also get an `if` statement:
+List comprehensions also get an `if` expression:
 ```python
 >>> [n ** 2 for n in range(5) if n % 2 == 0]
 [0, 4, 16]

--- a/bot/resources/tags/listcomps.md
+++ b/bot/resources/tags/listcomps.md
@@ -10,8 +10,8 @@ Using list comprehensions can make this both shorter and more readable. As a lis
 >>> [n ** 2 for n in range(5)]
 [0, 1, 4, 9, 16]
 ```
-List comprehensions also get an `if` expression:
-```python
+List comprehensions also get an `if` clause:
+```py
 >>> [n ** 2 for n in range(5) if n % 2 == 0]
 [0, 4, 16]
 ```

--- a/bot/resources/tags/local-file.md
+++ b/bot/resources/tags/local-file.md
@@ -7,8 +7,8 @@ file = discord.File("/this/is/path/to/my/file.png", filename="file.png")
 with open("/this/is/path/to/my/file.png", "rb") as f:
     file = discord.File(f)
 ```
-When using the file-like object, you have to open it in `rb` mode. Also, in this case, passing `filename` to it is not necessary.
-Please note that `filename` can't contain underscores. This is a Discord limitation.
+When using the file-like object, you have to open it in `rb` ('read binary') mode. Also, in this case, passing `filename` to it is not necessary.
+Please note that `filename` must not contain underscores. This is a Discord limitation.
 
 [`discord.Embed`](https://discordpy.readthedocs.io/en/stable/api.html#discord.Embed) instances have a [`set_image`](https://discordpy.readthedocs.io/en/stable/api.html#discord.Embed.set_image) method which can be used to set an attachment as an image:
 ```py

--- a/bot/resources/tags/slicing.md
+++ b/bot/resources/tags/slicing.md
@@ -3,7 +3,7 @@ aliases: ["slice", "seqslice", "seqslicing", "sequence-slice", "sequence-slicing
 embed:
     title: "Sequence slicing"
 ---
-*Slicing* is a way of accessing a part of a sequence by specifying a start, stop, and step. As with normal indexing, negative numbers can be used to count backwards.
+**Slicing** is a way of accessing a part of a sequence by specifying a start, stop, and step. As with normal indexing, negative numbers can be used to count backwards.
 
 **Examples**
 ```py

--- a/bot/resources/tags/traceback.md
+++ b/bot/resources/tags/traceback.md
@@ -10,6 +10,7 @@ Traceback (most recent call last):
     add_three("6")
   File "my_file.py", line 2, in add_three
     a = num + 3
+        ~~~~^~~
 TypeError: can only concatenate str (not "int") to str
 ```
 If the traceback is long, use [our pastebin](https://paste.pythondiscord.com/).

--- a/bot/resources/tags/venv.md
+++ b/bot/resources/tags/venv.md
@@ -1,4 +1,8 @@
-**Virtual Environments**
+---
+aliases: ["virtualenv"]
+embed:
+    title: "Virtual Environments"
+---
 
 Virtual environments are isolated Python environments, which make it easier to keep your system clean and manage dependencies. By default, when activated, only libraries and scripts installed in the virtual environment are accessible, preventing cross-project dependency conflicts, and allowing easy isolation of requirements.
 
@@ -16,5 +20,7 @@ For more information, take a read of the [documentation](https://docs.python.org
 
 Tools such as [poetry](https://python-poetry.org/docs/basic-usage/) and [pipenv](https://pipenv.pypa.io/en/latest/) can manage the creation of virtual environments as well as project dependencies, making packaging and installing your project easier.
 
-**Note:** When using Windows PowerShell, you may need to change the [execution policy](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies) first. This is only required once:
-`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`
+**Note:** When using PowerShell in Windows, you may need to change the [execution policy](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies) first. This is only required once per user:
+```ps1
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+```


### PR DESCRIPTION
- `environments.md`:
  - Added `envs` alias
  - Moved `Python Environments` to the embed's title field
  - Unwrapped `sys.executable` since it's a REPL example
- `identity.md`: Converted the example with lists to a snippet from a REPL session.
- `inline.md`: Added info about including a backtick in an inline code snippet.
- `listcomps.md`: `if` in list comprehensions is an expression, not a statement, so I changed that.
- `local-file.md`: Short explanation of `rb`, changed modal verb in a sentence
- `slicing.md`: The word "slicing" at the start is now in bold, not in italics.
- `traceback.md`: Added a line that appears since newer Python versions in tracebacks.
- `venv.md`:
  - Added `virtualenv` alias
  - Moved `Virtual Environments` to the embed's title
  - PowerShell is no longer called Windows PowerShell, since its core is cross-platform now. Instead, mentioned that it's about PowerShell in Windows.
  - `-Scope CurrentUser` will make the change apply just for the user, so mentioned that it's required *once per user*.
  - Changed the PowerShell snippet to make it have syntax highlighting

I felt like changing it since I saw what I could improve in `venv.md`, but decided to check more tags as well.