### PR TITLE
Don't upload to pastebin when no truncation

### DIFF
--- a/bot/exts/utils/snekbox/_cog.py
+++ b/bot/exts/utils/snekbox/_cog.py
@@ -266,14 +266,14 @@ class Snekbox(Cog):
         truncated = False
         lines = output.splitlines()
 
-        if len(lines) > 1:
-            if line_nums:
-                lines = [f"{i:03d} | {line}" for i, line in enumerate(lines, 1)]
-            lines = lines[:max_lines+1]  # Limiting to max+1 lines
+        if len(lines) > 1 and line_nums:
+            lines = [f"{i:03d} | {line}" for i, line in enumerate(lines, 1)]
             output = "\n".join(lines)
 
         if len(lines) > max_lines:
             truncated = True
+            lines = lines[:max_lines]
+            output = "\n".join(lines)
             if len(output) >= max_chars:
                 output = f"{output[:max_chars]}\n... (truncated - too long, too many lines)"
             else:

--- a/tests/bot/exts/utils/snekbox/test_snekbox.py
+++ b/tests/bot/exts/utils/snekbox/test_snekbox.py
@@ -199,7 +199,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
 
         too_many_lines = (
             "001 | v\n002 | e\n003 | r\n004 | y\n005 | l\n006 | o\n"
-            "007 | n\n008 | g\n009 | b\n010 | e\n011 | a\n... (truncated - too many lines)"
+            "007 | n\n008 | g\n009 | b\n010 | e\n... (truncated - too many lines)"
         )
         too_long_too_many_lines = (
             "\n".join(


### PR DESCRIPTION
See issue #3045 

New behaviour:
![image](https://github.com/python-discord/bot/assets/37447267/e9d6e691-4c0b-4ec6-9d05-1264e83266e3)
