### PR TITLE
Change DM users get when warned

### DIFF
--- a/bot/exts/moderation/infraction/_utils.py
+++ b/bot/exts/moderation/infraction/_utils.py
@@ -39,14 +39,23 @@ INFRACTION_APPEAL_MODMAIL_FOOTER = (
     "\nIf you would like to discuss or appeal this infraction, "
     f"send a message to the ModMail bot (<@{MODMAIL_ACCOUNT_ID}>)."
 )
+INFRACTION_MODMAIL_FOOTER = (
+    "\nIf you would like to discuss this infraction, "
+    f"send a message to the ModMail bot (<@{MODMAIL_ACCOUNT_ID}>)."
+)
 INFRACTION_AUTHOR_NAME = "Infraction information"
 
 LONGEST_EXTRAS = max(len(INFRACTION_APPEAL_SERVER_FOOTER), len(INFRACTION_APPEAL_MODMAIL_FOOTER))
 
-INFRACTION_DESCRIPTION_TEMPLATE = (
+INFRACTION_DESCRIPTION_NOT_WARNING_TEMPLATE = (
     "**Type:** {type}\n"
     "**Duration:** {duration}\n"
     "**Expires:** {expires}\n"
+    "**Reason:** {reason}\n"
+)
+
+INFRACTION_DESCRIPTION_WARNING_TEMPLATE = (
+    "**Type:** Warning\n"
     "**Reason:** {reason}\n"
 )
 
@@ -213,18 +222,27 @@ async def notify_infraction(
     if reason is None:
         reason = infraction["reason"]
 
-    text = INFRACTION_DESCRIPTION_TEMPLATE.format(
-        type=infr_type.title(),
-        expires=expires_at,
-        duration=duration,
-        reason=reason or "No reason provided."
-    )
+    if infraction["type"] == "warning":
+        text = INFRACTION_DESCRIPTION_WARNING_TEMPLATE.format(
+            reason=reason or "No reason provided."
+        )
+    else:
+        text = INFRACTION_DESCRIPTION_NOT_WARNING_TEMPLATE.format(
+            type=infr_type.title(),
+            expires=expires_at,
+            duration=duration,
+            reason=reason or "No reason provided."
+        )
 
     # For case when other fields than reason is too long and this reach limit, then force-shorten string
     if len(text) > 4096 - LONGEST_EXTRAS:
         text = f"{text[:4093-LONGEST_EXTRAS]}..."
 
-    text += INFRACTION_APPEAL_SERVER_FOOTER if infraction["type"] == "ban" else INFRACTION_APPEAL_MODMAIL_FOOTER
+    text += (
+        INFRACTION_APPEAL_SERVER_FOOTER if infraction["type"] == "ban"
+        else INFRACTION_MODMAIL_FOOTER if infraction["type"] == "warning"
+        else INFRACTION_APPEAL_MODMAIL_FOOTER
+    )
 
     embed = discord.Embed(
         description=text,

--- a/tests/bot/exts/moderation/infraction/test_utils.py
+++ b/tests/bot/exts/moderation/infraction/test_utils.py
@@ -142,7 +142,7 @@ class ModerationUtilsTests(unittest.IsolatedAsyncioTestCase):
                 ),
                 "expected_output": Embed(
                     title=utils.INFRACTION_TITLE,
-                    description=utils.INFRACTION_DESCRIPTION_TEMPLATE.format(
+                    description=utils.INFRACTION_DESCRIPTION_NOT_WARNING_TEMPLATE.format(
                         type="Ban",
                         expires="2020-02-26 09:20 (23 hours and 59 minutes)",
                         reason="No reason provided."
@@ -160,7 +160,7 @@ class ModerationUtilsTests(unittest.IsolatedAsyncioTestCase):
                 "args": (dict(id=0, type="warning", reason="Test reason.", expires_at=None), self.user),
                 "expected_output": Embed(
                     title=utils.INFRACTION_TITLE,
-                    description=utils.INFRACTION_DESCRIPTION_TEMPLATE.format(
+                    description=utils.INFRACTION_DESCRIPTION_NOT_WARNING_TEMPLATE.format(
                         type="Warning",
                         expires="N/A",
                         reason="Test reason."
@@ -180,7 +180,7 @@ class ModerationUtilsTests(unittest.IsolatedAsyncioTestCase):
                 "args": (dict(id=0, type="note", reason=None, expires_at=None), self.user),
                 "expected_output": Embed(
                     title=utils.INFRACTION_TITLE,
-                    description=utils.INFRACTION_DESCRIPTION_TEMPLATE.format(
+                    description=utils.INFRACTION_DESCRIPTION_NOT_WARNING_TEMPLATE.format(
                         type="Note",
                         expires="N/A",
                         reason="No reason provided."
@@ -201,7 +201,7 @@ class ModerationUtilsTests(unittest.IsolatedAsyncioTestCase):
                 ),
                 "expected_output": Embed(
                     title=utils.INFRACTION_TITLE,
-                    description=utils.INFRACTION_DESCRIPTION_TEMPLATE.format(
+                    description=utils.INFRACTION_DESCRIPTION_NOT_WARNING_TEMPLATE.format(
                         type="Mute",
                         expires="2020-02-26 09:20 (23 hours and 59 minutes)",
                         reason="Test"
@@ -219,7 +219,7 @@ class ModerationUtilsTests(unittest.IsolatedAsyncioTestCase):
                 "args": (dict(id=0, type="mute", reason="foo bar" * 4000, expires_at=None), self.user),
                 "expected_output": Embed(
                     title=utils.INFRACTION_TITLE,
-                    description=utils.INFRACTION_DESCRIPTION_TEMPLATE.format(
+                    description=utils.INFRACTION_DESCRIPTION_NOT_WARNING_TEMPLATE.format(
                         type="Mute",
                         expires="N/A",
                         reason="foo bar" * 4000


### PR DESCRIPTION
Create separate message for warnings without duration, expiry, or "to appeal this infraction ..."

Since warnings involve no change in permissions, the DM that users receive said "Duration: Permanent \\ Expires: Never", which some interpreted to mean that we hold a permanent grudge. This is not intended, so this commit creates a separate template that omits those fields. Some users also thought they could appeal a warning to have it removed from the record, but this is not the case, so this commit creates a separate footer that removes "or appeal" from the instruction to contact the ModMail bot.

Showing the new message received when warned:
![image](https://github.com/python-discord/bot/assets/32915757/b63bbb9e-1f97-450f-859d-ae10b5b1baf1)

Showing the message received when muted (which has not changed):
![image](https://github.com/python-discord/bot/assets/32915757/5dbc267f-8faa-4517-8a9e-a829b2ffcad8)

(The ModMail bot is not in the user cache for the dummy account that I muted.)