### PR TITLE
Fix help channels with no content not opening properly

### DIFF
--- a/bot/exts/help_channels/_channel.py
+++ b/bot/exts/help_channels/_channel.py
@@ -94,7 +94,7 @@ async def send_opened_post_dm(post: discord.Thread) -> None:
             return
 
     formatted_message = textwrap.shorten(message.content, width=100, placeholder="...").strip()
-    if formatted_message is None:
+    if not formatted_message:
         # This most likely means the initial message is only an image or similar
         formatted_message = "No text content."
 


### PR DESCRIPTION
Chanels that just contained one or more images as an example would have the message.content equal to the empty string which != None, so the current check never got hit.

Closes #2355 Closes BOT-3BW