### PR TITLE
Add 'n' alias and 'nom' root alias to 'nominate' command

### DIFF
--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -313,7 +313,11 @@ class TalentPool(Cog, name="Talentpool"):
         """
         await self._nominate_user(ctx, user, reason)
 
-    @nomination_group.command(name="nominate", aliases=("w", "add", "a", "watch"), root_aliases=("nominate",))
+    @nomination_group.command(
+        name="nominate",
+        aliases=("nom", "n", "watch", "w", "add", "a"),
+        root_aliases=("nominate", "nom")
+    )
     @has_any_role(*STAFF_ROLES)
     async def nominate_command(self, ctx: Context, user: MemberOrUser, *, reason: str = "") -> None:
         """


### PR DESCRIPTION
This PR adds a `!nom` root-alias to the `!talentpool nominate` command, as well as a `!talentpool nom` and `!talentpool n` alias. This means staff can now nominate someone via `!nom {userid} {reason}`, as well as the old `!nominate {userid} {reason}` etc..

I figured since it's such a small change it doesn't need an issue.