### PR TITLE
Allow members to self assign roles through a persistent view

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -465,6 +465,8 @@ class Channels(metaclass=YAMLGetter):
 
     big_brother_logs: int
 
+    roles: int
+
 
 class Webhooks(metaclass=YAMLGetter):
     section = "guild"

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -151,7 +151,7 @@ class SingleRoleButton(discord.ui.Button):
         self.style = self.REMOVE_STYLE if self.assigned else self.ADD_STYLE
         self.label = self.LABEL_FORMAT.format(action="Remove" if self.assigned else "Add", role_name=self.role.name)
         try:
-            await interaction.message.edit(view=self.view)
+            await self.view.anchor_message.edit(view=self.view)
         except discord.NotFound:
             log.debug("Subscribe message for %s removed before buttons could be updated", interaction.user)
             self.view.stop()
@@ -184,6 +184,7 @@ class ShowAllSelfAssignableRolesButton(discord.ui.Button):
         view = prepare_self_assignable_roles_view(interaction, self.assignable_roles)
         message = await interaction.followup.send(
             view=view,
+            ephemeral=True
         )
         # Keep reference of the message that contains the view to be deleted
         view.anchor_message = message

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -183,7 +183,7 @@ class Subscribe(commands.Cog):
 
     SELF_ASSIGNABLE_ROLES_MESSAGE = (
         f"Hi there {GREETING_EMOJI},"
-        "\nWe have self-assignable roles for server updates an events!"
+        "\nWe have self-assignable roles for server updates and events!"
         "\nClick the button below to toggle them:"
     )
 

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -214,7 +214,7 @@ class Subscribe(commands.Cog):
 
         placeholder_message_view_tuple = await self._fetch_or_create_self_assignable_roles_message()
         self_assignable_roles_message, self_assignable_roles_view = placeholder_message_view_tuple
-        self.__attach_persistent_roles_view(self_assignable_roles_message, self_assignable_roles_view)
+        self._attach_persistent_roles_view(self_assignable_roles_message, self_assignable_roles_view)
 
     @commands.cooldown(1, 10, commands.BucketType.member)
     @commands.command(name="subscribe", aliases=("unsubscribe",))
@@ -250,7 +250,7 @@ class Subscribe(commands.Cog):
         placeholder_message = await roles_channel.send(self.SELF_ASSIGNABLE_ROLES_MESSAGE, view=view)
         return placeholder_message, view
 
