### PR TITLE
Update filtering.py to reduce nickname alert spam

### DIFF
--- a/bot/exts/filtering/filtering.py
+++ b/bot/exts/filtering/filtering.py
@@ -260,7 +260,7 @@ class Filtering(Cog):
     async def on_voice_state_update(self, member: discord.Member, *_) -> None:
         """Checks for bad words in usernames when users join, switch or leave a voice channel."""
         ctx = FilterContext(Event.NICKNAME, member, None, member.display_name, None)
-        await self._check_bad_name(ctx)
+        await self._check_bad_display_name(ctx)
 
     @Cog.listener()
     async def on_thread_create(self, thread: Thread) -> None:


### PR DESCRIPTION
This updates the `on_voice_state_update` listener of the filtering cog.

Currently, it calls `self._check_bad_name` where it should call `self._check_bad_display_name`. The difference is that the latter method rate-limits how often a filtering alert is sent for a specific user's display name. Using the former method results in spammy alerts when a user with a bad display name is in a voice channel.