### PR TITLE
Update all references of 3.11 in eval to 3.12

### DIFF
--- a/bot/exts/utils/snekbox/_cog.py
+++ b/bot/exts/utils/snekbox/_cog.py
@@ -86,7 +86,7 @@ SNEKBOX_ROLES = (Roles.helpers, Roles.moderators, Roles.admins, Roles.owners, Ro
 REDO_EMOJI = "\U0001f501"  # :repeat:
 REDO_TIMEOUT = 30
 
-SupportedPythonVersions = Literal["3.11"]
+SupportedPythonVersions = Literal["3.12"]
 
 
 class FilteredFiles(NamedTuple):
@@ -562,13 +562,13 @@ class Snekbox(Cog):
         If multiple codeblocks are in a message, all of them will be joined and evaluated,
         ignoring the text outside them.
 
-        Currently only 3.11 version is supported.
+        Currently only 3.12 version is supported.
 
         We've done our best to make this sandboxed, but do let us know if you manage to find an
         issue with it!
         """
         code: list[str]
-        python_version = python_version or "3.11"
+        python_version = python_version or "3.12"
         job = EvalJob.from_code("\n".join(code)).as_version(python_version)
         await self.run_job(ctx, job)
 
@@ -598,13 +598,13 @@ class Snekbox(Cog):
         If multiple formatted codeblocks are provided, the first one will be the setup code, which will
         not be timed. The remaining codeblocks will be joined together and timed.
 
-        Currently only 3.11 version is supported.
+        Currently only 3.12 version is supported.
 
         We've done our best to make this sandboxed, but do let us know if you manage to find an
         issue with it!
         """
         code: list[str]
-        python_version = python_version or "3.11"
+        python_version = python_version or "3.12"
         args = self.prepare_timeit_input(code)
         job = EvalJob(args, version=python_version, name="timeit")
 

--- a/bot/exts/utils/snekbox/_eval.py
+++ b/bot/exts/utils/snekbox/_eval.py
@@ -26,7 +26,7 @@ class EvalJob:
     args: list[str]
     files: list[FileAttachment] = field(default_factory=list)
     name: str = "eval"
-    version: SupportedPythonVersions = "3.11"
+    version: SupportedPythonVersions = "3.12"
 
     @classmethod
     def from_code(cls, code: str, path: str = "main.py") -> EvalJob:

--- a/tests/bot/exts/utils/snekbox/test_snekbox.py
+++ b/tests/bot/exts/utils/snekbox/test_snekbox.py
@@ -103,9 +103,9 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
     def test_eval_result_message(self):
         """EvalResult.get_message(), should return message."""
         cases = (
-            ("ERROR", None, ("Your 3.11 eval job has failed", "ERROR", "")),
-            ("", 128 + snekbox._eval.SIGKILL, ("Your 3.11 eval job timed out or ran out of memory", "", "")),
-            ("", 255, ("Your 3.11 eval job has failed", "A fatal NsJail error occurred", ""))
+            ("ERROR", None, ("Your 3.12 eval job has failed", "ERROR", "")),
+            ("", 128 + snekbox._eval.SIGKILL, ("Your 3.12 eval job timed out or ran out of memory", "", "")),
+            ("", 255, ("Your 3.12 eval job has failed", "A fatal NsJail error occurred", ""))
         )
         for stdout, returncode, expected in cases:
             exp_msg, exp_err, exp_files_err = expected
@@ -177,8 +177,8 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         mock_signals.return_value.name = "SIGTEST"
         result = EvalResult(stdout="", returncode=127)
         self.assertEqual(
-            result.get_message(EvalJob([], version="3.11")),
-            "Your 3.11 eval job has completed with return code 127 (SIGTEST)"
+            result.get_message(EvalJob([], version="3.12")),
+            "Your 3.12 eval job has completed with return code 127 (SIGTEST)"
         )
 
     def test_eval_result_status_emoji(self):
@@ -252,7 +252,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         self.cog.send_job = AsyncMock(return_value=response)
         self.cog.continue_job = AsyncMock(return_value=None)
 
-        await self.cog.eval_command(self.cog, ctx=ctx, python_version="3.11", code=["MyAwesomeCode"])
+        await self.cog.eval_command(self.cog, ctx=ctx, python_version="3.12", code=["MyAwesomeCode"])
         job = EvalJob.from_code("MyAwesomeCode")
         self.cog.send_job.assert_called_once_with(ctx, job)
         self.cog.continue_job.assert_called_once_with(ctx, response, "eval")
@@ -266,7 +266,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         self.cog.continue_job = AsyncMock()
         self.cog.continue_job.side_effect = (EvalJob.from_code("MyAwesomeFormattedCode"), None)
 
-        await self.cog.eval_command(self.cog, ctx=ctx, python_version="3.11", code=["MyAwesomeCode"])
+        await self.cog.eval_command(self.cog, ctx=ctx, python_version="3.12", code=["MyAwesomeCode"])
 
         expected_job = EvalJob.from_code("MyAwesomeFormattedCode")
         self.cog.send_job.assert_called_with(ctx, expected_job)
@@ -311,7 +311,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         ctx.send.assert_called_once()
         self.assertEqual(
             ctx.send.call_args.args[0],
-            "@LemonLemonishBeard#0042 :warning: Your 3.11 eval job has completed "
+            "@LemonLemonishBeard#0042 :warning: Your 3.12 eval job has completed "
             "with return code 0.\n\n```\n[No output]\n```"
         )
         allowed_mentions = ctx.send.call_args.kwargs["allowed_mentions"]
@@ -337,13 +337,13 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         mocked_filter_cog.filter_snekbox_output = AsyncMock(return_value=(False, []))
         self.bot.get_cog.return_value = mocked_filter_cog
 
-        job = EvalJob.from_code("MyAwesomeCode").as_version("3.11")
+        job = EvalJob.from_code("MyAwesomeCode").as_version("3.12")
         await self.cog.send_job(ctx, job),
 
         ctx.send.assert_called_once()
         self.assertEqual(
             ctx.send.call_args.args[0],
-            "@LemonLemonishBeard#0042 :white_check_mark: Your 3.11 eval job "
+            "@LemonLemonishBeard#0042 :white_check_mark: Your 3.12 eval job "
             "has completed with return code 0."
             "\n\n```\nWay too long beard\n```\nFull output: lookatmybeard.com"
         )
@@ -366,13 +366,13 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         mocked_filter_cog.filter_snekbox_output = AsyncMock(return_value=(False, []))
         self.bot.get_cog.return_value = mocked_filter_cog
 
-        job = EvalJob.from_code("MyAwesomeCode").as_version("3.11")
+        job = EvalJob.from_code("MyAwesomeCode").as_version("3.12")
         await self.cog.send_job(ctx, job),
 
         ctx.send.assert_called_once()
         self.assertEqual(
             ctx.send.call_args.args[0],
-            "@LemonLemonishBeard#0042 :x: Your 3.11 eval job has completed with return code 127."
+            "@LemonLemonishBeard#0042 :x: Your 3.12 eval job has completed with return code 127."
             "\n\n```\nERROR\n```"
         )
 
@@ -394,13 +394,13 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         mocked_filter_cog.filter_snekbox_output = AsyncMock(return_value=(False, [".disallowed"]))
         self.bot.get_cog.return_value = mocked_filter_cog
 
-        job = EvalJob.from_code("MyAwesomeCode").as_version("3.11")
+        job = EvalJob.from_code("MyAwesomeCode").as_version("3.12")
         await self.cog.send_job(ctx, job),
 
         ctx.send.assert_called_once()
         res = ctx.send.call_args.args[0]
         self.assertTrue(
-            res.startswith("@user#7700 :white_check_mark: Your 3.11 eval job has completed with return code 0.")
+            res.startswith("@user#7700 :white_check_mark: Your 3.12 eval job has completed with return code 0.")
         )
         self.assertIn("Files with disallowed extensions can't be uploaded: **.disallowed**", res)
 


### PR DESCRIPTION
snekbox now runs 3.12 by default, so the user output should reflect that.

Once snekbox support multiple versions, version detection will be done programmatically based on snekbox's response.