### PR TITLE
Fix some test warnings

### DIFF
--- a/bot/exts/backend/logging.py
+++ b/bot/exts/backend/logging.py
@@ -15,7 +15,7 @@ class Logging(Cog):
     def __init__(self, bot: Bot):
         self.bot = bot
 
-        scheduling.create_task(self.startup_greeting(), event_loop=self.bot.loop)
+        scheduling.create_task(self.startup_greeting())
 
     async def startup_greeting(self) -> None:
         """Announce our presence to the configured devlog channel."""

--- a/bot/exts/info/codeblock/_cog.py
+++ b/bot/exts/info/codeblock/_cog.py
@@ -114,7 +114,7 @@ class CodeBlockCog(Cog, name="Code Block"):
         bot_message = await message.channel.send(f"Hey {message.author.mention}!", embed=embed)
         self.codeblock_message_ids[message.id] = bot_message.id
 
-        scheduling.create_task(wait_for_deletion(bot_message, (message.author.id,)), event_loop=self.bot.loop)
+        scheduling.create_task(wait_for_deletion(bot_message, (message.author.id,)))
 
         # Increase amount of codeblock correction in stats
         self.bot.stats.incr("codeblock_corrections")

--- a/bot/exts/info/doc/_batch_parser.py
+++ b/bot/exts/info/doc/_batch_parser.py
@@ -30,8 +30,7 @@ class StaleInventoryNotifier:
     def __init__(self):
         self._init_task = scheduling.create_task(
             self._init_channel(),
-            name="StaleInventoryNotifier channel init",
-            event_loop=bot.instance.loop,
+            name="StaleInventoryNotifier channel init"
         )
         self._warned_urls = set()
 

--- a/bot/exts/moderation/incidents.py
+++ b/bot/exts/moderation/incidents.py
@@ -319,10 +319,10 @@ class Incidents(Cog):
         self.bot = bot
         self.incidents_webhook = None
 
-        scheduling.create_task(self.fetch_webhook(), event_loop=self.bot.loop)
+        scheduling.create_task(self.fetch_webhook())
 
         self.event_lock = asyncio.Lock()
-        self.crawl_task = scheduling.create_task(self.crawl_incidents(), event_loop=self.bot.loop)
+        self.crawl_task = scheduling.create_task(self.crawl_incidents())
 
     async def fetch_webhook(self) -> None:
         """Fetch the incidents webhook object, so we can post message link embeds to it."""
@@ -416,7 +416,7 @@ class Incidents(Cog):
             return payload.message_id == incident.id
 
         coroutine = self.bot.wait_for("raw_message_delete", check=check, timeout=timeout)
-        return scheduling.create_task(coroutine, event_loop=self.bot.loop)
+        return scheduling.create_task(coroutine)
 
     async def process_event(self, reaction: str, incident: discord.Message, member: discord.Member) -> None:
         """

--- a/bot/exts/moderation/watchchannels/_watchchannel.py
+++ b/bot/exts/moderation/watchchannels/_watchchannel.py
@@ -169,7 +169,7 @@ class WatchChannel(metaclass=CogABCMeta):
         """Queues up messages sent by watched users."""
         if msg.author.id in self.watched_users:
             if not self.consuming_messages:
-                self._consume_task = scheduling.create_task(self.consume_messages(), event_loop=self.bot.loop)
+                self._consume_task = scheduling.create_task(self.consume_messages())
 
             self.log.trace(f"Received message: {msg.content} ({len(msg.attachments)} attachments)")
             self.message_queue[msg.author.id][msg.channel.id].append(msg)
@@ -199,10 +199,7 @@ class WatchChannel(metaclass=CogABCMeta):
 
         if self.message_queue:
             self.log.trace("Channel queue not empty: Continuing consuming queues")
-            self._consume_task = scheduling.create_task(
-                self.consume_messages(delay_consumption=False),
-                event_loop=self.bot.loop,
-            )
+            self._consume_task = scheduling.create_task(self.consume_messages(delay_consumption=False))
         else:
             self.log.trace("Done consuming messages.")
 

--- a/tests/bot/exts/backend/test_logging.py
+++ b/tests/bot/exts/backend/test_logging.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from bot import constants
 from bot.exts.backend.logging import Logging
-from tests.helpers import MockBot, MockTextChannel
+from tests.helpers import MockBot, MockTextChannel, no_create_task
 
 
 class LoggingTests(unittest.IsolatedAsyncioTestCase):
@@ -11,7 +11,8 @@ class LoggingTests(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.bot = MockBot()
-        self.cog = Logging(self.bot)
+        with no_create_task():
+            self.cog = Logging(self.bot)
         self.dev_log = MockTextChannel(id=1234, name="dev-log")
 
     @patch("bot.exts.backend.logging.DEBUG_MODE", False)

--- a/tests/bot/exts/moderation/test_incidents.py
+++ b/tests/bot/exts/moderation/test_incidents.py
@@ -17,7 +17,7 @@ from bot.utils.time import TimestampFormats, discord_timestamp
 from tests.base import RedisTestCase
 from tests.helpers import (
     MockAsyncWebhook, MockAttachment, MockBot, MockMember, MockMessage, MockReaction, MockRole, MockTextChannel,
-    MockUser
+    MockUser, no_create_task
 )
 
 CURRENT_TIME = datetime.datetime(2022, 1, 1, tzinfo=datetime.UTC)
@@ -306,7 +306,8 @@ class TestIncidents(RedisTestCase):
         Note that this will not schedule `crawl_incidents` in the background, as everything
         is being mocked. The `crawl_task` attribute will end up being None.
         """
