### PR TITLE
Add tag for Discord bot hosting

### DIFF
--- a/bot/resources/tags/discord-bot-hosting.md
+++ b/bot/resources/tags/discord-bot-hosting.md
@@ -3,7 +3,7 @@ embed:
     title: Discord Bot Hosting
 ---
 
-Using free hosting options like repl.it or Heroku for continuous 24/7 bot hosting is strongly discouraged. 
+Using free hosting options like repl.it or Heroku for continuous 24/7 bot hosting is strongly discouraged.
 Instead, opt for a virtual private server (VPS) or use your own spare hardware if you'd rather not pay for hosting.
 
 See our [Discord Bot Hosting Guide](https://www.pythondiscord.com/pages/guides/python-guides/vps-services/) on our website that compares many hosting providers, both free and paid.

--- a/bot/resources/tags/discord-bot-hosting.md
+++ b/bot/resources/tags/discord-bot-hosting.md
@@ -1,0 +1,11 @@
+---
+embed:
+    title: Discord Bot Hosting
+---
+
+Using free hosting options like repl.it or Heroku for continuous 24/7 bot hosting is strongly discouraged. 
+Instead, opt for a virtual private server (VPS) or use your own spare hardware if you'd rather not pay for hosting.
+
+See our [Discord Bot Hosting Guide](https://www.pythondiscord.com/pages/guides/python-guides/vps-services/) on our website that compares many hosting providers, both free and paid.
+
+You may also use <#965291480992321536> to discuss different discord bot hosting options.


### PR DESCRIPTION
Completes task in [python-discord/site#695](https://github.com/python-discord/site/issues/695)

Add a short tag explaining disadvantages of free hosting, and linking to resource on our site and #discord-bot-hosting thread.