### PR TITLE
Preserve personal config

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -11,14 +11,13 @@ will default to the values passed to the `default` kwarg.
 """
 import os
 from enum import Enum
-from typing import Optional
 
 from pydantic import BaseModel, BaseSettings, root_validator
 
 
 class EnvConfig(BaseSettings):
     class Config:
-        env_file = ".env", ".env.server",
+        env_file = ".env.server", ".env",
         env_file_encoding = 'utf-8'
         env_nested_delimiter = '__'
 

--- a/botstrap.py
+++ b/botstrap.py
@@ -162,4 +162,8 @@ with DiscordClient() as discord_client:
         config_str += f"webhooks_{webhook_name}__id={webhook_id}\n"
         config_str += f"webhooks_{webhook_name}__channel={all_channels[webhook_name]}\n"
 
-    env_file_path.write_text(config_str)
+    config_str += "\n#Emojis\n"
+    config_str += "emojis_trashcan=🗑️"
+
+    with env_file_path.open("ab") as file:
+        file.write(config_str.encode("utf-8"))


### PR DESCRIPTION
Closes #2462 

This switches the order of the env files that Pydantic looks into.

It will always look in `.env.server` first, and if there are values that need to be overriden for some reason, then they'll need to go inside .env`, which is where Pydantic will look for them last

This also has the easter egg of adding the default 🗑️ emoji to the .env.server upon `botstrap`ping