### PR TITLE
Make admins confirm edits of other users' reminders

### DIFF
--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -38,14 +38,14 @@ log = get_logger(__name__)
 LOCK_NAMESPACE = "reminder"
 WHITELISTED_CHANNELS = Guild.reminder_whitelist
 MAXIMUM_REMINDERS = 5
-CONFIRMATION_TIMEOUT = 60
+REMINDER_EDIT_CONFIRMATION_TIMEOUT = 60
 
 Mentionable = discord.Member | discord.Role
 ReminderMention = UnambiguousUser | discord.Role
 
 
-class ModifyConfirmationView(discord.ui.View):
-    """A view to confirm modifying someone else's reminder."""
+class ModifyReminderConfirmationView(discord.ui.View):
+    """A view to confirm modifying someone else's reminder by admins."""
 
     def __init__(self, author: discord.Member | discord.User):
         super().__init__(timeout=CONFIRMATION_TIMEOUT)
@@ -572,11 +572,11 @@ class Reminders(Cog):
             raise e
 
         if api_response["author"] == ctx.author.id:
-            log.debug(f"{ctx.author} is the reminder author and passes the check.")
+            log.debug(f"{ctx.author} is the reminder's author and passes the check.")
             return True
 
         if await has_any_role_check(ctx, Roles.admins):
