### PR TITLE
Remove usage of `site` config variable

### DIFF
--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -66,7 +66,7 @@ async def main() -> None:
             intents=intents,
             allowed_roles=list({discord.Object(id_) for id_ in constants.MODERATION_ROLES}),
             api_client=APIClient(
-                site_api_url=f"{constants.URLs.site_api_scheme}{constants.URLs.site_api}",
+                site_api_url=constants.URLs.site_api,
                 site_api_token=constants.Keys.site_api,
             ),
         )

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -66,7 +66,7 @@ async def main() -> None:
             intents=intents,
             allowed_roles=list({discord.Object(id_) for id_ in constants.MODERATION_ROLES}),
             api_client=APIClient(
-                site_api_url=f"{constants.URLs.site_api_schema}{constants.URLs.site_api}",
+                site_api_url=f"{constants.URLs.site_api_scheme}{constants.URLs.site_api}",
                 site_api_token=constants.Keys.site_api,
             ),
         )

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -527,8 +527,7 @@ class _BaseURLs(EnvConfig):
     github_bot_repo = "https://github.com/python-discord/bot"
 
     # Site
-    site_api = "site.default.svc.cluster.local/api"
-    site_api_scheme = "http://"
+    site_api = "http://site.default.svc.cluster.local/api"
     site_paste = "https://paste.pythondiscord.com"
 
 
@@ -546,6 +545,7 @@ class _URLs(_BaseURLs):
 
     paste_service: str = "".join([BaseURLs.site_paste, "/{key}"])
     site_logs_view: str = "https://pythondiscord.com/staff/bot/logs"
+
 
 URLs = _URLs()
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -527,10 +527,9 @@ class _BaseURLs(EnvConfig):
     github_bot_repo = "https://github.com/python-discord/bot"
 
     # Site
-    site = "pythondiscord.com"
-    site_schema = "https://"
     site_api = "site.default.svc.cluster.local/api"
     site_api_schema = "http://"
+    site_paste = "https://paste.pythondiscord.com"
 
 
 BaseURLs = _BaseURLs()
@@ -545,13 +544,8 @@ class _URLs(_BaseURLs):
     connect_max_retries = 3
     connect_cooldown = 5
 
-    site_staff: str = "".join([BaseURLs.site_schema, BaseURLs.site, "/staff"])
-    site_paste = "".join(["paste.", BaseURLs.site])
-
-    # Site endpoints
-    site_logs_view: str = "".join([BaseURLs.site_schema, BaseURLs.site, "/staff/bot/logs"])
-    paste_service: str = "".join([BaseURLs.site_schema, "paste.", BaseURLs.site, "/{key}"])
-
+    paste_service: str = "".join([BaseURLs.site_paste, "/{key}"])
+    site_logs_view: str = "https://pythondiscord.com/staff/bot/logs"
 
 URLs = _URLs()
 

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -528,7 +528,7 @@ class _BaseURLs(EnvConfig):
 
     # Site
     site_api = "site.default.svc.cluster.local/api"
-    site_api_schema = "http://"
+    site_api_scheme = "http://"
     site_paste = "https://paste.pythondiscord.com"
 
 

--- a/bot/exts/filters/antimalware.py
+++ b/bot/exts/filters/antimalware.py
@@ -5,7 +5,7 @@ from discord import Embed, Message, NotFound
 from discord.ext.commands import Cog
 
 from bot.bot import Bot
-from bot.constants import Channels, Filter, URLs
+from bot.constants import BaseURLs, Channels, Filter
 from bot.exts.events.code_jams._channels import CATEGORY_NAME as JAM_CATEGORY_NAME
 from bot.log import get_logger
 
