### PR TITLE
Escape full stops in Filter.__str__

### DIFF
--- a/bot/exts/filtering/_filters/filter.py
+++ b/bot/exts/filtering/_filters/filter.py
@@ -78,7 +78,7 @@ class Filter(FieldRequiring):
 
     def __str__(self) -> str:
         """A string representation of the filter."""
-        string = f"{self.id}. `{self.content}`"
+        string = fr"{self.id}\. `{self.content}`"
         if self.description:
             string += f" - {self.description}"
         return string


### PR DESCRIPTION
Discord sees a number followed by a dot as a potential numbered list, so messes up the numbering when on sequential lines. Escaping the dot disables this discord behaviour.