### PR TITLE
Fix `!src` command resulting in 404 for tags

### DIFF
--- a/bot/exts/info/source.py
+++ b/bot/exts/info/source.py
@@ -69,7 +69,7 @@ class BotSource(commands.Cog):
 
         # Handle tag file location differently than others to avoid errors in some cases
         if not first_line_no:
-            file_location = Path(filename).relative_to("bot/")
+            file_location = Path(filename)
         else:
             file_location = Path(filename).relative_to(Path.cwd()).as_posix()
 


### PR DESCRIPTION
Closes #2770 

The `!src` would give a GitHub link that's invalid for tags. For instance, this is the link given by `!src enumerate` compared to what it should've been:
- `https://github.com/python-discord/bot/blob/main/resources/tags/enumerate.md`
- `https://github.com/python-discord/bot/blob/main/bot/resources/tags/enumerate.md`

Note the difference. I think this is because of the path being relative to `bot`:
https://github.com/python-discord/bot/blob/66c8414396b28a7cac8f05602ee7f2bc360e4f14/bot/exts/info/source.py#L70-L72

Please let me know if removing this relative to has any unintended side effects I'm not aware of. I've tested this locally with a few different tags and other targets and it seems to be fine.