### PR TITLE
Make new helper role pingable for help request.

### DIFF
--- a/bot/exts/recruitment/helper_utils.py
+++ b/bot/exts/recruitment/helper_utils.py
@@ -4,6 +4,7 @@ import re
 
 import arrow
 from async_rediscache import RedisCache
+
 import discord
 from discord import Message
 from discord.ext.commands import Cog

--- a/bot/exts/recruitment/helper_utils.py
+++ b/bot/exts/recruitment/helper_utils.py
@@ -4,6 +4,7 @@ import re
 
 import arrow
 from async_rediscache import RedisCache
+import discord
 from discord import Message
 from discord.ext.commands import Cog
 
@@ -65,7 +66,8 @@ class NewHelperUtils(Cog):
 
         if self._is_question(message.content):
             self.last_pinged = arrow.utcnow()
-            await message.reply(random.choice(self.MESSAGES))
+            allowed_mentions = discord.AllowedMentions(everyone=False, roles=[discord.Object(NEW_HELPER_ROLE_ID)])
+            await message.reply(random.choice(self.MESSAGES), allowed_mentions=allowed_mentions)
             await self.cooldown_cache.set(self.CACHE_KEY, self.last_pinged.timestamp())
 
 

--- a/bot/exts/recruitment/helper_utils.py
+++ b/bot/exts/recruitment/helper_utils.py
@@ -3,9 +3,8 @@ import random
 import re
 
 import arrow
-from async_rediscache import RedisCache
-
 import discord
+from async_rediscache import RedisCache
 from discord import Message
 from discord.ext.commands import Cog
 


### PR DESCRIPTION
Previously, the message from the bot requesting that new helpers answer off-topic questions did not cause a ping. Solved by this commit.