@@ -13,13 +13,13 @@ log = get_logger(__name__)
 
 PY_EMBED_DESCRIPTION = (
     "It looks like you tried to attach a Python file - "
-    f"please use a code-pasting service such as {URLs.site_schema}{URLs.site_paste}"
+    f"please use a code-pasting service such as {BaseURLs.site_paste}"
 )
 
 TXT_LIKE_FILES = {".txt", ".csv", ".json"}
 TXT_EMBED_DESCRIPTION = (
     "You either uploaded a `{blocked_extension}` file or entered a message that was too long. "
-    f"Please use our [paste bin]({URLs.site_schema}{URLs.site_paste}) instead."
+    f"Please use our [paste bin]({BaseURLs.site_paste}) instead."
 )
 
 DISALLOWED_EMBED_DESCRIPTION = (

--- a/bot/exts/recruitment/talentpool/_api.py
+++ b/bot/exts/recruitment/talentpool/_api.py
@@ -29,8 +29,8 @@ class Nomination(BaseModel):
 class NominationAPI:
     """Abstraction of site API interaction for talentpool."""
 
-    def __init__(self, site_api: APIClient):
-        self.site_api = site_api
+    def __init__(self, site_api_client: APIClient):
+        self.site_api_client = site_api_client
 
     async def get_nominations(
         self,
@@ -49,13 +49,13 @@ class NominationAPI:
         if user_id is not None:
             params["user__id"] = str(user_id)
 
-        data = await self.site_api.get("bot/nominations", params=params)
+        data = await self.site_api_client.get("bot/nominations", params=params)
         nominations = parse_obj_as(list[Nomination], data)
         return nominations
 
     async def get_nomination(self, nomination_id: int) -> Nomination:
         """Fetch a nomination by ID."""
-        data = await self.site_api.get(f"bot/nominations/{nomination_id}")
+        data = await self.site_api_client.get(f"bot/nominations/{nomination_id}")
         nomination = Nomination.parse_obj(data)
         return nomination
 
@@ -83,7 +83,7 @@ class NominationAPI:
         if thread_id is not None:
             data["thread_id"] = thread_id
 
-        result = await self.site_api.patch(f"bot/nominations/{nomination_id}", json=data)
+        result = await self.site_api_client.patch(f"bot/nominations/{nomination_id}", json=data)
         return Nomination.parse_obj(result)
 
     async def edit_nomination_entry(
@@ -95,7 +95,7 @@ class NominationAPI:
     ) -> Nomination:
         """Edit a nomination entry."""
         data = {"actor": actor_id, "reason": reason}
-        result = await self.site_api.patch(f"bot/nominations/{nomination_id}", json=data)
+        result = await self.site_api_client.patch(f"bot/nominations/{nomination_id}", json=data)
         return Nomination.parse_obj(result)
 
     async def post_nomination(
@@ -110,5 +110,5 @@ class NominationAPI:
             "reason": reason,
             "user": user_id,
         }
-        result = await self.site_api.post("bot/nominations", json=data)
+        result = await self.site_api_client.post("bot/nominations", json=data)
         return Nomination.parse_obj(result)

--- a/bot/exts/recruitment/talentpool/_api.py
+++ b/bot/exts/recruitment/talentpool/_api.py
@@ -29,8 +29,8 @@ class Nomination(BaseModel):
 class NominationAPI:
     """Abstraction of site API interaction for talentpool."""
 
-    def __init__(self, site_api_client: APIClient):
-        self.site_api_client = site_api_client
+    def __init__(self, site_api: APIClient):
+        self.site_api = site_api
 
     async def get_nominations(
         self,
@@ -49,13 +49,13 @@ class NominationAPI:
         if user_id is not None:
             params["user__id"] = str(user_id)
 
-        data = await self.site_api_client.get("bot/nominations", params=params)
+        data = await self.site_api.get("bot/nominations", params=params)
         nominations = parse_obj_as(list[Nomination], data)
         return nominations
 
     async def get_nomination(self, nomination_id: int) -> Nomination:
         """Fetch a nomination by ID."""
-        data = await self.site_api_client.get(f"bot/nominations/{nomination_id}")
+        data = await self.site_api.get(f"bot/nominations/{nomination_id}")
         nomination = Nomination.parse_obj(data)
         return nomination
 
@@ -83,7 +83,7 @@ class NominationAPI:
         if thread_id is not None:
             data["thread_id"] = thread_id
 
-        result = await self.site_api_client.patch(f"bot/nominations/{nomination_id}", json=data)
+        result = await self.site_api.patch(f"bot/nominations/{nomination_id}", json=data)
         return Nomination.parse_obj(result)
 
     async def edit_nomination_entry(
@@ -95,7 +95,7 @@ class NominationAPI:
     ) -> Nomination:
         """Edit a nomination entry."""
         data = {"actor": actor_id, "reason": reason}
-        result = await self.site_api_client.patch(f"bot/nominations/{nomination_id}", json=data)
+        result = await self.site_api.patch(f"bot/nominations/{nomination_id}", json=data)
         return Nomination.parse_obj(result)
 
     async def post_nomination(
@@ -110,5 +110,5 @@ class NominationAPI:
             "reason": reason,
             "user": user_id,
         }
-        result = await self.site_api_client.post("bot/nominations", json=data)
+        result = await self.site_api.post("bot/nominations", json=data)
         return Nomination.parse_obj(result)

--- a/bot/exts/utils/ping.py
+++ b/bot/exts/utils/ping.py
@@ -38,7 +38,7 @@ class Latency(commands.Cog):
             bot_ping = f"{bot_ping:.{ROUND_LATENCY}f} ms"
 
         try:
-            async with self.bot.http_session.get(f"{URLs.site_api_scheme}{URLs.site_api}/healthcheck") as request:
+            async with self.bot.http_session.get(f"{URLs.site_api}/healthcheck") as request:
                 request.raise_for_status()
                 site_status = "Healthy"
 

--- a/bot/exts/utils/ping.py
+++ b/bot/exts/utils/ping.py
@@ -38,7 +38,7 @@ class Latency(commands.Cog):
             bot_ping = f"{bot_ping:.{ROUND_LATENCY}f} ms"
 
         try:
-            async with self.bot.http_session.get(f"{URLs.site_api_schema}{URLs.site_api}/healthcheck") as request:
+            async with self.bot.http_session.get(f"{URLs.site_api_scheme}{URLs.site_api}/healthcheck") as request:
                 request.raise_for_status()
                 site_status = "Healthy"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,7 +113,7 @@ services:
       - .env
     environment:
       API_KEYS_SITE_API: "badbot13m0n8f570f942013fc818f234916ca531"
-      URLS_SITE_API: "web:8000/api"
+      URLS_SITE_API: "http://web:8000/api"
       URLS_SNEKBOX_EVAL_API: "http://snekbox/eval"
       URLS_SNEKBOX_311_EVAL_API: "http://snekbox-311/eval"
       REDIS_HOST: "redis"


### PR DESCRIPTION
This defaults `site_paste` to our production pastebin as i don't think no one will ever host their own pastebin service. And this moves it to `BaseURLs`

Same goes for `site_logs_view`, however this one can be overriden if people want to access logs from their local sites. So it'll be included in the guide as an optional section to work with mod logs.

After the previously mentioned changes, `site` and `site_schema` aren't needed anymore, which is why they're removed.
`site_staff` isn't referenced anywhere as well  which is why it's removed.