### PR TITLE
Branding: improve IO resilience

### DIFF
--- a/bot/exts/backend/branding/_cog.py
+++ b/bot/exts/backend/branding/_cog.py
@@ -611,8 +611,6 @@ class Branding(commands.Cog):
 
         await ctx.send(embed=resp)
 
-        await ctx.invoke(self.branding_calendar_group)
-
     # endregion
     # region: Command interface (branding daemon)
 

--- a/bot/exts/backend/branding/_cog.py
+++ b/bot/exts/backend/branding/_cog.py
@@ -592,8 +592,24 @@ class Branding(commands.Cog):
         log.info("Performing command-requested event cache refresh.")
 
         async with ctx.typing():
-            available_events = await self.repository.get_events()
-            await self.populate_cache_events(available_events)
+            try:
+                available_events = await self.repository.get_events()
+            except Exception:
+                log.exception("Refresh aborted: failed to fetch events.")
+                resp = make_embed(
+                    "Refresh aborted",
+                    "Failed to fetch events. See log for details.",
+                    success=False,
+                )
+            else:
+                await self.populate_cache_events(available_events)
+                resp = make_embed(
+                    "Refresh successful",
+                    "The event calendar has been refreshed.",
+                    success=True,
+                )
+
+        await ctx.send(embed=resp)
 
         await ctx.invoke(self.branding_calendar_group)
 

--- a/bot/exts/backend/branding/_cog.py
+++ b/bot/exts/backend/branding/_cog.py
@@ -342,13 +342,13 @@ class Branding(commands.Cog):
         """
         log.debug("Synchronise: fetching current event.")
 
-        current_event, available_events = await self.repository.get_current_event()
+        try:
+            current_event, available_events = await self.repository.get_current_event()
+        except Exception:
+            log.exception("Synchronisation aborted: failed to fetch events.")
+            return False, False
 
         await self.populate_cache_events(available_events)
-
-        if current_event is None:
-            log.error("Failed to fetch event. Cannot synchronise!")
-            return False, False
 
         return await self.enter_event(current_event)
 
@@ -432,10 +432,6 @@ class Branding(commands.Cog):
         new_event, available_events = await self.repository.get_current_event()
 
         await self.populate_cache_events(available_events)
-
-        if new_event is None:
-            log.warning("Daemon main: failed to get current event from branding repository, will do nothing.")
-            return
 
         if new_event.path != await self.cache_information.get("event_path"):
             log.debug("Daemon main: new event detected!")

--- a/bot/exts/backend/branding/_repository.py
+++ b/bot/exts/backend/branding/_repository.py
@@ -119,7 +119,7 @@ class BrandingRepository:
         """
         log.trace(f"Response status: {response.status}")
         if response.status >= 500:
-            raise GitHubServerError()
+            raise GitHubServerError
         response.raise_for_status()
 
     @retry_on_server_error

--- a/bot/exts/backend/branding/_repository.py
+++ b/bot/exts/backend/branding/_repository.py
@@ -202,14 +202,14 @@ class BrandingRepository:
 
         return instances
 
-    async def get_current_event(self) -> tuple[Event | None, list[Event]]:
+    async def get_current_event(self) -> tuple[Event, list[Event]]:
         """
         Get the currently active event, or the fallback event.
 
         The second return value is a list of all available events. The caller may discard it, if not needed.
         Returning all events alongside the current one prevents having to query the API twice in some cases.
 
-        The current event may be None in the case that no event is active, and no fallback event is found.
+        If no event is active and the fallback event cannot be found, raise an error.
         """
         utc_now = datetime.now(tz=UTC)
         log.debug(f"Finding active event for: {utc_now}.")
@@ -232,5 +232,4 @@ class BrandingRepository:
             if event.meta.is_fallback:
                 return event, available_events
 
-        log.warning("No event is currently active and no fallback event was found!")
-        return None, available_events
+        raise RuntimeError("No event is currently active and no fallback event was found!")

--- a/bot/exts/backend/branding/_repository.py
+++ b/bot/exts/backend/branding/_repository.py
@@ -85,6 +85,7 @@ retry_on_server_error = backoff.on_exception(
     backoff.expo,
     GitHubServerError,
     max_tries=5,
+    jitter=None,
 )
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -221,6 +221,17 @@ tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+description = "Function decoration for backoff and retry"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8"},
+    {file = "backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba"},
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.2"
 description = "Screen-scraping library"
@@ -2376,4 +2387,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.*"
-content-hash = "99dba45ac109c6fd2f7faede136992c79509883e0c5bc1c589a3fde3d478bd7d"
+content-hash = "9b5f39eb1230c6035f37e96a82b7d54b93d4242388813cab50377dc991abb7e0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ pydis_core = { version = "10.5.1", extras = ["async-rediscache"] }
 
 aiohttp = "3.9.1"
 arrow = "1.3.0"
+backoff = "2.2.1"
 beautifulsoup4 = "4.12.2"
 colorama = { version = "0.4.6", markers = "sys_platform == 'win32'" }
 coloredlogs = "15.0.1"


### PR DESCRIPTION
Closes GH-2808

This PR aims to improve the resiliency of the Branding manager cog.

# Context

The Branding manager automatically discovers events once per day at midnight -- or when instructed to. During each such discovery, it makes multiple HTTP requests to the GitHub API. First, it fetches a list of all events in the Branding repository, and then it fetches those events one-by-one.

If the bot fails to fetch an event, it skips it. This behaviour made sense originally, as we didn't want the bot to stop the discovery iteration if just one event is badly configured. In practice, however, this is a non-issue as events are validated in the Branding repository before they reach the `main` branch. Additionally, this behaviour also affects server errors - if the bot receives a 503 when fetching en event, the event is simply excluded from the result set. This has an unfortunate consequence - if the bot fails to fetch the currently active event, it decides that the event has ended, and will revert the branding to the evergreen (fallback) season.

This PR makes adjustments to the error handling methodology. Now, if any of the requests fail, the whole discovery iteration will be aborted & retried the following day (or it may be retried manually via the `sync` command). The current state remains in the Redis cache, so the cog will continue working just fine. Additionally, to reduce the likelihood of a discovery iteration being aborted, there will be a retry mechanism on each request. For every request that fails on a server error, the request will be retried up to 5 times with exponential backoff.

# Implementation

Adjusting the error handling was easy - I basically just removed the error handling clauses from the repository module. This means that errors occurring during event fetch will now propagate to the cog. The daemon already handles exceptions, and so if a fetch fails, the daemon will simply log it and sleep until the next midnight.

Another way to trigger the event discovery is via the `sync` command. This also already handles errors - I just removed a redundant check for when no active event was found, which will now result in an exception.

Finally, the calendar refresh cmd used to automatically show the calendar after running discovery. Because discovery can now fail (well, it always could, but the error used to be hidden), it now responds with an info embed:

![image](https://github.com/python-discord/bot/assets/44734341/e96ad277-c43e-4e15-ad92-8f03c7eb7e03)

![image](https://github.com/python-discord/bot/assets/44734341/d0120d46-dfe3-4c2d-ab7f-c31f404f28f6)

The user can then use check the calendar via the calender cmd. I think this makes more sense, but I'm open to feedback.

Within the repository module, I added a custom exception for GitHub server errors, and revamped the response status checks. I've added the MIT-licensed [backoff](https://pypi.org/project/backoff/) library to avoid implementing the retry mechanism myself, but if we would rather avoid the dependency, then a custom implementation is also possible. The backoff decorator basically retries the decorated function if it raises the specified exception, up to the configured amount of times.