### PR TITLE
Replace correct separator when mapping webhook ids to .env.server

### DIFF
--- a/botstrap.py
+++ b/botstrap.py
@@ -159,6 +159,6 @@ with DiscordClient() as discord_client:
             webhook_id = create_webhook(webhook_name, webhook_channel_id, client=discord_client)
         else:
             webhook_id = webhook_model.id
-        config_str += f"webhooks_{webhook_name}.id={webhook_id}\n"
+        config_str += f"webhooks_{webhook_name}_id={webhook_id}\n"
 
     env_file_path.write_text(config_str)


### PR DESCRIPTION
Nested attributes are separated by `_` in the `.env.server`, and that's how they're picked up by Pydantic.

The separator for webhooks was still a "." due to a last minute change in the separator.
This PR fixes that