### PR TITLE
Ensure filter list is present in previously triggered cache before accessing

### DIFF
--- a/bot/exts/filtering/_filter_lists/filter_list.py
+++ b/bot/exts/filtering/_filter_lists/filter_list.py
@@ -107,7 +107,7 @@ class AtomicList:
         if ctx.event == Event.MESSAGE_EDIT and ctx.message and self.list_type == ListType.DENY:
             previously_triggered = ctx.message_cache.get_message_metadata(ctx.message.id)
             # The message might not be cached.
-            if previously_triggered:
+            if previously_triggered and self in previously_triggered:
                 ignore_filters = previously_triggered[self]
                 # This updates the cache. Some filters are ignored, but they're necessary if there's another edit.
                 previously_triggered[self] = relevant_filters


### PR DESCRIPTION
Solves #2912 Solves BOT-3FF

This check was previously present, but removed in this commit https://github.com/python-discord/bot/commit/8f2f188cee48096aebf5b7aeff04d632643dc7be