### PR TITLE
Fix faulty hyperlink in charinfo command.

### DIFF
--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -71,7 +71,7 @@ class Utils(Cog):
             else:
                 u_code = f"\\U{digit:>08}"
             url = f"https://www.compart.com/en/unicode/U+{digit:>04}"
-            name = f"[{unicodedata.name(char, '')}]({url})"
+            name = f"[{unicodedata.name(char, 'Name not found')}]({url})"
             info = f"`{u_code.ljust(10)}`: {name} - {utils.escape_markdown(char)}"
             return info, u_code
 


### PR DESCRIPTION
Give a default name of "Name not found" if `unicodedata` is unable to find one, to fix the faulty hyperlinks.

![image](https://leo.might-be.gay/Y3MVXG.png)