### PR TITLE
Fix broken hyperlink rendering in windows-path tag

### DIFF
--- a/bot/resources/tags/windows-path.md
+++ b/bot/resources/tags/windows-path.md
@@ -6,7 +6,7 @@ If you have installed Python but forgot to check the `Add Python to PATH` option
 
 If you did not uncheck the option to install the `py launcher`, then you'll instead have a `py` command which can be used in the same way. If you want to be able to access your Python installation via the `python` command, then your best option is to re-install Python (remembering to tick the `Add Python to PATH` checkbox).
 
-You can pass any options to the Python interpreter, e.g. to install the `[numpy](https://pypi.org/project/numpy/)` module from PyPI you can run `py -3 -m pip install numpy` or `python -m pip install numpy`.
+You can pass any options to the Python interpreter, e.g. to install the [`numpy`](https://pypi.org/project/numpy/) module from PyPI you can run `py -3 -m pip install numpy` or `python -m pip install numpy`.
 
 You can also access different versions of Python using the version flag of the `py` command, like so:
 ```


### PR DESCRIPTION
This is a minor fix for the !windows-path tag incorrectly rendering this hyperlink:

![Screenshot of Discord not formating hyperlink to numpy](https://github.com/python-discord/bot/assets/61257169/e43a40a7-93ed-40e3-a038-30b982d84de2)