### PR TITLE
Fix typehint that broke duckpond channel blacklist

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -404,7 +404,7 @@ class _DuckPond(EnvConfig):
 
     threshold = 7
 
-    channel_blacklist: list[str] = [
+    channel_blacklist: list[int] = [
         Channels.announcements,
         Channels.python_news,
         Channels.python_events,


### PR DESCRIPTION
A tiny PR that fixes the typehint of the channel blacklist (`list[str]` -> `list[int]`).

### More Detail:
Since the typehint is `list[str]`, and it's inside a pydantic model, the list is converted to be a list of strings. This means that in [the code](https://github.com/python-discord/bot/blob/main/bot/exts/fun/duck_pond.py#L147-L149), when we check whether the channel id (which is an int) is in the list, it will always say it's not.
