### PR TITLE
Also sync user's display_name

### DIFF
--- a/bot/exts/backend/sync/_syncers.py
+++ b/bot/exts/backend/sync/_syncers.py
@@ -170,6 +170,7 @@ class UserSyncer(Syncer):
                 seen_guild_users.add(guild_user.id)
 
                 maybe_update("name", guild_user.name)
+                maybe_update("display_name", guild_user.display_name)
                 maybe_update("discriminator", int(guild_user.discriminator))
                 maybe_update("in_guild", True)
 
@@ -196,6 +197,7 @@ class UserSyncer(Syncer):
                 new_user = {
                     "id": member.id,
                     "name": member.name,
+                    "display_name": member.display_name,
                     "discriminator": int(member.discriminator),
                     "roles": [role.id for role in member.roles],
                     "in_guild": True

--- a/tests/bot/exts/backend/sync/test_cog.py
+++ b/tests/bot/exts/backend/sync/test_cog.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock
 from unittest import mock
 
 import discord
@@ -60,40 +61,52 @@ class SyncCogTestCase(unittest.IsolatedAsyncioTestCase):
 class SyncCogTests(SyncCogTestCase):
     """Tests for the Sync cog."""
 
-    async def test_sync_cog_sync_on_load(self):
-        """Roles and users should be synced on cog load."""
-        guild = helpers.MockGuild()
-        self.bot.get_guild = mock.MagicMock(return_value=guild)
-
-        self.RoleSyncer.reset_mock()
-        self.UserSyncer.reset_mock()
-
-        await self.cog.cog_load()
-
-        self.RoleSyncer.sync.assert_called_once_with(guild)
-        self.UserSyncer.sync.assert_called_once_with(guild)
-
-    async def test_sync_cog_sync_guild(self):
-        """Roles and users should be synced only if a guild is successfully retrieved."""
+    @unittest.mock.patch("bot.exts.backend.sync._cog.create_task", new_callable=unittest.mock.MagicMock)
+    async def test_sync_cog_sync_on_load(self, mock_create_task: unittest.mock.MagicMock):
+        """Sync function should be synced on cog load only if guild is found."""
         for guild in (helpers.MockGuild(), None):
             with self.subTest(guild=guild):
+                mock_create_task.reset_mock()
                 self.bot.reset_mock()
                 self.RoleSyncer.reset_mock()
                 self.UserSyncer.reset_mock()
 
                 self.bot.get_guild = mock.MagicMock(return_value=guild)
-
-                await self.cog.cog_load()
-
-                self.bot.wait_until_guild_available.assert_called_once()
-                self.bot.get_guild.assert_called_once_with(constants.Guild.id)
+                error_raised = False
+                try:
+                    await self.cog.cog_load()
+                except ValueError:
+                    if guild is None:
+                        error_raised = True
+                    else:
+                        raise
 
                 if guild is None:
-                    self.RoleSyncer.sync.assert_not_called()
-                    self.UserSyncer.sync.assert_not_called()
+                    self.assertTrue(error_raised)
+                    mock_create_task.assert_not_called()
                 else:
-                    self.RoleSyncer.sync.assert_called_once_with(guild)
-                    self.UserSyncer.sync.assert_called_once_with(guild)
+                    mock_create_task.assert_called_once()
+                    self.assertIsInstance(mock_create_task.call_args[0][0], type(self.cog.sync()))
+
+
+    async def test_sync_cog_sync_guild(self):
+        """Roles and users should be synced only if a guild is successfully retrieved."""
+        guild = helpers.MockGuild()
+        self.bot.reset_mock()
+        self.RoleSyncer.reset_mock()
+        self.UserSyncer.reset_mock()
+
+        self.bot.get_guild = mock.MagicMock(return_value=guild)
+        await self.cog.cog_load()
+
+        with mock.patch("asyncio.sleep", new_callable=unittest.mock.AsyncMock):
+            await self.cog.sync()
+
+        self.bot.wait_until_guild_available.assert_called_once()
+        self.bot.get_guild.assert_called_once_with(constants.Guild.id)
+
+        self.RoleSyncer.sync.assert_called_once()
+        self.UserSyncer.sync.assert_called_once()
 
     async def patch_user_helper(self, side_effect: BaseException) -> None:
         """Helper to set a side effect for bot.api_client.patch and then assert it is called."""

--- a/tests/bot/exts/backend/sync/test_users.py
+++ b/tests/bot/exts/backend/sync/test_users.py
@@ -11,6 +11,7 @@ def fake_user(**kwargs):
     """Fixture to return a dictionary representing a user with default values set."""
     kwargs.setdefault("id", 43)
     kwargs.setdefault("name", "bob the test man")
+    kwargs.setdefault("display_name", "bob")
     kwargs.setdefault("discriminator", 1337)
     kwargs.setdefault("roles", [helpers.MockRole(id=666)])
     kwargs.setdefault("in_guild", True)


### PR DESCRIPTION
This updates the sync cog to also sync user's display_names.

This PR also moves the initial sync to 10 seconds after cog start up, to give other cogs a chance to start up.