### PR TITLE
Create python-help forum channel in `botstrap`

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -125,6 +125,8 @@ class _Channels(EnvConfig):
     duck_pond = 637820308341915648
     roles = 851270062434156586
 
+    rules = 693837295685730335
+
 
 Channels = _Channels()
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -189,6 +189,7 @@ class _Categories(EnvConfig):
 
     # 2021 Summer Code Jam
     summer_code_jam = 861692638540857384
+    python_help_system = 691405807388196926
 
 
 Categories = _Categories()

--- a/botstrap.py
+++ b/botstrap.py
@@ -22,7 +22,6 @@ ANNOUNCEMENTS_CHANNEL_NAME = "announcements"
 RULES_CHANNEL_NAME = "rules"
 GUILD_FORUM_TYPE = 15
 
-
 if not BOT_TOKEN:
     message = (
         "Couldn't find the `BOT_TOKEN` environment variable. "
@@ -43,130 +42,118 @@ if not GUILD_ID:
 class DiscordClient(Client):
     """An HTTP client to communicate with Discord's APIs."""
 
-    def __init__(self):
+    def __init__(self, guild_id):
         super().__init__(
             base_url="https://discord.com/api/v10",
             headers={"Authorization": f"Bot {BOT_TOKEN}"},
             event_hooks={"response": [self._raise_for_status]},
         )
+        self.guild_id = guild_id
 
     @staticmethod
     def _raise_for_status(response: Response) -> None:
         response.raise_for_status()
 
+    def upgrade_server_to_community_if_necessary(
+        self,
+        rules_channel_id_: int | str,
+        announcements_channel_id_: int | str,
+    ) -> None:
+        """Fetches server info & upgrades to COMMUNITY if necessary."""
+        response = self.get(f"/guilds/{self.guild_id}")
+        payload = response.json()
 
-def upgrade_server_to_community_if_necessary(
-    guild_id: int | str,
-    rules_channel_id_: int | str,
-    announcements_channel_id_: int | str,
-    client: DiscordClient
-) -> None:
-    """Fetches server info & upgrades to COMMUNITY if necessary."""
-    response = client.get(f"/guilds/{guild_id}")
-    payload = response.json()
+        if COMMUNITY_FEATURE not in payload["features"]:
+            log.warning("This server is currently not a community, upgrading.")
+            payload["features"].append(COMMUNITY_FEATURE)
+            payload["rules_channel_id"] = rules_channel_id_
+            payload["public_updates_channel_id"] = announcements_channel_id_
+            self.patch(f"/guilds/{self.guild_id}", json=payload)
+            log.info(f"Server {self.guild_id} has been successfully updated to a community.")
 
-    if COMMUNITY_FEATURE not in payload["features"]:
-        log.warning("This server is currently not a community, upgrading.")
-        payload["features"].append(COMMUNITY_FEATURE)
-        payload["rules_channel_id"] = rules_channel_id_
-        payload["public_updates_channel_id"] = announcements_channel_id_
-        client.patch(f"/guilds/{guild_id}", json=payload)
-        log.info(f"Server {guild_id} has been successfully updated to a community.")
+    def create_forum_channel(
+        self,
+        channel_name_: str,
+        category_id_: int | str | None = None
+    ) -> int:
+        """Creates a new forum channel."""
+        payload = {"name": channel_name_, "type": GUILD_FORUM_TYPE}
+        if category_id_:
+            payload["parent_id"] = category_id_
 
+        response = self.post(f"/guilds/{self.guild_id}/channels", json=payload)
+        forum_channel_id = response.json()["id"]
+        log.info(f"New forum channel: {channel_name_} has been successfully created.")
+        return forum_channel_id
 
-def create_forum_channel(
-    channel_name_: str,
-    guild_id: str,
-    client: DiscordClient,
-    category_id_: int | None = None
-) -> int:
-    """Creates a new forum channel."""
-    payload = {"name": channel_name_, "type": GUILD_FORUM_TYPE}
-    if category_id_:
-        payload["parent_id"] = category_id_
+    def is_forum_channel(self, channel_id_: str) -> bool:
+        """A boolean that indicates if a channel is of type GUILD_FORUM."""
+        response = self.get(f"/channels/{channel_id_}")
+        return response.json()["type"] == GUILD_FORUM_TYPE
 
-    response = client.post(f"/guilds/{guild_id}/channels", json=payload)
-    forum_channel_id = response.json()["id"]
-    log.info(f"New forum channel: {channel_name_} has been successfully created.")
-    return forum_channel_id
+    def delete_channel(self, channel_id_: id) -> None:
+        """Upgrades a channel to a channel of type GUILD FORUM."""
+        log.info(f"Channel python-help: {channel_id_} is not a forum channel and will be replaced with one.")
+        self.delete(f"/channels/{channel_id_}")
 
+    def get_all_roles(self) -> dict:
+        """Fetches all the roles in a guild."""
+        result = {}
 
-def is_forum_channel(channel_id_: str, client: DiscordClient) -> bool:
-    """A boolean that indicates if a channel is of type GUILD_FORUM."""
-    response = client.get(f"/channels/{channel_id_}")
-    return response.json()["type"] == GUILD_FORUM_TYPE
+        response = self.get(f"guilds/{self.guild_id}/roles")
+        roles = response.json()
 
+        for role in roles:
+            name = "_".join(part.lower() for part in role["name"].split(" ")).replace("-", "_")
+            result[name] = role["id"]
 
-def delete_channel(channel_id_: id, client: DiscordClient) -> None:
-    """Upgrades a channel to a channel of type GUILD FORUM."""
-    log.info(f"Channel python-help: {channel_id_} is not a forum channel and will be replaced with one.")
-    client.delete(f"/channels/{channel_id_}")
+        return result
 
+    def get_all_channels_and_categories(self) -> tuple[dict[str, str], dict[str, str]]:
+        """Fetches all the text channels & categories in a guild."""
+        off_topic_channel_name_regex = r"ot\d{1}(_.*)+"
+        off_topic_count = 0
+        channels = {}  # could be text channels only as well
+        categories = {}
 
-def get_all_roles(guild_id: int | str, client: DiscordClient) -> dict:
-    """Fetches all the roles in a guild."""
-    result = {}
+        response = self.get(f"guilds/{self.guild_id}/channels")
+        server_channels = response.json()
 
-    response = client.get(f"guilds/{guild_id}/roles")
-    roles = response.json()
+        for channel in server_channels:
+            channel_type = channel["type"]
+            name = "_".join(part.lower() for part in channel["name"].split(" ")).replace("-", "_")
+            if re.match(off_topic_channel_name_regex, name):
+                name = f"off_topic_{off_topic_count}"
+                off_topic_count += 1
 
-    for role in roles:
-        name = "_".join(part.lower() for part in role["name"].split(" ")).replace("-", "_")
-        result[name] = role["id"]
+            if channel_type == 4:
+                categories[name] = channel["id"]
+            else:
+                channels[name] = channel["id"]
 
-    return result
+        return channels, categories
 
+    def webhook_exists(self, webhook_id_: int) -> bool:
+        """A predicate that indicates whether a webhook exists already or not."""
+        try:
+            self.get(f"webhooks/{webhook_id_}")
+            return True
+        except HTTPStatusError:
+            return False
 
-def get_all_channels_and_categories(
-        guild_id: int | str,
-        client: DiscordClient
-) -> tuple[dict[str, str], dict[str, str]]:
-    """Fetches all the text channels & categories in a guild."""
-    off_topic_channel_name_regex = r"ot\d{1}(_.*)+"
-    off_topic_count = 0
-    channels = {}  # could be text channels only as well
-    categories = {}
+    def create_webhook(self, name: str, channel_id_: int) -> str:
+        """Creates a new webhook for a particular channel."""
+        payload = {"name": name}
 
-    response = client.get(f"guilds/{guild_id}/channels")
-    server_channels = response.json()
-
-    for channel in server_channels:
-        channel_type = channel["type"]
-        name = "_".join(part.lower() for part in channel["name"].split(" ")).replace("-", "_")
-        if re.match(off_topic_channel_name_regex, name):
-            name = f"off_topic_{off_topic_count}"
-            off_topic_count += 1
-
-        if channel_type == 4:
-            categories[name] = channel["id"]
-        else:
-            channels[name] = channel["id"]
-
-    return channels, categories
-
-
-def webhook_exists(webhook_id_: int, client: DiscordClient) -> bool:
-    """A predicate that indicates whether a webhook exists already or not."""
-    try:
-        client.get(f"webhooks/{webhook_id_}")
-        return True
-    except HTTPStatusError:
-        return False
+        response = self.post(f"channels/{channel_id_}/webhooks", json=payload)
+        new_webhook = response.json()
+        return new_webhook["id"]
 
 
-def create_webhook(name: str, channel_id_: int, client: DiscordClient) -> str:
-    """Creates a new webhook for a particular channel."""
-    payload = {"name": name}
-
-    response = client.post(f"channels/{channel_id_}/webhooks", json=payload)
-    new_webhook = response.json()
-    return new_webhook["id"]
-
-
-with DiscordClient() as discord_client:
+with DiscordClient(guild_id=GUILD_ID) as discord_client:
     config_str = "#Roles\n"
 
-    all_roles = get_all_roles(guild_id=GUILD_ID, client=discord_client)
+    all_roles = discord_client.get_all_roles()
 
     for role_name in _Roles.__fields__:
 
@@ -177,28 +164,28 @@ with DiscordClient() as discord_client:
 
         config_str += f"roles_{role_name}={role_id}\n"
 
-    all_channels, all_categories = get_all_channels_and_categories(guild_id=GUILD_ID, client=discord_client)
+    all_channels, all_categories = discord_client.get_all_channels_and_categories()
 
     config_str += "\n#Channels\n"
 
     rules_channel_id = all_channels[RULES_CHANNEL_NAME]
     announcements_channel_id = all_channels[ANNOUNCEMENTS_CHANNEL_NAME]
 
-    upgrade_server_to_community_if_necessary(GUILD_ID, rules_channel_id, announcements_channel_id, discord_client)
+    discord_client.upgrade_server_to_community_if_necessary(rules_channel_id, announcements_channel_id)
 
     create_help_channel = True
 
     if PYTHON_HELP_CHANNEL_NAME in all_channels:
         python_help_channel_id = all_channels[PYTHON_HELP_CHANNEL_NAME]
-        if not is_forum_channel(python_help_channel_id, discord_client):
-            delete_channel(python_help_channel_id, discord_client)
+        if not discord_client.is_forum_channel(python_help_channel_id):
+            discord_client.delete_channel(python_help_channel_id)
         else:
             create_help_channel = False
 
     if create_help_channel:
         python_help_channel_name = PYTHON_HELP_CHANNEL_NAME.replace('_', '-')
         python_help_category_id = all_categories[PYTHON_HELP_CATEGORY_NAME]
-        python_help_channel_id = create_forum_channel(python_help_channel_name, GUILD_ID, discord_client, python_help_category_id)
+        python_help_channel_id = discord_client.create_forum_channel(python_help_channel_name, python_help_category_id)
         all_channels[PYTHON_HELP_CHANNEL_NAME] = python_help_channel_id
 
     for channel_name in _Channels.__fields__:
@@ -229,10 +216,10 @@ with DiscordClient() as discord_client:
     config_str += "\n#Webhooks\n"
 
     for webhook_name, webhook_model in Webhooks:
-        webhook = webhook_exists(webhook_model.id, client=discord_client)
+        webhook = discord_client.webhook_exists(webhook_model.id)
         if not webhook:
             webhook_channel_id = int(all_channels[webhook_name])
-            webhook_id = create_webhook(webhook_name, webhook_channel_id, client=discord_client)
+            webhook_id = discord_client.create_webhook(webhook_name, webhook_channel_id)
         else:
             webhook_id = webhook_model.id
         config_str += f"webhooks_{webhook_name}__id={webhook_id}\n"

--- a/botstrap.py
+++ b/botstrap.py
@@ -175,6 +175,20 @@ with DiscordClient() as discord_client:
 
     config_str += "\n#Channels\n"
 
+    if not is_community_server(GUILD_ID, discord_client):
+        upgrade_server_to_community(GUILD_ID, discord_client)
+
+    create_help_channel = True
+    if PYTHON_HELP_NAME in all_channels:
+        python_help_channel_id = all_channels[PYTHON_HELP_NAME]
+        if not is_forum_channel(python_help_channel_id, discord_client):
+            delete_channel(python_help_channel_id, discord_client)
+        else:
+            create_help_channel = False
+
+    if create_help_channel:
+        python_help_channel_id = create_forum_channel(PYTHON_HELP_NAME.replace('_', '-'), GUILD_ID, discord_client)
+
     for channel_name in _Channels.__fields__:
         channel_id = all_channels.get(channel_name, None)
         if not channel_id:
@@ -184,6 +198,7 @@ with DiscordClient() as discord_client:
             continue
 
         config_str += f"channels_{channel_name}={channel_id}\n"
+    config_str += f"channels_{PYTHON_HELP_NAME}={python_help_channel_id}\n"
 
     config_str += "\n#Categories\n"
 

--- a/botstrap.py
+++ b/botstrap.py
@@ -42,7 +42,7 @@ if not GUILD_ID:
 class DiscordClient(Client):
     """An HTTP client to communicate with Discord's APIs."""
 
-    def __init__(self, guild_id):
+    def __init__(self, guild_id: int | str):
         super().__init__(
             base_url="https://discord.com/api/v10",
             headers={"Authorization": f"Bot {BOT_TOKEN}"},

--- a/botstrap.py
+++ b/botstrap.py
@@ -46,6 +46,7 @@ class DiscordClient(Client):
         super().__init__(
             base_url="https://discord.com/api/v10",
             headers={"Authorization": f"Bot {BOT_TOKEN}"},
+            event_hooks={"response": [self._raise_for_status]},
         )
 
     @staticmethod

--- a/botstrap.py
+++ b/botstrap.py
@@ -17,6 +17,7 @@ GUILD_ID = os.getenv("GUILD_ID", None)
 
 COMMUNITY_FEATURE = "COMMUNITY"
 PYTHON_HELP_CHANNEL_NAME = "python_help"
+PYTHON_HELP_CATEGORY_NAME = "python_help_system"
 ANNOUNCEMENTS_CHANNEL_NAME = "announcements"
 RULES_CHANNEL_NAME = "rules"
 GUILD_FORUM_TYPE = 15
@@ -196,7 +197,8 @@ with DiscordClient() as discord_client:
 
     if create_help_channel:
         python_help_channel_name = PYTHON_HELP_CHANNEL_NAME.replace('_', '-')
-        python_help_channel_id = create_forum_channel(python_help_channel_name, GUILD_ID, discord_client)
+        python_help_category_id = all_categories[PYTHON_HELP_CATEGORY_NAME]
+        python_help_channel_id = create_forum_channel(python_help_channel_name, GUILD_ID, discord_client, python_help_category_id)
         all_channels[PYTHON_HELP_CHANNEL_NAME] = python_help_channel_id
 
     for channel_name in _Channels.__fields__:

--- a/botstrap.py
+++ b/botstrap.py
@@ -16,9 +16,9 @@ BOT_TOKEN = os.getenv("BOT_TOKEN", None)
 GUILD_ID = os.getenv("GUILD_ID", None)
 
 COMMUNITY_FEATURE = "COMMUNITY"
-PYTHON_HELP_CHANNEL_NAME = _Channels.__fields__["python_help"].name
-ANNOUNCEMENTS_CHANNEL_NAME = _Channels.__fields__["announcements"].name
-RULES_CHANNEL_NAME = _Channels.__fields__["rules"].name
+PYTHON_HELP_CHANNEL_NAME = "python_help"
+ANNOUNCEMENTS_CHANNEL_NAME = "announcements"
+RULES_CHANNEL_NAME = "rules"
 GUILD_FORUM_TYPE = 15
 
 

--- a/botstrap.py
+++ b/botstrap.py
@@ -82,6 +82,13 @@ def create_forum_channel(channel_name_: str, guild_id: str, client: DiscordClien
     return response.json()["id"]
 
 
+def is_forum_channel(channel_id_: str, client: DiscordClient) -> bool:
+    """A boolean that indicates if a channel is of type GUILD_FORUM"""
+
+    response = client.get(f"/channels/{channel_id_}")
+    return response.json()["type"] == GUILD_FORUM_TYPE
+
+
 def delete_channel(channel_id_: id, client: DiscordClient):
     """Upgrades a channel to a channel of type GUILD FORUM"""
 

--- a/botstrap.py
+++ b/botstrap.py
@@ -52,8 +52,11 @@ class SilencedDict(dict):
             super().__getitem__(item)
         except KeyError:
             log.warning(f"Couldn't find key: {item} in dict: {self.name} ")
-            log.warning("Please make sure to use our template: https://discord.new/zmHtscpYN9E3"
-                        "to make your own copy of the server to guarantee a successful run of botstrap ")
+            log.warning(
+                "Please make sure to follow our contribution guideline "
+                "https://www.pythondiscord.com/pages/guides/pydis-guides/contributing/bot/ "
+                "to guarantee a successful run of botstrap "
+            )
             sys.exit(-1)
 
 
@@ -193,11 +196,12 @@ with DiscordClient(guild_id=GUILD_ID) as discord_client:
 
     create_help_channel = True
 
-    python_help_channel_id = all_channels[PYTHON_HELP_CHANNEL_NAME]
-    if not discord_client.is_forum_channel(python_help_channel_id):
-        discord_client.delete_channel(python_help_channel_id)
-    else:
-        create_help_channel = False
+    if PYTHON_HELP_CHANNEL_NAME in all_channels:
+        python_help_channel_id = all_channels[PYTHON_HELP_CHANNEL_NAME]
+        if not discord_client.is_forum_channel(python_help_channel_id):
+            discord_client.delete_channel(python_help_channel_id)
+        else:
+            create_help_channel = False
 
     if create_help_channel:
         python_help_channel_name = PYTHON_HELP_CHANNEL_NAME.replace('_', '-')

--- a/botstrap.py
+++ b/botstrap.py
@@ -69,17 +69,7 @@ def upgrade_server_to_community_if_necessary(
         payload["rules_channel_id"] = rules_channel_id_
         payload["public_updates_channel_id"] = announcements_channel_id_
         client.patch(f"/guilds/{guild_id}", json=payload)
-
-
-def upgrade_server_to_community(guild_id: int | str, client: DiscordClient) -> None:
-    """
-    Transforms a server into a community one.
-
-    Return true if the server has been correctly upgraded, False otherwise.
-    """
-    payload = {"features": [COMMUNITY_FEATURE]}
-    client.patch(f"/guilds/{guild_id}", json=payload)
-    log.info(f"Server {guild_id} has been successfully updated to a community.")
+        log.info(f"Server {guild_id} has been successfully updated to a community.")
 
 
 def create_forum_channel(

--- a/botstrap.py
+++ b/botstrap.py
@@ -52,6 +52,44 @@ class DiscordClient(Client):
         response.raise_for_status()
 
 
+def is_community_server(guild_id: int | str, client: DiscordClient) -> bool:
+    """A predicate that indicates whether a server has the COMMUNITY feature or not"""
+    response = client.get(f"/guilds/{guild_id}")
+    return COMMUNITY_FEATURE in response.json()["features"]
+
+
+def upgrade_server_to_community(guild_id: int | str, client: DiscordClient) -> bool:
+    """Transforms a server into a community one.
+
+    Return true if the server has been correctly upgraded, False otherwise.
+    """
+
+    payload = {"features": [COMMUNITY_FEATURE]}
+    response = client.patch(f"/guilds/{guild_id}", json=payload)
+
+    return 200 <= response.status_code < 300
+
+
+def create_forum_channel(channel_name_: str, guild_id: str, client: DiscordClient, category_id_: int | None = None):
+    """Creates a new forum channel"""
+
+    payload = {"name": channel_name_, "type": GUILD_FORUM_TYPE}
+    if category_id_:
+        payload["parent_id"] = category_id_
+
+    response = client.post(f"/guilds/{guild_id}/channels", json=payload)
+
+    return response.json()["id"]
+
+
+def delete_channel(channel_id_: id, client: DiscordClient):
+    """Upgrades a channel to a channel of type GUILD FORUM"""
+
+    response = client.delete(f"/channels/{channel_id_}")
+
+    return response.json()
+
+
 def get_all_roles(guild_id: int | str, client: DiscordClient) -> dict:
     """Fetches all the roles in a guild."""
     result = {}

--- a/botstrap.py
+++ b/botstrap.py
@@ -49,7 +49,7 @@ class SilencedDict(dict):
 
     def __getitem__(self, item: str):
         try:
-            super().__getitem__(item)
+            return super().__getitem__(item)
         except KeyError:
             log.warning(f"Couldn't find key: {item} in dict: {self.name} ")
             log.warning(

--- a/botstrap.py
+++ b/botstrap.py
@@ -15,6 +15,10 @@ env_file_path = Path(".env.server")
 BOT_TOKEN = os.getenv("BOT_TOKEN", None)
 GUILD_ID = os.getenv("GUILD_ID", None)
 
+COMMUNITY_FEATURE = "COMMUNITY"
+PYTHON_HELP_NAME = _Channels.__fields__["python_help"].name
+GUILD_FORUM_TYPE = 15
+
 
 if not BOT_TOKEN:
     message = (

--- a/botstrap.py
+++ b/botstrap.py
@@ -59,7 +59,7 @@ def upgrade_server_to_community_if_necessary(
         rules_channel_id_: int | str,
         announcements_channel_id_: int | str,
         client: DiscordClient) -> None:
-    """Fetches server info & upgrades to COMMUNITY if necessary"""
+    """Fetches server info & upgrades to COMMUNITY if necessary."""
     response = client.get(f"/guilds/{guild_id}")
     payload = response.json()
 
@@ -72,19 +72,23 @@ def upgrade_server_to_community_if_necessary(
 
 
 def upgrade_server_to_community(guild_id: int | str, client: DiscordClient) -> None:
-    """Transforms a server into a community one.
+    """
+    Transforms a server into a community one.
 
     Return true if the server has been correctly upgraded, False otherwise.
     """
-
     payload = {"features": [COMMUNITY_FEATURE]}
     client.patch(f"/guilds/{guild_id}", json=payload)
     log.info(f"Server {guild_id} has been successfully updated to a community.")
 
 
-def create_forum_channel(channel_name_: str, guild_id: str, client: DiscordClient, category_id_: int | None = None):
-    """Creates a new forum channel"""
-
+def create_forum_channel(
+        channel_name_: str,
+        guild_id: str,
+        client: DiscordClient,
+        category_id_: int | None = None
+) -> int:
+    """Creates a new forum channel."""
     payload = {"name": channel_name_, "type": GUILD_FORUM_TYPE}
     if category_id_:
         payload["parent_id"] = category_id_
@@ -96,18 +100,15 @@ def create_forum_channel(channel_name_: str, guild_id: str, client: DiscordClien
 
 
 def is_forum_channel(channel_id_: str, client: DiscordClient) -> bool:
-    """A boolean that indicates if a channel is of type GUILD_FORUM"""
-
+    """A boolean that indicates if a channel is of type GUILD_FORUM."""
     response = client.get(f"/channels/{channel_id_}")
     return response.json()["type"] == GUILD_FORUM_TYPE
 
 
-def delete_channel(channel_id_: id, client: DiscordClient):
-    """Upgrades a channel to a channel of type GUILD FORUM"""
+def delete_channel(channel_id_: id, client: DiscordClient) -> None:
+    """Upgrades a channel to a channel of type GUILD FORUM."""
     log.info(f"Channel python-help: {channel_id_} is not a forum channel and will be replaced with one.")
-    response = client.delete(f"/channels/{channel_id_}")
-
-    return response.json()
+    client.delete(f"/channels/{channel_id_}")
 
 
 def get_all_roles(guild_id: int | str, client: DiscordClient) -> dict:
@@ -203,7 +204,8 @@ with DiscordClient() as discord_client:
             create_help_channel = False
 
     if create_help_channel:
-        python_help_channel_id = create_forum_channel(PYTHON_HELP_CHANNEL_NAME.replace('_', '-'), GUILD_ID, discord_client)
+        python_help_channel_name = PYTHON_HELP_CHANNEL_NAME.replace('_', '-')
+        python_help_channel_id = create_forum_channel(python_help_channel_name, GUILD_ID, discord_client)
 
     for channel_name in _Channels.__fields__:
         channel_id = all_channels.get(channel_name, None)

--- a/botstrap.py
+++ b/botstrap.py
@@ -196,6 +196,7 @@ with DiscordClient() as discord_client:
     if create_help_channel:
         python_help_channel_name = PYTHON_HELP_CHANNEL_NAME.replace('_', '-')
         python_help_channel_id = create_forum_channel(python_help_channel_name, GUILD_ID, discord_client)
+        all_channels[PYTHON_HELP_CHANNEL_NAME] = python_help_channel_id
 
     for channel_name in _Channels.__fields__:
         channel_id = all_channels.get(channel_name, None)

--- a/botstrap.py
+++ b/botstrap.py
@@ -55,10 +55,11 @@ class DiscordClient(Client):
 
 
 def upgrade_server_to_community_if_necessary(
-        guild_id: int | str,
-        rules_channel_id_: int | str,
-        announcements_channel_id_: int | str,
-        client: DiscordClient) -> None:
+    guild_id: int | str,
+    rules_channel_id_: int | str,
+    announcements_channel_id_: int | str,
+    client: DiscordClient
+) -> None:
     """Fetches server info & upgrades to COMMUNITY if necessary."""
     response = client.get(f"/guilds/{guild_id}")
     payload = response.json()
@@ -73,10 +74,10 @@ def upgrade_server_to_community_if_necessary(
 
 
 def create_forum_channel(
-        channel_name_: str,
-        guild_id: str,
-        client: DiscordClient,
-        category_id_: int | None = None
+    channel_name_: str,
+    guild_id: str,
+    client: DiscordClient,
+    category_id_: int | None = None
 ) -> int:
     """Creates a new forum channel."""
     payload = {"name": channel_name_, "type": GUILD_FORUM_TYPE}


### PR DESCRIPTION
Closes #2466 

This now checks if the server is a community & updates it when it's not.
It also provides the announcements & rules channels upon patching the guild since they are needed.

Upgrading a channel from Text to Forum isn't possible, so this basically deletes the text channel if it finds it & makes a new one as a replacement.