### PR TITLE
Support editing of timeout durations.

### DIFF
--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -230,10 +230,8 @@ class Infractions(InfractionScheduler, commands.Cog):
         if duration is None:
             duration = await Duration().convert(ctx, "1h")
         else:
-            now = arrow.utcnow()
-            if isinstance(duration, relativedelta):
-                duration += now
-            if duration > now + MAXIMUM_TIMEOUT_DAYS:
+            capped, duration = _utils.cap_timeout_duration(duration)
+            if capped:
                 cap_message_for_user = TIMEOUT_CAP_MESSAGE.format(user.mention)
                 if is_mod_channel(ctx.channel):
                     await ctx.reply(f":warning: {cap_message_for_user}")
@@ -241,10 +239,6 @@ class Infractions(InfractionScheduler, commands.Cog):
                     await self.bot.get_channel(Channels.mods).send(
                         f":warning: {ctx.author.mention} {cap_message_for_user}"
                     )
-                duration = now + MAXIMUM_TIMEOUT_DAYS - timedelta(minutes=1)  # Duration cap is exclusive.
-            elif duration > now + MAXIMUM_TIMEOUT_DAYS - timedelta(minutes=1):
-                # Duration cap is exclusive. This is to still allow specifying "28d".
-                duration -= timedelta(minutes=1)
 
         await self.apply_timeout(ctx, user, reason, duration_or_expiry=duration)
 

--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -233,7 +233,9 @@ class ModManagement(commands.Cog):
                 self.infractions_cog.schedule_expiration(new_infraction)
                 # Timeouts are handled by Discord itself, so we need to edit the expiry in Discord as well
                 if user and infraction["type"] == "timeout":
-                    _, duration = _utils.cap_timeout_duration(expiry)
+                    capped, duration = _utils.cap_timeout_duration(expiry)
+                    if capped:
+                        await _utils.notify_timeout_cap(self.bot, ctx, user)
                     await user.edit(reason=reason, timed_out_until=expiry)
 
             log_text += f"""

--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -232,7 +232,7 @@ class ModManagement(commands.Cog):
             if request_data["expires_at"]:
                 self.infractions_cog.schedule_expiration(new_infraction)
                 # Timeouts are handled by Discord itself, so we need to edit the expiry in Discord as well
-                if infraction["type"] == "timeout":
+                if user and infraction["type"] == "timeout":
                     await user.edit(reason=reason, timed_out_until=expiry)
 
             log_text += f"""

--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -233,6 +233,7 @@ class ModManagement(commands.Cog):
                 self.infractions_cog.schedule_expiration(new_infraction)
                 # Timeouts are handled by Discord itself, so we need to edit the expiry in Discord as well
                 if user and infraction["type"] == "timeout":
+                    _, duration = _utils.cap_timeout_duration(expiry)
                     await user.edit(reason=reason, timed_out_until=expiry)
 
             log_text += f"""

--- a/bot/exts/moderation/infraction/management.py
+++ b/bot/exts/moderation/infraction/management.py
@@ -197,8 +197,8 @@ class ModManagement(commands.Cog):
             # Update `last_applied` if expiry changes.
             request_data["last_applied"] = origin.isoformat()
             request_data["expires_at"] = expiry.isoformat()
-            expiry = time.format_with_duration(expiry, origin)
-            confirm_messages.append(f"set to expire on {expiry}")
+            formatted_expiry = time.format_with_duration(expiry, origin)
+            confirm_messages.append(f"set to expire on {formatted_expiry}")
         else:
             confirm_messages.append("expiry unchanged")
 
@@ -218,6 +218,10 @@ class ModManagement(commands.Cog):
             json=request_data,
         )
 
+        # Get information about the infraction's user
+        user_id = new_infraction["user"]
+        user = await get_or_fetch_member(ctx.guild, user_id)
+
         # Re-schedule infraction if the expiration has been updated
         if "expires_at" in request_data:
             # A scheduled task should only exist if the old infraction wasn't permanent
@@ -227,6 +231,9 @@ class ModManagement(commands.Cog):
             # If the infraction was not marked as permanent, schedule a new expiration task
             if request_data["expires_at"]:
                 self.infractions_cog.schedule_expiration(new_infraction)
+                # Timeouts are handled by Discord itself, so we need to edit the expiry in Discord as well
+                if infraction["type"] == "timeout":
+                    await user.edit(reason=reason, timed_out_until=expiry)
 
             log_text += f"""
                 Previous expiry: {time.until_expiration(infraction['expires_at'])}
@@ -235,10 +242,6 @@ class ModManagement(commands.Cog):
 
         changes = " & ".join(confirm_messages)
         await ctx.send(f":ok_hand: Updated infraction #{infraction_id}: {changes}")
-
-        # Get information about the infraction's user
-        user_id = new_infraction["user"]
-        user = await get_or_fetch_member(ctx.guild, user_id)
 
         if user:
             user_text = messages.format_user(user)


### PR DESCRIPTION
All of the infractions that we have are scheduled for expiry thanks to our own Scheduler.

However, when it comes to `timeouts/mutes`, the expiry is handled by Discord itself, and the duration that we set in our databse serves no purposes besides their notifying the user about re-acquiring the ability to send messages again.

So this particular case needs to be handled on its own whenver the infraction type is a `timeout` and a new `expiry` datetime has been assigned.