### PR TITLE
Misc Fixes For Help Forum

### DIFF
--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -80,7 +80,7 @@ async def send_opened_post_dm(thread: discord.Thread) -> None:
         try:
             message = await thread.fetch_message(thread.id)
         except discord.HTTPException:
-            log.warning(f"Could not fetch message for thread {thread.name} ({thread.id})")
+            log.warning(f"Could not fetch message for thread {thread.id}")
             return
 
     formatted_message = textwrap.shorten(message.content, width=100, placeholder="...")

--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -125,9 +125,14 @@ async def help_thread_opened(opened_thread: discord.Thread, *, reopen: bool = Fa
 
     await send_opened_post_dm(opened_thread)
 
-    if opened_thread.starter_message:
-        # To cover the case where the user deletes their starter message before code execution reaches this line.
+    try:
         await opened_thread.starter_message.pin()
+    except discord.HTTPException as e:
+        if e.code == 10008:
+            # The message was not found, most likely deleted
+            pass
+        else:
+            raise e
 
     await send_opened_post_message(opened_thread)
 

--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -1,5 +1,5 @@
 """Contains all logic to handle changes to posts in the help forum."""
-
+import asyncio
 import textwrap
 
 import discord
@@ -108,6 +108,11 @@ async def help_thread_opened(opened_thread: discord.Thread, *, reopen: bool = Fa
         log.debug(f"{opened_thread.owner_id} isn't a member. Closing post.")
         await _close_help_thread(opened_thread, _stats.ClosingReason.CLEANUP)
         return
+
+    # Discord sends the open event long before the thread is ready for actions in the API.
+    # This causes actions such as fetching the message, pinning message, etc to fail.
+    # We sleep here to try and delay our code enough so the thread is ready in the API.
+    await asyncio.sleep(2)
 
     await send_opened_post_dm(opened_thread)
 

--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -52,6 +52,15 @@ async def _close_help_thread(closed_thread: discord.Thread, closed_on: _stats.Cl
 
     poster = closed_thread.owner
     cooldown_role = closed_thread.guild.get_role(constants.Roles.help_cooldown)
+
+    if poster is None:
+        # We can't include the owner ID/name here since the thread only contains None
+        log.info(
+            f"Failed to remove cooldown role for owner of thread ({closed_thread.id}). "
+            f"The user is likely no longer on the server."
+        )
+        return
+
     await members.handle_role_change(poster, poster.remove_roles, cooldown_role)
 
 

--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -132,10 +132,8 @@ async def help_thread_opened(opened_thread: discord.Thread, *, reopen: bool = Fa
     try:
         await opened_thread.starter_message.pin()
     except discord.HTTPException as e:
-        if e.code == 10008:
-            # The message was not found, most likely deleted
-            pass
-        else:
+        # Suppress if the message was not found, most likely deleted
+        if e.code != 10008:
             raise e
 
     await send_opened_post_message(opened_thread)

--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -92,7 +92,11 @@ async def send_opened_post_dm(thread: discord.Thread) -> None:
             log.warning(f"Could not fetch message for thread {thread.id}")
             return
 
-    formatted_message = textwrap.shorten(message.content, width=100, placeholder="...")
+    formatted_message = textwrap.shorten(message.content, width=100, placeholder="...").strip()
+    if formatted_message is None:
+        # This most likely means the initial message is only an image or similar
+        formatted_message = "No text content."
+
     embed.add_field(name="Your message", value=formatted_message, inline=False)
     embed.add_field(
         name="Conversation",

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -119,9 +119,8 @@ class HelpForum(commands.Cog):
         if thread.parent_id != self.help_forum_channel_id:
             return
 
-        await _channel.help_thread_opened(thread)
-
         await self.post_with_disallowed_title_check(thread)
+        await _channel.help_thread_opened(thread)
 
     @commands.Cog.listener()
     async def on_thread_update(self, before: discord.Thread, after: discord.Thread) -> None:

--- a/bot/pagination.py
+++ b/bot/pagination.py
@@ -303,7 +303,12 @@ class LinePaginator(Paginator):
                 return await message.delete()
             elif reaction.emoji in PAGINATION_EMOJI:
                 total_pages = len(paginator.pages)
-                await message.remove_reaction(reaction.emoji, user)
+                try:
+                    await message.remove_reaction(reaction.emoji, user)
+                except discord.HTTPException as e:
+                    # Suppress if trying to act on an archived thread.
+                    if e.code != 50083:
+                        raise e
 
                 if reaction.emoji == FIRST_EMOJI:
                     current_page = 0
@@ -347,8 +352,6 @@ class LinePaginator(Paginator):
             try:
                 await message.clear_reactions()
             except discord.HTTPException as e:
-                if e.code == 50083:
-                    # Trying to act on an archived thread, just ignore
-                    pass
-                else:
+                # Suppress if trying to act on an archived thread.
+                if e.code != 50083:
                     raise e

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -98,18 +98,17 @@ async def wait_for_deletion(
         try:
             await bot.instance.wait_for('reaction_add', check=check, timeout=timeout)
         except asyncio.TimeoutError:
-            try:
-                await message.clear_reactions()
-            except discord.HTTPException as e:
-                if isinstance(message.channel, discord.Thread):
-                    # Threads might not be accessible by the time we try to remove the reaction.
-                    pass
-                else:
-                    raise e
+            await message.clear_reactions()
         else:
             await message.delete()
+
     except discord.NotFound:
         log.trace(f"wait_for_deletion: message {message.id} deleted prematurely.")
+
+    except discord.HTTPException:
+        if not isinstance(message.channel, discord.Thread):
+            # Threads might not be accessible by the time the timeout expires
+            raise
 
 
 async def send_attachments(

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -98,7 +98,14 @@ async def wait_for_deletion(
         try:
             await bot.instance.wait_for('reaction_add', check=check, timeout=timeout)
         except asyncio.TimeoutError:
-            await message.clear_reactions()
+            try:
+                await message.clear_reactions()
+            except discord.HTTPException as e:
+                if isinstance(message.channel, discord.Thread):
+                    # Threads might not be accessible by the time we try to remove the reaction.
+                    pass
+                else:
+                    raise e
         else:
             await message.delete()
     except discord.NotFound:


### PR DESCRIPTION
This PR includes a few small fixes for the help forum. Each commit includes descriptions of the issue, and the fix.

- ed815a1c Is meant to improve reporting in sentry issues
- fcf7e1cc closes [BOT-3AW](https://sentry.io/organizations/python-discord/issues/3768535764/?referrer=github_integration) (see #2335 for additional fixes) [BOT-3BF](https://sentry.io/organizations/python-discord/issues/3769312713/?referrer=github_integration). BOT-3BF was intentionally not marked as closed since sentry keeps generating new events for this same issue, so I'll manually merge them and close them by hand once this PR is merged. See previous commit
- 4779d424 closes BOT-3BB
- 81a68784 closes BOT-3BC
- 555ed4e9 closes BOT-3B0 closes BOT-3B5 closes BOT-3BE
- dddf9734 preemptive fix similar in vein to the wait_for_deletion issues
- 4ca04f60 closes BOT-3BJ
