### PR TITLE
Make snekbox 3.11 stable default, with 3.10 as an option

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -546,7 +546,7 @@ class URLs(metaclass=YAMLGetter):
 
     # Snekbox endpoints
     snekbox_eval_api: str
-    snekbox_311_eval_api: str
+    snekbox_310_eval_api: str
 
     # Discord API endpoints
     discord_api: str

--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -196,9 +196,9 @@ class Snekbox(Cog):
     ) -> dict:
         """Send a POST request to the Snekbox API to evaluate code and return the results."""
         if python_version == "3.10":
-            url = URLs.snekbox_eval_api
+            url = URLs.snekbox_310_eval_api
         else:
-            url = URLs.snekbox_311_eval_api
+            url = URLs.snekbox_eval_api
 
         data = {"input": code}
 

--- a/config-default.yml
+++ b/config-default.yml
@@ -386,7 +386,7 @@ urls:
 
     # Snekbox
     snekbox_eval_api: !ENV ["SNEKBOX_EVAL_API", "http://snekbox.default.svc.cluster.local/eval"]
-    snekbox_311_eval_api: !ENV ["SNEKBOX_311_EVAL_API", "http://snekbox-311.default.svc.cluster.local/eval"]
+    snekbox_310_eval_api: !ENV ["SNEKBOX_310_EVAL_API", "http://snekbox-310.default.svc.cluster.local/eval"]
 
     # Discord API URLs
     discord_api:        &DISCORD_API "https://discordapp.com/api/v7/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,18 +61,18 @@ services:
     ports:
      - "127.0.0.1:8060:8060"
     privileged: true
-    profiles:
-      - "3.10"
 
-  snekbox-311:
+  snekbox-310:
     << : *logging
     << : *restart_policy
-    image: ghcr.io/python-discord/snekbox:3.11-dev
+    image: ghcr.io/python-discord/snekbox:2022.8.14.2  # Most recent 3.10 image
     init: true
     ipc: none
     ports:
      - "127.0.0.1:8065:8060"
     privileged: true
+    profiles:
+      - "3.10"
 
   web:
     << : *logging
@@ -108,7 +108,7 @@ services:
     depends_on:
       - web
       - redis
-      - snekbox-311
+      - snekbox
     env_file:
       - .env
     environment:

--- a/tests/bot/exts/utils/test_snekbox.py
+++ b/tests/bot/exts/utils/test_snekbox.py
@@ -29,7 +29,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(await self.cog.post_job("import random", "3.10"), "return")
         self.bot.http_session.post.assert_called_with(
-            constants.URLs.snekbox_eval_api,
+            constants.URLs.snekbox_310_eval_api,
             json={"input": "import random"},
             raise_for_status=True
         )


### PR DESCRIPTION
The manifests in https://github.com/python-discord/kubernetes/pull/144 should be applied before this PR is merged.

3.11 is now the default version for snekbox, so we no longer need a special cased 3.11 service. This 3.10 service has been created so that we can retain the version swapping capiblities for the next time we want to do something similar.