### PR TITLE
Send DM message to help post opener sooner in the process

### DIFF
--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -109,12 +109,13 @@ async def help_thread_opened(opened_thread: discord.Thread, *, reopen: bool = Fa
         await _close_help_thread(opened_thread, _stats.ClosingReason.CLEANUP)
         return
 
+    await send_opened_post_dm(opened_thread)
+
     if opened_thread.starter_message:
         # To cover the case where the user deletes their starter message before code execution reaches this line.
         await opened_thread.starter_message.pin()
 
     await send_opened_post_message(opened_thread)
-    await send_opened_post_dm(opened_thread)
 
     cooldown_role = opened_thread.guild.get_role(constants.Roles.help_cooldown)
     await members.handle_role_change(opened_thread.owner, opened_thread.owner.add_roles, cooldown_role)


### PR DESCRIPTION
This is to give Discord time to make the thread actually avaiulable to be posted in for the send_opened_post_message call

Closes #2334 Closes BOT-3AW