### PR TITLE
Rename print-return to return-gif

### DIFF
--- a/bot/resources/tags/return-gif.md
+++ b/bot/resources/tags/return-gif.md
@@ -1,4 +1,5 @@
 ---
+aliases: ["print-return", "return-jif"]
 embed:
     title: Print and Return
     image:


### PR DESCRIPTION
This renames `!print-return` to `!return-gif` based on some feedback from Helpers. 

It also adds `!print-return` and `!return-jif` as aliases.