### PR TITLE
Fix broken roles view

### DIFF
--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -100,7 +100,6 @@ class SingleRoleButton(discord.ui.Button):
     REMOVE_STYLE = discord.ButtonStyle.red
     UNAVAILABLE_STYLE = discord.ButtonStyle.secondary
     LABEL_FORMAT = "{action} role {role_name}"
-    CUSTOM_ID_FORMAT = "subscribe-{role_id}"
 
     def __init__(self, role: AssignableRole, assigned: bool, row: int):
         if role.is_currently_available():

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -82,6 +82,16 @@ class RoleButtonView(discord.ui.View):
             row = index // ITEMS_PER_ROW
             self.add_item(SingleRoleButton(role, role.role_id in author_roles, row))
 
+    async def interaction_check(self, interaction: Interaction) -> bool:
+        """Ensure that the user clicking the button is the member who invoked the command."""
+        if interaction.user != self.interaction_owner:
+            await interaction.response.send_message(
+                ":x: This is not your command to react to!",
+                ephemeral=True
+            )
+            return False
+        return True
+
 
 class SingleRoleButton(discord.ui.Button):
     """A button that adds or removes a role from the member depending on its current state."""

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -82,16 +82,6 @@ class RoleButtonView(discord.ui.View):
             row = index // ITEMS_PER_ROW
             self.add_item(SingleRoleButton(role, role.role_id in author_roles, row))
 
-    async def interaction_check(self, interaction: Interaction) -> bool:
-        """Ensure that the user clicking the button is the member who invoked the command."""
-        if interaction.user != self.interaction_owner:
-            await interaction.response.send_message(
-                ":x: This is not your command to react to!",
-                ephemeral=True
-            )
-            return False
-        return True
-
 
 class SingleRoleButton(discord.ui.Button):
     """A button that adds or removes a role from the member depending on its current state."""
@@ -113,7 +103,6 @@ class SingleRoleButton(discord.ui.Button):
         super().__init__(
             style=style,
             label=label,
-            custom_id=self.CUSTOM_ID_FORMAT.format(role_id=role.role_id),
             row=row,
         )
         self.role = role


### PR DESCRIPTION
We have had the feedback that when interacting with the new roles view, users will get an error from the bot saying that they cannot interact with it.

This is due to the way discord.py routes requests when views have preset custom_ids, which result in a "uniqueness" of that view whenver it's invoked. So whenever a view is instantiated with a custom id, all requests will always be routed to the latest instantiated one with that id.

The `interaction_check` is also kept since we still keep the `!subscribe` text command