### PR TITLE
Update modlog for threads

### DIFF
--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -826,7 +826,8 @@ class ModLog(Cog, name="ModLog"):
             (
                 f"Thread {after.mention} ({after.name}, `{after.id}`) from {after.parent.mention} "
                 f"(`{after.parent.id}`) was {action}"
-            )
+            ),
+            channel_id=Channels.message_log,
         )
 
     @Cog.listener()
@@ -843,7 +844,8 @@ class ModLog(Cog, name="ModLog"):
             (
                 f"Thread {thread.mention} ({thread.name}, `{thread.id}`) from {thread.parent.mention} "
                 f"(`{thread.parent.id}`) deleted"
-            )
+            ),
+            channel_id=Channels.message_log,
         )
 
     @Cog.listener()

--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -847,23 +847,6 @@ class ModLog(Cog, name="ModLog"):
         )
 
     @Cog.listener()
-    async def on_thread_create(self, thread: Thread) -> None:
-        """Log thread creation."""
-        if self.is_channel_ignored(thread.id):
-            log.trace("Ignoring creation of thread %s (%d)", thread.mention, thread.id)
-            return
-
-        await self.send_log_message(
-            Icons.hash_green,
-            Colours.soft_green,
-            "Thread created",
-            (
-                f"Thread {thread.mention} ({thread.name}, `{thread.id}`) from {thread.parent.mention} "
-                f"(`{thread.parent.id}`) created"
-            )
-        )
-
-    @Cog.listener()
     async def on_voice_state_update(
         self,
         member: discord.Member,


### PR DESCRIPTION
With some discussion with mods, it was agreed that logging thread creation wasn't needed, for the same reasons we do not log message creations.

Thread edits & deletes are still wanted, but mod-log doesn't seem like the right place for it. Since it serves a similar purpose to our message logs, we decided to place it there instead.