### PR TITLE
Add Tag Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tag-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/tag-suggestion.yml
@@ -1,0 +1,17 @@
+name: Tag Suggestion
+description: Suggest a new tag.
+title: I DID NOT READ THE INSTRUCTIONS
+labels: []
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for trying to improve the community! We do not take tag suggestions on this repository, however please submit your suggestion on the [meta](https://github.com/python-discord/meta) repostiory instead.
+  # Mandatory non-markdown body field.
+  - type: input
+    id: data
+    attributes:
+      label: Do not fill this out
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/tag-suggestion.yml
+++ b/.github/ISSUE_TEMPLATE/tag-suggestion.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for trying to improve the community! We do not take tag suggestions on this repository, however please submit your suggestion on the [meta](https://github.com/python-discord/meta) repostiory instead.
+        Thank you for trying to improve the community! We do not take tag suggestions on this repository, however please submit your suggestion on the [meta](https://github.com/python-discord/meta/issues/new?assignees=&labels=area%3A+tags&template=tag-request.yaml) repostiory instead.
   # Mandatory non-markdown body field.
   - type: input
     id: data


### PR DESCRIPTION
People (contribs, staff, and core-devs alike) have often been confused by where to create issues for adding new tags. Creating issues on this repository makes the most sense - issue follows implementation - but it's rarely the correct option. Tag suggestions issues are never about implementation details, but specific tag details such as: do we want this? what form do we want it in? etc.

These questions can not be discussed adequately on this repository as it's difficult to gain traction and get people seeing it. The meta repository is a much better location for it, and hence the [tag suggestion template](https://github.com/python-discord/meta/blob/main/.github/ISSUE_TEMPLATE/tag-request.yaml) exists. This is an attempt at guiding people towards it.