### PR TITLE
Temporarily remove suport for evaling under 3.10

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -477,8 +477,7 @@ class _BaseURLs(EnvConfig):
     EnvConfig.Config.env_prefix = "urls_"
 
     # Snekbox endpoints
-    snekbox_eval_api = "http://snekbox-310.default.svc.cluster.local/eval"
-    snekbox_311_eval_api = "http://snekbox.default.svc.cluster.local/eval"
+    snekbox_eval_api = "http://snekbox.default.svc.cluster.local/eval"
 
     # Discord API
     discord_api = "https://discordapp.com/api/v7/"

--- a/bot/exts/utils/snekbox/_cog.py
+++ b/bot/exts/utils/snekbox/_cog.py
@@ -185,13 +185,15 @@ class Snekbox(Cog):
         if current_python_version == "3.10":
             alt_python_version = "3.11"
         else:
-            alt_python_version = "3.10"
+            alt_python_version = "3.10"  # noqa: F841
 
         view = interactions.ViewWithUserAndRoleCheck(
             allowed_users=(ctx.author.id,),
             allowed_roles=MODERATION_ROLES,
         )
-        view.add_item(PythonVersionSwitcherButton(alt_python_version, self, ctx, job))
+        # Temp disabled until snekbox multi-version support is complete
+        # https://github.com/python-discord/snekbox/issues/158
+        # view.add_item(PythonVersionSwitcherButton(alt_python_version, self, ctx, job))
         view.add_item(interactions.DeleteMessageButton())
 
         return view

--- a/bot/exts/utils/snekbox/_cog.py
+++ b/bot/exts/utils/snekbox/_cog.py
@@ -88,7 +88,7 @@ SNEKBOX_ROLES = (Roles.helpers, Roles.moderators, Roles.admins, Roles.owners, Ro
 REDO_EMOJI = "\U0001f501"  # :repeat:
 REDO_TIMEOUT = 30
 
-PythonVersion = Literal["3.10", "3.11"]
+SupportedPythonVersions = Literal["3.11"]
 
 class FilteredFiles(NamedTuple):
     allowed: list[FileAttachment]
@@ -137,7 +137,7 @@ class PythonVersionSwitcherButton(ui.Button):
 
     def __init__(
         self,
-        version_to_switch_to: PythonVersion,
+        version_to_switch_to: SupportedPythonVersions,
         snekbox_cog: Snekbox,
         ctx: Context,
         job: EvalJob,
@@ -176,12 +176,12 @@ class Snekbox(Cog):
 
     def build_python_version_switcher_view(
         self,
-        current_python_version: PythonVersion,
+        current_python_version: SupportedPythonVersions,
         ctx: Context,
         job: EvalJob,
     ) -> interactions.ViewWithUserAndRoleCheck:
         """Return a view that allows the user to change what version of Python their code is run on."""
-        alt_python_version: PythonVersion
+        alt_python_version: SupportedPythonVersions
         if current_python_version == "3.10":
             alt_python_version = "3.11"
         else:
@@ -200,14 +200,9 @@ class Snekbox(Cog):
 
     async def post_job(self, job: EvalJob) -> EvalResult:
         """Send a POST request to the Snekbox API to evaluate code and return the results."""
-        if job.version == "3.10":
-            url = URLs.snekbox_eval_api
-        else:
-            url = URLs.snekbox_311_eval_api
-
         data = job.to_dict()
 
-        async with self.bot.http_session.post(url, json=data, raise_for_status=True) as resp:
+        async with self.bot.http_session.post(URLs.snekbox_eval_api, json=data, raise_for_status=True) as resp:
             return EvalResult.from_dict(await resp.json())
 
     @staticmethod
@@ -546,7 +541,7 @@ class Snekbox(Cog):
     async def eval_command(
         self,
         ctx: Context,
-        python_version: PythonVersion | None,
+        python_version: SupportedPythonVersions | None,
         *,
         code: CodeblockConverter
     ) -> None:
@@ -585,7 +580,7 @@ class Snekbox(Cog):
     async def timeit_command(
         self,
         ctx: Context,
-        python_version: PythonVersion | None,
+        python_version: SupportedPythonVersions | None,
         *,
         code: CodeblockConverter
     ) -> None:

--- a/bot/exts/utils/snekbox/_eval.py
+++ b/bot/exts/utils/snekbox/_eval.py
@@ -12,7 +12,7 @@ from bot.exts.utils.snekbox._io import FILE_COUNT_LIMIT, FILE_SIZE_LIMIT, FileAt
 from bot.log import get_logger
 
 if TYPE_CHECKING:
-    from bot.exts.utils.snekbox._cog import PythonVersion
+    from bot.exts.utils.snekbox._cog import SupportedPythonVersions
 
 log = get_logger(__name__)
 
@@ -26,7 +26,7 @@ class EvalJob:
     args: list[str]
     files: list[FileAttachment] = field(default_factory=list)
     name: str = "eval"
-    version: PythonVersion = "3.11"
+    version: SupportedPythonVersions = "3.11"
 
     @classmethod
     def from_code(cls, code: str, path: str = "main.py") -> EvalJob:
@@ -36,7 +36,7 @@ class EvalJob:
             files=[FileAttachment(path, code.encode())],
         )
 
-    def as_version(self, version: PythonVersion) -> EvalJob:
+    def as_version(self, version: SupportedPythonVersions) -> EvalJob:
         """Return a copy of the job with a different Python version."""
         return EvalJob(
             args=self.args,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,18 +54,6 @@ services:
     ports:
      - "127.0.0.1:8060:8060"
     privileged: true
-    profiles:
-      - "3.10"
-
-  snekbox-311:
-    logging : *default-logging
-    restart: unless-stopped
-    image: ghcr.io/python-discord/snekbox:3.11-dev
-    init: true
-    ipc: none
-    ports:
-     - "127.0.0.1:8065:8060"
-    privileged: true
 
   web:
     logging : *default-logging
@@ -101,13 +89,12 @@ services:
     depends_on:
       - web
       - redis
-      - snekbox-311
+      - snekbox
     env_file:
       - .env
     environment:
       API_KEYS_SITE_API: "badbot13m0n8f570f942013fc818f234916ca531"
       URLS_SITE_API: "http://web:8000/api"
       URLS_SNEKBOX_EVAL_API: "http://snekbox:8060/eval"
-      URLS_SNEKBOX_311_EVAL_API: "http://snekbox-311:8060/eval"
       REDIS_HOST: "redis"
       STATS_STATSD_HOST: "http://localhost"


### PR DESCRIPTION
This is until snekbox supports multi-version natively https://github.com/python-discord/snekbox/issues/158.

This also updates the docker compose environment, so by default just 1 snekbox container is spun up, and updates the list of supported versions to be just 3.11

Closes BOT-3GA Closes #2620