### PR TITLE
Make sure channel parent isn't None

### DIFF
--- a/bot/exts/info/stats.py
+++ b/bot/exts/info/stats.py
@@ -42,7 +42,7 @@ class Stats(Cog):
                 return
 
         channel = message.channel
-        if hasattr(channel, 'parent'):
+        if hasattr(channel, 'parent') and channel.parent:
             channel = channel.parent
         reformatted_name = CHANNEL_NAME_OVERRIDES.get(channel.id, channel.name)
         reformatted_name = "".join(char if char in ALLOWED_CHARS else '_' for char in reformatted_name)


### PR DESCRIPTION
This shouldn't happen, but the type hint says it can so but just in case.