### PR TITLE
Fix warning in tests

### DIFF
--- a/tests/bot/test_constants.py
+++ b/tests/bot/test_constants.py
@@ -10,7 +10,7 @@ current_path = Path(__file__)
 env_file_path = current_path.parent / ".testenv"
 
 
-class TestEnvConfig(
+class _TestEnvConfig(
     EnvConfig,
     env_file=env_file_path,
 ):
@@ -21,7 +21,7 @@ class NestedModel(BaseModel):
     server_name: str
 
 
-class _TestConfig(TestEnvConfig, env_prefix="unittests_"):
+class _TestConfig(_TestEnvConfig, env_prefix="unittests_"):
 
     goat: str
     execution_env: str = "local"


### PR DESCRIPTION
Fixes this warning
```
  D:\bot\tests\bot\test_constants.py:13: PytestCollectionWarning: cannot collect test class 'TestEnvConfig' because it has a __init__ constructor (from: tests/bot/test_constants.py)
    class TestEnvConfig(
```
Pytest tries to collect any class beginning with `Test` as a test.

I'd like to enable failing tests with warnings to catch things like this, but we'll need to wait for https://github.com/Rapptz/discord.py/issues/9477 first.