### PR TITLE
Recognize `pyi` as `py` in code snippets

### DIFF
--- a/bot/exts/info/code_snippets.py
+++ b/bot/exts/info/code_snippets.py
@@ -210,6 +210,9 @@ class CodeSnippets(Cog):
         if not is_valid_language:
             language = ""
 
+        if language == "pyi":
+            language = "py"
+
         # Adds a label showing the file path to the snippet
         if start_line == end_line:
             ret = f"`{file_path}` line {start_line}\n"


### PR DESCRIPTION
Closes #2843 

This special cases `pyi` only, I thought of adding a `lang_map` dictionary, but that seemed unnecessary at the moment.