### PR TITLE
Increase help thread timeout 30 -> 60

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -336,7 +336,7 @@ class _HelpChannels(EnvConfig):
     EnvConfig.Config.env_prefix = "help_channels_"
 
     enable = True
-    idle_minutes = 30
+    idle_minutes = 60
     deleted_idle_minutes = 5
     # Roles which are allowed to use the command which makes channels dormant
     cmd_whitelist = Guild.moderation_roles


### PR DESCRIPTION
We decided after a staff meeting to have help threads time out after 60 minutes instead of 30, as the forum system allows us to have more concurrent help sessions than under the dynamic channel system.

![image](https://github.com/python-discord/bot/assets/32915757/4602c952-03df-40e6-851f-1740c83c9dd2)
