### PR TITLE
Make the infraction message mention @ModMail

### DIFF
--- a/bot/exts/moderation/infraction/_utils.py
+++ b/bot/exts/moderation/infraction/_utils.py
@@ -31,12 +31,13 @@ RULES_URL = "https://pythondiscord.com/pages/rules"
 Infraction = t.Dict[str, t.Union[str, int, bool]]
 
 APPEAL_SERVER_INVITE = "https://discord.gg/WXrCJxWBnm"
+MODMAIL_ACCOUNT_ID = "683001325440860340"
 
 INFRACTION_TITLE = "Please review our rules"
 INFRACTION_APPEAL_SERVER_FOOTER = f"\nTo appeal this infraction, join our [appeals server]({APPEAL_SERVER_INVITE})."
 INFRACTION_APPEAL_MODMAIL_FOOTER = (
     '\nIf you would like to discuss or appeal this infraction, '
-    'send a message to the ModMail bot.'
+    f'send a message to <@{MODMAIL_ACCOUNT_ID}>.'
 )
 INFRACTION_AUTHOR_NAME = "Infraction information"
 

--- a/bot/exts/moderation/infraction/_utils.py
+++ b/bot/exts/moderation/infraction/_utils.py
@@ -37,7 +37,7 @@ INFRACTION_TITLE = "Please review our rules"
 INFRACTION_APPEAL_SERVER_FOOTER = f"\nTo appeal this infraction, join our [appeals server]({APPEAL_SERVER_INVITE})."
 INFRACTION_APPEAL_MODMAIL_FOOTER = (
     '\nIf you would like to discuss or appeal this infraction, '
-    f'send a message to <@{MODMAIL_ACCOUNT_ID}>.'
+    f'send a message to the ModMail bot (<@{MODMAIL_ACCOUNT_ID}>).'
 )
 INFRACTION_AUTHOR_NAME = "Infraction information"
 


### PR DESCRIPTION
Previously, the footer for non-ban infraction messages would say to DM the ModMail bot. This commit makes "ModMail" a clickable mention of the bot.

![image](https://user-images.githubusercontent.com/32915757/210181147-52bd0cb8-56d8-4594-ab3b-7af22438a9ce.png)

When this footer was introduced, we decided not to make it a mention, in case the recipient did not have the ModMail bot account in their user cache (which would cause it to render as the account ID, ie "send a message to 683001325440860340"). Chris has determined that because the bot is at the top of the user list, it seems to always be in the cache for any guild member, even without visiting the guild or viewing the user list.