### PR TITLE
Reference the `/tag` slash-command instead of the old `!tags` in the footer of tags listings

### DIFF
--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -25,7 +25,7 @@ TEST_CHANNELS = (
 )
 
 REGEX_NON_ALPHABET = re.compile(r"[^a-z]", re.MULTILINE & re.IGNORECASE)
-FOOTER_TEXT = f"To show a tag, type {constants.Bot.prefix}tags <tagname>."
+FOOTER_TEXT = "To show a tag, use /tag <tagname>."
 
 
 class COOLDOWN(enum.Enum):


### PR DESCRIPTION
I have written a way too long PR title but I think that'll explain it 😄

<img width="324" alt="image" src="https://github.com/python-discord/bot/assets/50042066/a321d4ee-3132-42f1-acfb-82979b476c04"> <img width="325" alt="image" src="https://github.com/python-discord/bot/assets/50042066/a73dfea5-546b-4fff-ade1-af7fca20102b">

We don't have a `!tags` anymore. It should reference `/tag` instead.