-            log.debug(f"{ctx.author} is an admin, asking for confirmation to modify the reminder.")
+            log.debug(f"{ctx.author} is an admin, asking for confirmation to modify someone else's.")
 
             confirmation_view = ModifyConfirmationView(ctx.author)
             await ctx.send(

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -48,7 +48,7 @@ class ModifyReminderConfirmationView(discord.ui.View):
     """A view to confirm modifying someone else's reminder by admins."""
 
     def __init__(self, author: discord.Member | discord.User):
-        super().__init__(timeout=CONFIRMATION_TIMEOUT)
+        super().__init__(timeout=REMINDER_EDIT_CONFIRMATION_TIMEOUT)
         self.author = author
         self.result: bool | None = None
 
@@ -578,7 +578,7 @@ class Reminders(Cog):
         if await has_any_role_check(ctx, Roles.admins):
             log.debug(f"{ctx.author} is an admin, asking for confirmation to modify someone else's.")
 
-            confirmation_view = ModifyConfirmationView(ctx.author)
+            confirmation_view = ModifyReminderConfirmationView(ctx.author)
             await ctx.reply(
                 "Are you sure you want to modify someone else's reminder?",
                 view=confirmation_view,

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -47,7 +47,7 @@ ReminderMention = UnambiguousUser | discord.Role
 class ModifyReminderConfirmationView(discord.ui.View):
     """A view to confirm modifying someone else's reminder by admins."""
 
-    def __init__(self, author: discord.Member | discord.User):
+    def __init__(self, author: discord.Member):
         super().__init__(timeout=REMINDER_EDIT_CONFIRMATION_TIMEOUT)
         self.author = author
         self.result: bool | None = None
@@ -581,7 +581,7 @@ class Reminders(Cog):
 
             confirmation_view = ModifyReminderConfirmationView(ctx.author)
             await ctx.reply(
-                "Are you sure you want to modify <@{owner_id}>'s reminder?",
+                f"Are you sure you want to modify <@{owner_id}>'s reminder?",
                 view=confirmation_view,
             )
             await confirmation_view.wait()

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -570,8 +570,9 @@ class Reminders(Cog):
                 if e.status == 404:
                     return False
             raise e
+        owner_id = api_response["author"]
 
-        if api_response["author"] == ctx.author.id:
+        if owner_id == ctx.author.id:
             log.debug(f"{ctx.author} is the reminder's author and passes the check.")
             return True
 
@@ -580,7 +581,7 @@ class Reminders(Cog):
 
             confirmation_view = ModifyReminderConfirmationView(ctx.author)
             await ctx.reply(
-                "Are you sure you want to modify someone else's reminder?",
+                "Are you sure you want to modify <@{owner_id}>'s reminder?",
                 view=confirmation_view,
             )
             await confirmation_view.wait()

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -70,7 +70,7 @@ class ModifyReminderConfirmationView(discord.ui.View):
     @discord.ui.button(label="Cancel", row=0)
     async def cancel(self, interaction: Interaction, button: discord.ui.Button) -> None:
         """Cancel the reminder modification."""
-        await interaction.response.edit_message(content="🚫 Operation canceled.", view=None)
+        await interaction.response.edit_message(view=None)
         self.result = False
         self.stop()
 
@@ -597,6 +597,7 @@ class Reminders(Cog):
             if confirmation_view.result:
                 log.debug(f"{ctx.author} has confirmed reminder modification.")
             else:
+                await ctx.send("🚫 Operation canceled.")
                 log.debug(f"{ctx.author} has cancelled reminder modification.")
             return confirmation_view.result
 

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -585,11 +585,14 @@ class Reminders(Cog):
                 modify_action = "edit"
 
             confirmation_view = ModifyReminderConfirmationView(ctx.author)
-            await ctx.reply(
+            confirmation_message = await ctx.reply(
                 f"Are you sure you want to {modify_action} <@{owner_id}>'s reminder?",
                 view=confirmation_view,
             )
-            await confirmation_view.wait()
+            view_timed_out = await confirmation_view.wait()
+            # We don't have access to the message in `on_timeout` so we have to delete the view here
+            if view_timed_out:
+                await confirmation_message.edit(view=None)
 
             if confirmation_view.result:
                 log.debug(f"{ctx.author} has confirmed reminder modification.")

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -579,9 +579,14 @@ class Reminders(Cog):
         if await has_any_role_check(ctx, Roles.admins):
             log.debug(f"{ctx.author} is an admin, asking for confirmation to modify someone else's.")
 
+            if ctx.command == self.delete_reminder:
+                modify_action = "delete"
+            else:
+                modify_action = "edit"
+
             confirmation_view = ModifyReminderConfirmationView(ctx.author)
             await ctx.reply(
-                f"Are you sure you want to modify <@{owner_id}>'s reminder?",
+                f"Are you sure you want to {modify_action} <@{owner_id}>'s reminder?",
                 view=confirmation_view,
             )
             await confirmation_view.wait()

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -591,7 +591,7 @@ class Reminders(Cog):
                 log.debug(f"{ctx.author} has cancelled reminder modification.")
             return confirmation_view.result
 
-        log.debug(f"{ctx.author} is not the reminder author and does not pass the check.")
+        log.debug(f"{ctx.author} is not the reminder's author and thus does not pass the check.")
         if send_on_denial:
             await send_denial(ctx, "You can't modify reminders of other users!")
         return False

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -560,7 +560,7 @@ class Reminders(Cog):
         """
         Check whether the reminder can be modified by the ctx author.
 
-        The check passes when the user is an admin, or if they created the reminder.
+        The check passes if the user created the reminder, or if they are an admin (with confirmation).
         """
         try:
             api_response = await self.bot.api_client.get(f"bot/reminders/{reminder_id}")

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -579,7 +579,7 @@ class Reminders(Cog):
             log.debug(f"{ctx.author} is an admin, asking for confirmation to modify someone else's.")
 
             confirmation_view = ModifyConfirmationView(ctx.author)
-            await ctx.send(
+            await ctx.reply(
                 "Are you sure you want to modify someone else's reminder?",
                 view=confirmation_view,
             )


### PR DESCRIPTION
Closes #2353

## Screenshots:

Confirmation:
![image](https://github.com/python-discord/bot/assets/84215197/b994613e-b86c-4ea9-9b5e-b4e8486a0075)
When cancelled:
![image](https://github.com/python-discord/bot/assets/84215197/6ec274f7-d090-4c57-9c1e-4e3725d3f3d0)
When confirmed:
![image](https://github.com/python-discord/bot/assets/84215197/6ba7d7ae-26c5-415e-a893-103cfb515420)
