### PR TITLE
Track forgotten nominations

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -618,6 +618,17 @@ class _Icons(EnvConfig):
 Icons = _Icons()
 
 
+class _GithubModsRepository(EnvConfig):
+    section = "github_mods_"
+
+    owner: str = "python-discord"
+    name: str = "mods"
+    token: str
+
+
+GithubModsRepository = _GithubModsRepository()
+
+
 class _Keys(EnvConfig):
 
     EnvConfig.Config.env_prefix = "api_keys_"


### PR DESCRIPTION
closes #2226

The idea is to fetch active nominations that are more than 2 weeks old, and create admin issues for them in Github so that staff will do the follow up.

As soon as a vote is tracked, we add a "🎫" reaction (which can change) to it to make sure we don't create duplicate issues for it, instead of keeping track in another way