-        self.cog_instance = incidents.Incidents(MockBot())
+        with no_create_task():
+            self.cog_instance = incidents.Incidents(MockBot())
 
 
 @patch("asyncio.sleep", AsyncMock())  # Prevent the coro from sleeping to speed up the test
@@ -458,7 +459,8 @@ class TestMakeConfirmationTask(TestIncidents):
         If this function begins to fail, first check that `created_check` is being retrieved
         correctly. It should be the function that is built locally in the tested method.
         """
-        self.cog_instance.make_confirmation_task(MockMessage(id=123))
+        with no_create_task():
+            self.cog_instance.make_confirmation_task(MockMessage(id=123))
 
         self.cog_instance.bot.wait_for.assert_called_once()
         created_check = self.cog_instance.bot.wait_for.call_args.kwargs["check"]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,7 @@ import logging
 import unittest.mock
 from asyncio import AbstractEventLoop
 from collections.abc import Iterable
+from contextlib import contextmanager
 from functools import cached_property
 
 import discord
@@ -664,3 +665,12 @@ class MockAsyncWebhook(CustomMockMixin, unittest.mock.MagicMock):
     """
     spec_set = webhook_instance
     additional_spec_asyncs = ("send", "edit", "delete", "execute")
+
+@contextmanager
+def no_create_task():
+    def side_effect(coro, *_, **__):
+        coro.close()
+
+    with unittest.mock.patch("pydis_core.utils.scheduling.create_task") as create_task:
+        create_task.side_effect = side_effect
+        yield


### PR DESCRIPTION
Currently these warnings are raised when running tests:
```python
tests/bot/exts/backend/test_logging.py::LoggingTests::test_debug_mode_false
tests/bot/exts/backend/test_logging.py::LoggingTests::test_debug_mode_true
  C:\Users\wookie\Documents\GitHub\bot\bot\exts\backend\logging.py:18: RuntimeWarning: coroutine 'Logging.startup_greeting' was never awaited
    scheduling.create_task(self.startup_greeting(), event_loop=self.bot.loop)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/bot/exts/moderation/test_incidents.py: 27 warnings
  C:\Users\wookie\Documents\GitHub\bot\bot\exts\moderation\incidents.py:322: RuntimeWarning: coroutine 'Incidents.fetch_webhook' was never awaited
    scheduling.create_task(self.fetch_webhook(), event_loop=self.bot.loop)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/bot/exts/moderation/test_incidents.py: 27 warnings
  C:\Users\wookie\Documents\GitHub\bot\bot\exts\moderation\incidents.py:325: RuntimeWarning: coroutine 'Incidents.crawl_incidents' was never awaited
    self.crawl_task = scheduling.create_task(self.crawl_incidents(), event_loop=self.bot.loop)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/bot/exts/moderation/test_incidents.py::TestMakeConfirmationTask::test_make_confirmation_task_check
  C:\Users\wookie\Documents\GitHub\bot\tests\bot\exts\moderation\test_incidents.py:461: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    self.cog_instance.make_confirmation_task(MockMessage(id=123))
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

This fixes that by patching `create_task` to just close the coroutine in these places. 

I also removed some unnecessary `bot.loop` arguments to `create_task`.