### PR TITLE
Don't close already closed posts

### DIFF
--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -204,6 +204,10 @@ async def maybe_archive_idle_post(post: discord.Thread, scheduler: scheduling.Sc
     If `has_task` is True and rescheduling is required, the extant task to make the post
     dormant will first be cancelled.
     """
+    if post.locked:
+        log.trace(f"Not closing already closed post #{post} ({post.id}).")
+        return
+
     log.trace(f"Handling open post #{post} ({post.id}).")
 
     closing_time, closing_reason = await get_closing_time(post)

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -91,6 +91,8 @@ class HelpForum(commands.Cog):
         if await self.close_check(ctx):
             log.info(f"Close command invoked by {ctx.author} in #{ctx.channel}.")
             await _channel.help_post_closed(ctx.channel)
+            if ctx.channel.id in self.scheduler:
+                self.scheduler.cancel(ctx.channel.id)
 
     @help_forum_group.command(name="dm", root_aliases=("helpdm",))
     async def help_dm_command(


### PR DESCRIPTION
We currently schedule a task to close a post after a certain amount of time, if a user closes their channel manually before that time, the scheduled task will still open & r-close the channel by sending the message.

This fixes that.