### PR TITLE
Check length of nomination reason before attempting to send to site API

### DIFF
--- a/bot/exts/recruitment/talentpool/_cog.py
+++ b/bot/exts/recruitment/talentpool/_cog.py
@@ -432,6 +432,13 @@ class TalentPool(Cog, name="Talentpool"):
 
             reason += f"\n\n{message.jump_url}"
 
+            if len(reason) > REASON_MAX_CHARS:
+                await interaction.response.send_message(
+                    ":x: Cannot add additional context due to nomination reason character limit.",
+                    ephemeral=True
+                )
+                return
+
             await self.api.edit_nomination_entry(
                 nomination.id,
                 actor_id=interaction.user.id,


### PR DESCRIPTION
This ensures we will not attempt to send a reason that is longer than
the REASON_MAX_CHARS value, which can quickly be reached through the
addition of message links in context.