### PR TITLE
Add line to `!code` about the pastebin

### DIFF
--- a/bot/resources/tags/codeblock.md
+++ b/bot/resources/tags/codeblock.md
@@ -5,3 +5,5 @@ print('Hello world!')
 \`\`\`
 
 **These are backticks, not quotes.** Check [this](https://superuser.com/questions/254076/how-do-i-type-the-tick-and-backtick-characters-on-windows/254077#254077) out if you can't find the backtick key.
+
+**For long code samples,** you can use our [pastebin](https://paste.pythondiscord.com/).


### PR DESCRIPTION
Something I've observed a lot is people running the `!code` command to tell users about markdown blocks, only for them to immediately reply saying "my code is too long". This PR adds a new line to the `!code` tag telling users about the pastebin.

For the sake of brevity, the added line says nothing about how to use the pastebin. If this PR is merged, and users who attempt to use the pastebin after seeing this tag end up finding it confusing, we can revisit the content of this tag.

![image](https://user-images.githubusercontent.com/32915757/221417447-fba05ed0-5a94-4ae5-90e8-26bf35d4d189.png)
