### PR TITLE
Relay creations and amendments to nominations to vote threads

### DIFF
--- a/bot/exts/recruitment/talentpool/_api.py
+++ b/bot/exts/recruitment/talentpool/_api.py
@@ -36,6 +36,7 @@ class NominationAPI:
         self,
         user_id: int | None = None,
         active: bool | None = None,
+        reviewed: bool | None = None,
         ordering: str = "-inserted_at"
     ) -> list[Nomination]:
         """
@@ -46,6 +47,8 @@ class NominationAPI:
         params = {"ordering": ordering}
         if active is not None:
             params["active"] = str(active)
+        if reviewed is not None:
+            params["reviewed"] = str(reviewed)
         if user_id is not None:
             params["user__id"] = str(user_id)
 

--- a/bot/exts/recruitment/talentpool/_api.py
+++ b/bot/exts/recruitment/talentpool/_api.py
@@ -62,6 +62,15 @@ class NominationAPI:
         nomination = Nomination.model_validate(data)
         return nomination
 
+    async def get_active_nomination(self, user_id: int) -> Nomination | None:
+        """Search for an active nomination for a user and return it."""
+        nominations = await self.get_nominations(user_id=user_id, active=True)
+
+        if len(nominations) >= 1:
+            return nominations[0]
+
+        return None
+
     async def get_nomination_reason(self, user_id: int, actor_id: int) -> tuple[Nomination, str] | None:
         """Search for a nomination & reason for a specific actor on a specific user."""
         nominations = await self.get_nominations(user_id, True)


### PR DESCRIPTION
If a nomination is actively being voted on and a staff member creates, updates
or attaches a message to their existing nomination we currently do not relay
that to the vote thread.

This PR relays any of these events to the vote thread so they are not lost.

This also allows moderators to use the message context menu command to attach
any relevant messages they find whilst reviewing into the active voting thread.