### PR TITLE
Add legacy help access to self-assignable roles

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -489,6 +489,7 @@ class Roles(metaclass=YAMLGetter):
     lovefest: int
     pyweek_announcements: int
     revival_of_code: int
+    legacy_help_channels_access: int
 
     contributors: int
     help_cooldown: int

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -49,6 +49,7 @@ class AssignableRole:
 ASSIGNABLE_ROLES = (
     AssignableRole(constants.Roles.announcements, None),
     AssignableRole(constants.Roles.pyweek_announcements, None),
+    AssignableRole(constants.Roles.legacy_help_channels_access, None),
     AssignableRole(constants.Roles.lovefest, (1, 2)),
     AssignableRole(constants.Roles.advent_of_code, (11, 12)),
     AssignableRole(constants.Roles.revival_of_code, (7, 8, 9, 10)),

--- a/config-default.yml
+++ b/config-default.yml
@@ -271,6 +271,7 @@ guild:
         lovefest:                               542431903886606399
         pyweek_announcements:                   897568414044938310
         revival_of_code:                        988801794668908655
+        legacy_help_channels_access:            1074780483776417964
 
         contributors:                           295488872404484098
         help_cooldown:                          699189276025421825


### PR DESCRIPTION
Puts viewing permission of the legacy help channels behind a role that can be self-assigned.