### PR TITLE
Log to #voice-log for passed and failed attempts at voice verification

### DIFF
--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -9,9 +9,11 @@ from pydis_core.site_api import ResponseCodeError
 from pydis_core.utils.channel import get_or_fetch_channel
 
 from bot.bot import Bot
-from bot.constants import Channels, MODERATION_ROLES, Roles, VoiceGate as GateConf
+from bot.constants import Channels, Icons, MODERATION_ROLES, Roles, VoiceGate as GateConf
 from bot.log import get_logger
 from bot.utils.checks import InWhitelistCheckFailure
+from bot.utils.messages import format_user
+from bot.utils.modlog import send_log_message
 
 log = get_logger(__name__)
 
@@ -119,6 +121,19 @@ class VoiceVerificationView(discord.ui.View):
                 ephemeral=True,
                 delete_after=GateConf.delete_after_delay,
             )
+
+            log_reasons = "\n".join(f"- Has {reason}." for reason in failed_reasons)
+
+            await send_log_message(
+                self.bot,
+                icon_url=Icons.defcon_denied,
+                colour=Colour.red(),
+                title="Voice gate failed",
+                text=f"{format_user(interaction.user)} failed the voice gate.\n\n{log_reasons}",
+                thumbnail=interaction.user.avatar,
+                channel_id=Channels.voice_log,
+            )
+
             return
 
         embed = discord.Embed(
@@ -137,6 +152,17 @@ class VoiceVerificationView(discord.ui.View):
             delete_after=GateConf.delete_after_delay,
         )
         await interaction.user.add_roles(discord.Object(Roles.voice_verified), reason="Voice Gate passed")
+
+        await send_log_message(
+            self.bot,
+            icon_url=Icons.defcon_unshutdown,
+            colour=Colour.green(),
+            title="Voice gate passed",
+            text=f"{format_user(interaction.user)} passed the voice gate.",
+            thumbnail=interaction.user.avatar,
+            channel_id=Channels.voice_log,
+        )
+
         self.bot.stats.incr("voice_gate.passed")
 
 

--- a/bot/exts/moderation/voice_gate.py
+++ b/bot/exts/moderation/voice_gate.py
@@ -26,10 +26,10 @@ FAILED_MESSAGE = (
 )
 
 MESSAGE_FIELD_MAP = {
-    "joined_at": f"have been on the server for less than {GateConf.minimum_days_member} days",
-    "voice_gate_blocked": "have an active voice infraction",
-    "total_messages": f"have sent less than {GateConf.minimum_messages} messages",
-    "activity_blocks": f"have been active for fewer than {GateConf.minimum_activity_blocks} ten-minute blocks",
+    "joined_at": f"been on the server for less than {GateConf.minimum_days_member} days",
+    "voice_gate_blocked": "an active voice infraction",
+    "total_messages": f"sent less than {GateConf.minimum_messages} messages",
+    "activity_blocks": f"been active for fewer than {GateConf.minimum_activity_blocks} ten-minute blocks",
 }
 
 VOICE_PING = (
@@ -108,7 +108,9 @@ class VoiceVerificationView(discord.ui.View):
 
             embed = discord.Embed(
                 title="Voice Gate failed",
-                description=FAILED_MESSAGE.format(reasons="\n".join(f"- You {reason}." for reason in failed_reasons)),
+                description=FAILED_MESSAGE.format(
+                    reasons="\n".join(f"- You have {reason}." for reason in failed_reasons)
+                ),
                 color=Colour.red()
             )
 


### PR DESCRIPTION
This PR adds a new #voice-log type for passing and failing the voice gate.

![image](https://github.com/python-discord/bot/assets/20439493/8b2d15e6-276b-4572-8b61-6c9dfb096ece)

The conditions used are the same that the user will receive in their failure message.

Icons are re-used from DEFCON, as they are pretty and apply to what the voice gate is! As a result though, the constant names are the same, do we care about this? Shall I add duplicate entries to the `Icons` constants area? I think it's minor as if we are updating/removing in future then it will get picked up on anyway.

Closes #2922