### PR TITLE
Allow use of message reply feature to add additional context to incident reports

### DIFF
--- a/bot/exts/moderation/incidents.py
+++ b/bot/exts/moderation/incidents.py
@@ -134,7 +134,8 @@ def is_incident(message: discord.Message) -> bool:
         message.channel.id == Channels.incidents,  # Message sent in #incidents
         not message.author.bot,                    # Not by a bot
         not message.content.startswith("#"),       # Doesn't start with a hash
-        not message.pinned,                        # And isn't header
+        not message.pinned,                        # Isn't header
+        not message.reference,                     # And is not a reply
     )
     return all(conditions)
 

--- a/tests/bot/exts/moderation/test_incidents.py
+++ b/tests/bot/exts/moderation/test_incidents.py
@@ -185,6 +185,7 @@ class TestIsIncident(unittest.TestCase):
             content="this is an incident",
             author=MockUser(bot=False),
             pinned=False,
+            reference=None,
         )
 
     def test_is_incident_true(self):


### PR DESCRIPTION
Closes #2647.
You can now include additional context to an incident reply by replying to a message and it will not be treated as a separate incident ticket.

I've not removed the previous method of adding additional context (iie, by prefixing `#`  to the message) for now to make transition easier (reporter muscle memory and all that).
Howeverm , IMO, removing it immediately will not inconvenience helpers much and  it may also assist in the discovery  of this change.

Screenshot:
![image](https://github.com/python-discord/bot/assets/37447267/e6c52406-d682-4598-b12d-84f0a743d85c)
