### PR TITLE
Add warning message when using `input`

### DIFF
--- a/bot/exts/utils/snekbox.py
+++ b/bot/exts/utils/snekbox.py
@@ -344,8 +344,14 @@ class Snekbox(Cog):
                 log.trace("Formatting output...")
                 output, paste_link = await self.format_output(results["stdout"])
 
+            warning_message = ""
+            # 33 is the length of the error message. It is done to make sure the last line of output contains
+            # the error and the error is not manually printed by the author with a syntax error.
+            if "EOFError: EOF when reading a line" in output[-33:] and results['returncode'] == 1:
+                warning_message += ":warning: Note: `input` is not supported by the bot :warning:\n\n"
+
             icon = self.get_status_emoji(results)
-            msg = f"{ctx.author.mention} {icon} {msg}.\n\n```\n{output}\n```"
+            msg = f"{ctx.author.mention} {icon} {msg}.\n\n{warning_message}```\n{output}\n```"
             if paste_link:
                 msg = f"{msg}\nFull output: {paste_link}"
 


### PR DESCRIPTION
Closes #2420
Closes (MAYBE) #2255

> We could check if EOFError is in the result (as well as maybe checking that "input" is on their code and the status code indicated an error), and if so add a message after the codeblock saying that input doesn't work with the bot.

No need to check if input is in their as the [docs](https://docs.python.org/3/library/exceptions.html#EOFError) say `EOFError` is only raised when
> the [input()](https://docs.python.org/3/library/functions.html#input) function hits an end-of-file condition (EOF) without reading any data

Screenshots:
![2023-03-01_16-52_1](https://user-images.githubusercontent.com/74553450/222125687-02abf7fd-48f4-450b-8144-4a486916191e.png)
![2023-03-01_16-52](https://user-images.githubusercontent.com/74553450/222125715-a5b7086a-3751-458e-a7fd-fa8c226f03b8.png)
