### PR TITLE
Added preview code block into the embed

### DIFF
--- a/bot/resources/tags/codeblock.md
+++ b/bot/resources/tags/codeblock.md
@@ -8,6 +8,12 @@ Here's how to format Python code on Discord:
 print('Hello world!')
 \`\`\`
 
+Preview:
+
+```py
+print('Hello world!')
+```
+
 **These are backticks, not quotes.** Check [this](https://superuser.com/questions/254076/how-do-i-type-the-tick-and-backtick-characters-on-windows/254077#254077) out if you can't find the backtick key.
 
 **For long code samples,** you can use our [pastebin](https://paste.pythondiscord.com/).


### PR DESCRIPTION
The help embed of the `!code` command needs to have a preview to be more descriptive, so I've added the colorful embed into the file

Resolves:

- https://github.com/python-discord/meta/issues/215