### PR TITLE
Remove call to the fixup reusable workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,12 +17,6 @@ jobs:
   lint-test:
     uses: ./.github/workflows/lint-test.yml
 
-  fixup-commit-blocker:
-    if: github.ref != 'refs/heads/main'
-    uses: python-discord/.github/.github/workflows/block-fixup-commits.yaml@main
-    needs: lint-test
-
-
   generate-sha-tag:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
We're having a couple of issues with the workflow so we're temporarily removing it.