### PR TITLE
Add Spammer field to `!user` info embed for moderators

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -292,9 +292,16 @@ class Information(Cog):
             # The 0 is for excluding the default @everyone role,
             # and the -1 is for reversing the order of the roles to highest to lowest in hierarchy.
             roles = ", ".join(role.mention for role in user.roles[:0:-1])
-            membership = {"Joined": joined, "Verified": not user.pending, "Roles": roles or None}
-            if not is_mod_channel(ctx.channel):
-                membership.pop("Verified")
+            membership = {
+                "Joined": joined,
+                "Roles": roles or None,
+            }
+
+            if is_mod_channel(ctx.channel):
+                membership.update({
+                    "Verified": not user.pending,
+                    "Spammer": user.public_flags.spammer,
+                })
 
             membership = textwrap.dedent("\n".join([f"{key}: {value}" for key, value in membership.items()]))
         else:


### PR DESCRIPTION
If the command is evoked in a mod channel, the resultant embed will display whether the user in question has been flagged by Discord as a spammer. This is potentially useful for evaluating reports of suspicious DMs.

Here it is when run in a moderator channel

![image](https://github.com/python-discord/bot/assets/32915757/b966f0cc-b932-480b-b7ad-d538be544914)

And in a public channel 

![image](https://github.com/python-discord/bot/assets/32915757/e14fdc08-3fa7-4c68-a272-4ce71bdbf2b6)
