### PR TITLE
Block fixup commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ concurrency:
 
 
 jobs:
+
+  fixup-commit-blocker:
+    uses: python-discord/.github/.github/workflows/block-fixup-commits.yaml@main
+
   lint-test:
     uses: ./.github/workflows/lint-test.yml
 


### PR DESCRIPTION
This uses the organisation's fixup commit blocker workflow.

The purpose is to make sure all commits prefixed with `fixup` need to be squashed before merging.