### PR TITLE
Fix docs link markdown

### DIFF
--- a/bot/exts/info/doc/_markdown.py
+++ b/bot/exts/info/doc/_markdown.py
@@ -49,6 +49,8 @@ class DocMarkdownConverter(markdownify.MarkdownConverter):
     def convert_a(self, el: PageElement, text: str, convert_as_inline: bool) -> str:
         """Resolve relative URLs to `self.page_url`."""
         el["href"] = urljoin(self.page_url, el["href"])
+        # Discord doesn't handle titles properly, showing links with them as raw text.
+        el["title"] = None
         return super().convert_a(el, text, convert_as_inline)
 
     def convert_p(self, el: PageElement, text: str, convert_as_inline: bool) -> str:


### PR DESCRIPTION
the new discord handling for URLs doesn't embed links with titles

![](https://i.imgur.com/nfDFWVe.png)