### PR TITLE
Build docker image in CI

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -2,7 +2,7 @@ name: Build & Deploy
 
 env:
   # Used to determine whether we should push & deploy the docker image.
-  IS_MAIN_REF: ${{ github.ref == github.event.repository.default_branch }}
+  IS_MAIN_REF: ${{ github.ref == 'refs/heads/main'}}
 
 on:
   workflow_call:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,9 +1,5 @@
 name: Build & Deploy
 
-env:
-  # Used to determine whether we should push & deploy the docker image.
-  IS_MAIN_REF: ${{ github.ref == 'refs/heads/main'}}
-
 on:
   workflow_call:
     inputs:
@@ -48,7 +44,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: $IS_MAIN_REF
+          push: ${{ github.ref == 'refs/heads/main' }}
           cache-from: type=registry,ref=ghcr.io/python-discord/bot:latest
           cache-to: type=inline
           tags: |
@@ -61,7 +57,7 @@ jobs:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
-    if: $IS_MAIN_REF
+    if: ${{ github.ref == 'refs/heads/main' }}
     environment: production
     steps:
       - name: Checkout Kubernetes repository

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,5 +1,9 @@
 name: Build & Deploy
 
+env:
+  # Used to determine whether we should push & deploy the docker image.
+  IS_MAIN_REF: ${{ github.ref == github.event.repository.default_branch }}
+
 on:
   workflow_call:
     inputs:
@@ -44,7 +48,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          push: true
+          push: $IS_MAIN_REF
           cache-from: type=registry,ref=ghcr.io/python-discord/bot:latest
           cache-to: type=inline
           tags: |
@@ -57,6 +61,7 @@ jobs:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
+    if: $IS_MAIN_REF
     environment: production
     steps:
       - name: Checkout Kubernetes repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
 
 
   build-deploy:
-    if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/build-deploy.yml
     needs:
       - lint-test


### PR DESCRIPTION
This updates our workflows to build (but not push) the docker image on each pull requests.

This will only push and deploy the image to our container register when the reference is main.

## Purpose

The idea is to make sure that the changes we're trying to merge result in a successful build before we even merge.