### PR TITLE
Simplify subscribe cog

### DIFF
--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -61,16 +61,7 @@ log = get_logger(__name__)
 
 
 class RoleButtonView(discord.ui.View):
-    """
-    A view that holds the list of SingleRoleButtons to show to the member.
-
-    Attributes
-    __________
-    interaction_owner: discord.Member
-        The member that initiated the interaction
-    """
-
-    interaction_owner: discord.Member
+    """A view that holds the list of SingleRoleButtons to show to the member."""
 
     def __init__(self, member: discord.Member, assignable_roles: list[AssignableRole]):
         super().__init__(timeout=DELETE_MESSAGE_AFTER)


### PR DESCRIPTION
The first commit fixes a bug that would mean if two people run the command at the same time, only the first person will be able to interact with the buttons.

The second commit removes the logic around when a role is available, this was deemed not needed so removing it from the code makes the cog easier to read.