### PR TITLE
Exclude help forum messages from the newlines filter

### DIFF
--- a/bot/rules/newlines.py
+++ b/bot/rules/newlines.py
@@ -11,7 +11,7 @@ async def apply(
 ) -> Optional[Tuple[str, Iterable[Member], Iterable[Message]]]:
     """
     Detects total newlines exceeding the set limit sent by a single user.
-    
+
     Messages sent in the help forum are excluded.
     """
     relevant_messages = tuple(

--- a/bot/rules/newlines.py
+++ b/bot/rules/newlines.py
@@ -1,17 +1,27 @@
 import re
 from typing import Dict, Iterable, List, Optional, Tuple
 
-from discord import Member, Message
+from discord import Member, Message, Thread
+
+from bot import constants
 
 
 async def apply(
     last_message: Message, recent_messages: List[Message], config: Dict[str, int]
 ) -> Optional[Tuple[str, Iterable[Member], Iterable[Message]]]:
-    """Detects total newlines exceeding the set limit sent by a single user."""
+    """
+    Detects total newlines exceeding the set limit sent by a single user.
+    
+    Messages sent in the help forum are excluded.
+    """
     relevant_messages = tuple(
         msg
         for msg in recent_messages
         if msg.author == last_message.author
+        if not (
+            isinstance(msg.channel, Thread)
+            and msg.channel.parent_id == constants.Channels.python_help
+        )
     )
 
     # Identify groups of newline characters and get group & total counts


### PR DESCRIPTION
Just a thought :P

The newlines filter is pretty noisy in the help forum. The frequent false-positives need a lot of moderator attention, and aren't a great experience for new users. Excluding help forum messages from the newline count could be a reasonable stopgap until the new filtering system arrives.

Relevant issue: #2009 