### PR TITLE
Don't count bot messages as an answer in a thread

### DIFF
--- a/bot/exts/help_channels/_caches.py
+++ b/bot/exts/help_channels/_caches.py
@@ -9,6 +9,6 @@ help_dm = RedisCache(namespace="HelpChannels.help_dm")
 # RedisCache[discord.TextChannel.id, str[set[discord.User.id]]]
 session_participants = RedisCache(namespace="HelpChannels.session_participants")
 
-# Stores posts that have had a non-claimant reply.
+# Stores posts that have had a non-claimant, non-bot, reply.
 # Currently only used to determine whether the post was answered or not when collecting stats.
 posts_with_non_claimant_messages = RedisCache(namespace="HelpChannels.posts_with_non_claimant_messages")

--- a/bot/exts/help_channels/_cog.py
+++ b/bot/exts/help_channels/_cog.py
@@ -179,5 +179,5 @@ class HelpForum(commands.Cog):
 
         await _message.notify_session_participants(message)
 
-        if message.author.id != message.channel.owner_id:
+        if not message.author.bot and message.author.id != message.channel.owner_id:
             await _caches.posts_with_non_claimant_messages.set(message.channel.id, "sentinel")


### PR DESCRIPTION
Not tested, as I don't have forum channels on my test server, but I think this is correct (`on_message` does include bot messages, right?). 