-    def __attach_persistent_roles_view(
+    def _attach_persistent_roles_view(
             self,
             placeholder_message: discord.Message,
             persistent_roles_view: discord.ui.View | None = None

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -161,7 +161,7 @@ class ShowAllSelfAssignableRolesButton(discord.ui.Button):
     def __init__(self, assignable_roles: list[AssignableRole]):
         super().__init__(
             style=discord.ButtonStyle.success,
-            label="Show available roles",
+            label="Show all self assignable roles",
             custom_id=self.CUSTOM_ID,
             row=1
         )
@@ -181,7 +181,7 @@ class ShowAllSelfAssignableRolesButton(discord.ui.Button):
 class Subscribe(commands.Cog):
     """Cog to allow user to self-assign & remove the roles present in ASSIGNABLE_ROLES."""
 
-    SELF_ASSIGNABLE_ROLES_MESSAGE = "Click on this button to earn all the currently available server roles"
+    SELF_ASSIGNABLE_ROLES_MESSAGE = "Click on this button to show all self assignable roles"
 
     def __init__(self, bot: Bot):
         self.bot = bot

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -147,14 +147,14 @@ class SingleRoleButton(discord.ui.Button):
 
 
 class AllSelfAssignableRolesView(discord.ui.View):
-    """A view that'll hold one button allowing interactors to get all available self-assignable roles."""
+    """A persistent view that'll hold one button allowing interactors to toggle all available self-assignable roles."""
 
     def __init__(self):
         super(AllSelfAssignableRolesView, self).__init__(timeout=None)
 
 
 class ShowAllSelfAssignableRolesButton(discord.ui.Button):
-    """A button that sends a view containing all the different roles a user can self assign at that time."""
+    """A button that, when clicked, sends a view a user can interact with to assign one or all the available roles."""
 
     CUSTOM_ID = "gotta-claim-them-all"
 

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -286,7 +286,7 @@ def prepare_self_assignable_roles_view(
 
 
 async def setup(bot: Bot) -> None:
-    """Load the Subscribe cog."""
+    """Load the 'Subscribe' cog."""
     if len(ASSIGNABLE_ROLES) > ITEMS_PER_ROW*5:  # Discord limits views to 5 rows of buttons.
         log.error("Too many roles for 5 rows, not loading the Subscribe cog.")
     else:

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -222,7 +222,7 @@ class Subscribe(commands.Cog):
         self.assignable_roles.sort(key=operator.attrgetter("name"))
         self.assignable_roles.sort(key=operator.methodcaller("is_currently_available"), reverse=True)
 
-        initial_self_assignable_roles_message = await self.__search_for_self_assignable_roles_message()
+        initial_self_assignable_roles_message = await self._fetch_or_create_self_assignable_roles_message()
         self.__attach_persistent_roles_view(initial_self_assignable_roles_message)
 
     @commands.cooldown(1, 10, commands.BucketType.member)
@@ -242,9 +242,9 @@ class Subscribe(commands.Cog):
         # Keep reference of the message that contains the view to be deleted
         view.anchor_message = message
 
-    async def __search_for_self_assignable_roles_message(self) -> discord.Message:
+    async def _fetch_or_create_self_assignable_roles_message(self) -> discord.Message:
         """
-        Searches for the message that holds the self assignable roles view.
+        Fetches the message that holds the self assignable roles view.
 
         If the initial message isn't found, a new one will be created.
         This message will always be needed to attach the persistent view to it

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -85,7 +85,7 @@ class RoleButtonView(discord.ui.View):
 
 
 class SingleRoleButton(discord.ui.Button):
-    """A button that adds or removes a role from the member depending on it's current state."""
+    """A button that adds or removes a role from the member depending on its current state."""
 
     ADD_STYLE = discord.ButtonStyle.success
     REMOVE_STYLE = discord.ButtonStyle.red
@@ -237,7 +237,7 @@ class Subscribe(commands.Cog):
         If the initial message isn't found, a new one will be created.
         This message will always be needed to attach the persistent view to it
         """
-        roles_channel = await get_or_fetch_channel(constants.Channels.roles)
+        roles_channel: discord.TextChannel = await get_or_fetch_channel(constants.Channels.roles)
 
         async for message in roles_channel.history(limit=30):
             if message.content == self.SELF_ASSIGNABLE_ROLES_MESSAGE:
@@ -287,7 +287,7 @@ def prepare_self_assignable_roles_view(
 
 async def setup(bot: Bot) -> None:
     """Load the 'Subscribe' cog."""
-    if len(ASSIGNABLE_ROLES) > ITEMS_PER_ROW*5:  # Discord limits views to 5 rows of buttons.
+    if len(ASSIGNABLE_ROLES) > ITEMS_PER_ROW * 5:  # Discord limits views to 5 rows of buttons.
         log.error("Too many roles for 5 rows, not loading the Subscribe cog.")
     else:
         await bot.add_cog(Subscribe(bot))

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -98,7 +98,7 @@ class SingleRoleButton(discord.ui.Button):
     ADD_STYLE = discord.ButtonStyle.success
     REMOVE_STYLE = discord.ButtonStyle.red
     UNAVAILABLE_STYLE = discord.ButtonStyle.secondary
-    LABEL_FORMAT = "{action} role {role_name}."
+    LABEL_FORMAT = "{action} role {role_name}"
     CUSTOM_ID_FORMAT = "subscribe-{role_id}"
 
     def __init__(self, role: AssignableRole, assigned: bool, row: int):
@@ -181,9 +181,11 @@ class Subscribe(commands.Cog):
 
     GREETING_EMOJI = ":wave:"
 
-    SELF_ASSIGNABLE_ROLES_MESSAGE = f"Hi there {GREETING_EMOJI}," \
-                                    "\nDid you know we had various self-assignable roles for server updates an events?"\
-                                    "\nClick the button below to toggle them."
+    SELF_ASSIGNABLE_ROLES_MESSAGE = (
+        f"Hi there {GREETING_EMOJI},"
+        "\nWe have self-assignable roles for server updates an events!"
+        "\nClick the button below to toggle them:"
+    )
 
     def __init__(self, bot: Bot):
         self.bot = bot

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -160,25 +160,17 @@ class SingleRoleButton(discord.ui.Button):
 class AllSelfAssignableRolesView(discord.ui.View):
     """A persistent view that'll hold one button allowing interactors to toggle all available self-assignable roles."""
 
-    def __init__(self):
-        super().__init__(timeout=None)
-
-
-class ShowAllSelfAssignableRolesButton(discord.ui.Button):
-    """A button that, when clicked, sends a view a user can interact with to assign one or all the available roles."""
-
-    CUSTOM_ID = "gotta-claim-them-all"
-
     def __init__(self, assignable_roles: list[AssignableRole]):
-        super().__init__(
-            style=discord.ButtonStyle.success,
-            label="Show all self assignable roles",
-            custom_id=self.CUSTOM_ID,
-            row=1
-        )
+        super().__init__(timeout=None)
         self.assignable_roles = assignable_roles
 
-    async def callback(self, interaction: Interaction) -> t.Any:
+    @discord.ui.button(
+        style=discord.ButtonStyle.success,
+        label="Show all self assignable roles",
+        custom_id="gotta-claim-them-all",
+        row=1
+    )
+    async def show_all_self_assignable_roles(self, interaction: Interaction, button: discord.ui.Button) -> None:
         """Sends the original subscription view containing the available self assignable roles."""
         await interaction.response.defer()
         view = prepare_self_assignable_roles_view(interaction, self.assignable_roles)
@@ -257,8 +249,7 @@ class Subscribe(commands.Cog):
                 return message
 
         log.debug("Self assignable roles view message hasn't been found, creating a new one.")
-        view = AllSelfAssignableRolesView()
-        view.add_item(ShowAllSelfAssignableRolesButton(self.assignable_roles))
+        view = AllSelfAssignableRolesView(self.assignable_roles)
         return await roles_channel.send(self.SELF_ASSIGNABLE_ROLES_MESSAGE, view=view)
 
     def __attach_persistent_roles_view(
@@ -275,8 +266,7 @@ class Subscribe(commands.Cog):
             :param placeholder_message: The message that will hold the persistent view allowing
             users to toggle the RoleButtonView
         """
-        view = AllSelfAssignableRolesView()
-        view.add_item(ShowAllSelfAssignableRolesButton(self.assignable_roles))
+        view = AllSelfAssignableRolesView(self.assignable_roles)
         self.bot.add_view(view, message_id=placeholder_message.id)
 
 

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -153,15 +153,15 @@ class AllSelfAssignableRolesView(discord.ui.View):
         super(AllSelfAssignableRolesView, self).__init__(timeout=None)
 
 
-class ClaimAllSelfAssignableRolesButton(discord.ui.Button):
-    """A button that adds all self assignable roles to the interactor."""
+class ShowAllSelfAssignableRolesButton(discord.ui.Button):
+    """A button that sends a view containing all the different roles a user can self assign at that time."""
 
     CUSTOM_ID = "gotta-claim-them-all"
 
     def __init__(self, assignable_roles: list[AssignableRole]):
         super().__init__(
             style=discord.ButtonStyle.success,
-            label="Claim all available roles",
+            label="Show available roles",
             custom_id=self.CUSTOM_ID,
             row=1
         )
@@ -246,7 +246,7 @@ class Subscribe(commands.Cog):
 
         log.debug("Self assignable roles view message hasn't been found, creating a new one.")
         view = AllSelfAssignableRolesView()
-        view.add_item(ClaimAllSelfAssignableRolesButton(self.assignable_roles))
+        view.add_item(ShowAllSelfAssignableRolesButton(self.assignable_roles))
         return await roles_channel.send(self.SELF_ASSIGNABLE_ROLES_MESSAGE, view=view)
 
     def __attach_view_to_initial_self_assignable_roles_message(self, message: discord.Message) -> None:
@@ -256,7 +256,7 @@ class Subscribe(commands.Cog):
         The message is searched for/created upon loading the Cog.
         """
         view = AllSelfAssignableRolesView()
-        view.add_item(ClaimAllSelfAssignableRolesButton(self.assignable_roles))
+        view.add_item(ShowAllSelfAssignableRolesButton(self.assignable_roles))
         self.bot.add_view(view, message_id=message.id)
 
 

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -168,7 +168,7 @@ class ShowAllSelfAssignableRolesButton(discord.ui.Button):
         self.assignable_roles = assignable_roles
 
     async def callback(self, interaction: Interaction) -> t.Any:
-        """Assigns all missing available roles to the interactor."""
+        """Sends the original subscription view containing the available self assignable roles."""
         await interaction.response.defer()
         view = prepare_available_role_subscription_view(interaction, self.assignable_roles)
         message = await interaction.followup.send(

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -59,6 +59,27 @@ DELETE_MESSAGE_AFTER = 300  # Seconds
 log = get_logger(__name__)
 
 
+class AllSelfAssignableRolesView(discord.ui.View):
+    """A view that'll hold one button allowing interactors to get all available self-assignable roles."""
+
+    def __init__(self):
+        super(AllSelfAssignableRolesView, self).__init__(timeout=None)
+
+
+class ClaimAllSelfAssignableRolesButton(discord.ui.Button):
+    """A button that adds all self assignable roles to the interactor."""
+
+    CUSTOM_ID = "gotta-claim-them-all"
+
+    def __init__(self):
+        super().__init__(
+            style=discord.ButtonStyle.success,
+            label="Assign me a",
+            custom_id=self.CUSTOM_ID,
+            row=1
+        )
+
+
 class RoleButtonView(discord.ui.View):
     """A list of SingleRoleButtons to show to the member."""
 
@@ -150,7 +171,6 @@ class Subscribe(commands.Cog):
     async def cog_load(self) -> None:
         """Initialise the cog by resolving the role IDs in ASSIGNABLE_ROLES to role names."""
         await self.bot.wait_until_guild_available()
-
         self.guild = self.bot.get_guild(constants.Guild.id)
 
         for role in ASSIGNABLE_ROLES:

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -138,7 +138,7 @@ class SingleRoleButton(discord.ui.Button):
 
         self.assigned = not self.assigned
         await self.update_view(interaction)
-        await interaction.response.send_message(
+        await interaction.followup.send(
             self.LABEL_FORMAT.format(action="Added" if self.assigned else "Removed", role_name=self.role.name),
             ephemeral=True,
         )

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -55,7 +55,7 @@ ASSIGNABLE_ROLES = (
 )
 
 ITEMS_PER_ROW = 3
-DELETE_MESSAGE_AFTER = 20  # Seconds
+DELETE_MESSAGE_AFTER = 300  # Seconds
 
 log = get_logger(__name__)
 

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -72,13 +72,14 @@ class ClaimAllSelfAssignableRolesButton(discord.ui.Button):
 
     CUSTOM_ID = "gotta-claim-them-all"
 
-    def __init__(self):
+    def __init__(self, assignable_roles: list[AssignableRole]):
         super().__init__(
             style=discord.ButtonStyle.success,
             label="Claim all available roles",
             custom_id=self.CUSTOM_ID,
             row=1
         )
+        self.assignable_roles = assignable_roles
 
 
 class RoleButtonView(discord.ui.View):
@@ -232,7 +233,7 @@ class Subscribe(commands.Cog):
 
         log.debug("Self assignable roles view message hasn't been found, creating a new one.")
         view = AllSelfAssignableRolesView()
-        view.add_item(ClaimAllSelfAssignableRolesButton())
+        view.add_item(ClaimAllSelfAssignableRolesButton(self.assignable_roles))
         return await roles_channel.send(self.SELF_ASSIGNABLE_ROLES_MESSAGE, view=view)
 
     def __attach_view_to_initial_self_assignable_roles_message(self, message: discord.Message) -> None:
@@ -242,7 +243,7 @@ class Subscribe(commands.Cog):
         The message is searched for/created upon loading the Cog.
         """
         view = AllSelfAssignableRolesView()
-        view.add_item(ClaimAllSelfAssignableRolesButton())
+        view.add_item(ClaimAllSelfAssignableRolesButton(self.assignable_roles))
         self.bot.add_view(view, message_id=message.id)
 
 

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -185,7 +185,11 @@ class AllSelfAssignableRolesView(discord.ui.View):
 class Subscribe(commands.Cog):
     """Cog to allow user to self-assign & remove the roles present in ASSIGNABLE_ROLES."""
 
-    SELF_ASSIGNABLE_ROLES_MESSAGE = "Click on this button to show all self assignable roles"
+    GREETING_EMOJI = ":wave:"
+
+    SELF_ASSIGNABLE_ROLES_MESSAGE = f"Hi there {GREETING_EMOJI}," \
+                                    "\nDid you know we had various self-assignable roles for server updates an events?"\
+                                    "\nClick the button below to toggle them."
 
     def __init__(self, bot: Bot):
         self.bot = bot

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -211,7 +211,7 @@ class Subscribe(commands.Cog):
         self.assignable_roles.sort(key=operator.methodcaller("is_currently_available"), reverse=True)
 
         initial_self_assignable_roles_message = await self.__search_for_self_assignable_roles_message()
-        self.__attach_view_to_initial_self_assignable_roles_message(initial_self_assignable_roles_message)
+        self.__attach_persistent_roles_view(initial_self_assignable_roles_message)
 
     @commands.cooldown(1, 10, commands.BucketType.member)
     @commands.command(name="subscribe", aliases=("unsubscribe",))
@@ -249,15 +249,23 @@ class Subscribe(commands.Cog):
         view.add_item(ShowAllSelfAssignableRolesButton(self.assignable_roles))
         return await roles_channel.send(self.SELF_ASSIGNABLE_ROLES_MESSAGE, view=view)
 
-    def __attach_view_to_initial_self_assignable_roles_message(self, message: discord.Message) -> None:
+    def __attach_persistent_roles_view(
+            self,
+            placeholder_message: discord.Message
+    ) -> None:
         """
-        Attaches the persistent self assignable roles view.
+        Attaches the persistent view that toggles self assignable roles to its placeholder message.
 
         The message is searched for/created upon loading the Cog.
+
+        Parameters
+        __________
+            :param placeholder_message: The message that will hold the persistent view allowing
+            users to toggle the RoleButtonView
         """
         view = AllSelfAssignableRolesView()
         view.add_item(ShowAllSelfAssignableRolesButton(self.assignable_roles))
-        self.bot.add_view(view, message_id=message.id)
+        self.bot.add_view(view, message_id=placeholder_message.id)
 
 
 def prepare_self_assignable_roles_view(

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -170,7 +170,7 @@ class ShowAllSelfAssignableRolesButton(discord.ui.Button):
     async def callback(self, interaction: Interaction) -> t.Any:
         """Sends the original subscription view containing the available self assignable roles."""
         await interaction.response.defer()
-        view = prepare_available_role_subscription_view(interaction, self.assignable_roles)
+        view = prepare_self_assignable_roles_view(interaction, self.assignable_roles)
         message = await interaction.followup.send(
             view=view,
         )
@@ -221,7 +221,7 @@ class Subscribe(commands.Cog):
     )
     async def subscribe_command(self, ctx: commands.Context, *_) -> None:  # We don't actually care about the args
         """Display the member's current state for each role, and allow them to add/remove the roles."""
-        view = prepare_available_role_subscription_view(ctx, self.assignable_roles)
+        view = prepare_self_assignable_roles_view(ctx, self.assignable_roles)
 
         message = await ctx.send(
             "Click the buttons below to add or remove your roles!",
@@ -260,7 +260,7 @@ class Subscribe(commands.Cog):
         self.bot.add_view(view, message_id=message.id)
 
 
-def prepare_available_role_subscription_view(
+def prepare_self_assignable_roles_view(
         trigger_action: commands.Context | Interaction,
         assignable_roles: list[AssignableRole]
 ) -> discord.ui.View:

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -161,7 +161,7 @@ class AllSelfAssignableRolesView(discord.ui.View):
     """A persistent view that'll hold one button allowing interactors to toggle all available self-assignable roles."""
 
     def __init__(self):
-        super(AllSelfAssignableRolesView, self).__init__(timeout=None)
+        super().__init__(timeout=None)
 
 
 class ShowAllSelfAssignableRolesButton(discord.ui.Button):

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -167,7 +167,7 @@ class AllSelfAssignableRolesView(discord.ui.View):
     @discord.ui.button(
         style=discord.ButtonStyle.success,
         label="Show all self assignable roles",
-        custom_id="gotta-claim-them-all",
+        custom_id="toggle-available-roles-button",
         row=1
     )
     async def show_all_self_assignable_roles(self, interaction: Interaction, button: discord.ui.Button) -> None:

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -61,12 +61,23 @@ log = get_logger(__name__)
 
 
 class RoleButtonView(discord.ui.View):
-    """A list of SingleRoleButtons to show to the member."""
+    """
+    A view that holds the list of SingleRoleButtons to show to the member.
+
+    Attributes
+    __________
+    anchor_message : discord.Message
+        The message to which this view will be attached
+    interaction_owner: discord.Member
+        The member that initiated the interaction
+    """
+
+    anchor_message: discord.Message
 
     def __init__(self, member: discord.Member):
         super().__init__(timeout=DELETE_MESSAGE_AFTER)
         # We can't obtain the reference to the message before the view is sent
-        self.original_message = None
+        self.anchor_message = None
         self.interaction_owner = member
 
     async def interaction_check(self, interaction: Interaction) -> bool:
@@ -81,7 +92,7 @@ class RoleButtonView(discord.ui.View):
 
     async def on_timeout(self) -> None:
         """Delete the original message that the view was sent along with."""
-        await self.original_message.delete()
+        await self.anchor_message.delete()
 
 
 class SingleRoleButton(discord.ui.Button):
@@ -175,7 +186,7 @@ class ShowAllSelfAssignableRolesButton(discord.ui.Button):
             view=view,
         )
         # Keep reference of the message that contains the view to be deleted
-        view.original_message = message
+        view.anchor_message = message
 
 
 class Subscribe(commands.Cog):
@@ -228,7 +239,7 @@ class Subscribe(commands.Cog):
             view=view,
         )
         # Keep reference of the message that contains the view to be deleted
-        view.original_message = message
+        view.anchor_message = message
 
     async def __search_for_self_assignable_roles_message(self) -> discord.Message:
         """
@@ -276,7 +287,7 @@ def prepare_self_assignable_roles_view(
     author = trigger_action.author if isinstance(trigger_action, commands.Context) else trigger_action.user
     author_roles = [role.id for role in author.roles]
     button_view = RoleButtonView(member=author)
-    button_view.original_message = trigger_action.message
+    button_view.anchor_message = trigger_action.message
 
     for index, role in enumerate(assignable_roles):
         row = index // ITEMS_PER_ROW

--- a/config-default.yml
+++ b/config-default.yml
@@ -235,6 +235,9 @@ guild:
         # Watch
         big_brother_logs:   &BB_LOGS        468507907357409333
 
+        # Roles
+        roles:                              851270062434156586
+
     moderation_categories:
         - *MODS_CATEGORY
         - *MODMAIL

--- a/config-default.yml
+++ b/config-default.yml
@@ -235,7 +235,7 @@ guild:
         # Watch
         big_brother_logs:   &BB_LOGS        468507907357409333
 
-        # Roles
+        # Information
         roles:                              851270062434156586
 
     moderation_categories:


### PR DESCRIPTION
Closes #2332 

As stated by Zig, subscribing to our public roles is currently not super visible since it revolves around executing the `!subscribe` command that usually goes by unnoticed.

To make this easier, more visible & to align with other communities have, we decided to add a persistent view in the `#roles` channel that allows people to subscribing to their chosen roles by a click of a button. 