### PR TITLE
add "CI" to the list of trigger workflow runs

### DIFF
--- a/.github/workflows/status_embed.yaml
+++ b/.github/workflows/status_embed.yaml
@@ -3,6 +3,7 @@ name: Status Embed
 on:
   workflow_run:
     workflows:
+      - CI
       - Lint & Test
       - Build
       - Deploy


### PR DESCRIPTION
This PR sets the stage for #2425 where we will be bubdling workflows into a main one, which will later handle the dispatching.

The reason we added this is that the workflows use the `workflow_run` trigger use the version in the main branch, so `Status Embed` won't be triggered by #2425