### PR TITLE
Update nested delimiter to double underscore

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -258,7 +258,7 @@ class ThreadArchiveTimes(Enum):
 
 class Webhook(BaseModel):
     id: int
-    channel: Optional[int]
+    channel: int
 
 
 class _Webhooks(EnvConfig):

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -20,6 +20,7 @@ class EnvConfig(BaseSettings):
     class Config:
         env_file = ".env", ".env.server",
         env_file_encoding = 'utf-8'
+        env_nested_delimiter = '__'
 
 
 class _Miscellaneous(EnvConfig):
@@ -262,7 +263,6 @@ class Webhook(BaseModel):
 
 class _Webhooks(EnvConfig):
     EnvConfig.Config.env_prefix = "webhooks_"
-    EnvConfig.Config.env_nested_delimiter = '_'
 
     big_brother: Webhook = Webhook(id=569133704568373283, channel=Channels.big_brother)
     dev_log: Webhook = Webhook(id=680501655111729222, channel=Channels.dev_log)
@@ -364,7 +364,6 @@ class Rules(BaseModel):
 
 class _AntiSpam(EnvConfig):
     EnvConfig.Config.env_prefix = 'anti_spam_'
-    EnvConfig.Config.env_nested_delimiter = '_'
 
     cache_size = 100
 

--- a/botstrap.py
+++ b/botstrap.py
@@ -159,6 +159,6 @@ with DiscordClient() as discord_client:
             webhook_id = create_webhook(webhook_name, webhook_channel_id, client=discord_client)
         else:
             webhook_id = webhook_model.id
-        config_str += f"webhooks_{webhook_name}_id={webhook_id}\n"
+        config_str += f"webhooks_{webhook_name}__id={webhook_id}\n"
 
     env_file_path.write_text(config_str)

--- a/botstrap.py
+++ b/botstrap.py
@@ -160,5 +160,6 @@ with DiscordClient() as discord_client:
         else:
             webhook_id = webhook_model.id
         config_str += f"webhooks_{webhook_name}__id={webhook_id}\n"
+        config_str += f"webhooks_{webhook_name}__channel={all_channels[webhook_name]}\n"
 
     env_file_path.write_text(config_str)


### PR DESCRIPTION
This fixed the way pydantic tries to pickup nested values when the attributes have underscores in them.

Without this, a case like the following with a delimiter of `_`

```py
class Webhook(BaseModel):
    id: int
    channel: Optional[int]


class _Webhooks(EnvConfig):
    EnvConfig.Config.env_prefix = "webhooks_"

    big_brother: Webhook = Webhook(id=123456789, channel=Channels.big_brother)
```

and an `.env.server` like this
```text
webhooks_big_brother_id=987654321
```

Will make pydantic think that it'll need to map to `Webhooks.big.brother.id`, which breaks the value
   