### PR TITLE
Update old redis version in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
   redis:
     logging : *default-logging
     restart: unless-stopped
-    image: redis:5.0.9
+    image: redis:latest
     ports:
       - "127.0.0.1:6379:6379"
 


### PR DESCRIPTION
I don't think there are any particularly relevant changes, but the previous version was 4 years old.

We've been doing fine with just `:latest` on lancebot, so I think it's fine here too.