### PR TITLE
Use COVERAGE_CORE=sysmon when running tests in CI

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -53,7 +53,7 @@ jobs:
         run: "ruff check --output-format=github ."
 
       - name: Run tests and generate coverage report
-        run: pytest -n auto --cov -q
+        run: COVERAGE_CORE=sysmon pytest -n auto --cov -q
 
       # Prepare the Pull Request Payload artifact. If this fails, we
       # we fail silently using the `continue-on-error` option. It's

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -53,7 +53,10 @@ jobs:
         run: "ruff check --output-format=github ."
 
       - name: Run tests and generate coverage report
-        run: COVERAGE_CORE=sysmon pytest -n auto --cov -q
+        run: pytest -n auto --cov -q
+        env:
+          # Use "sys.monitoring" based coverage backend for better speed (see #3075)
+          COVERAGE_CORE: sysmon
 
       # Prepare the Pull Request Payload artifact. If this fails, we
       # we fail silently using the `continue-on-error` option. It's


### PR DESCRIPTION
https://coverage.readthedocs.io/en/7.5.1/cmd.html#execution-coverage-run
> In Python 3.12 and above, you can try an experimental core based on the new [sys.monitoring](https://docs.python.org/3/library/sys.monitoring.html#module-sys.monitoring) module by defining a COVERAGE_CORE=sysmon environment variable. This should be faster, though plugins and dynamic contexts are not yet supported with it.

Confirmed it gives the same result for us, just a lot faster.