### PR TITLE
Skip line if no match against inventory line regex

### DIFF
--- a/bot/exts/info/doc/_inventory_parser.py
+++ b/bot/exts/info/doc/_inventory_parser.py
@@ -69,6 +69,13 @@ async def _load_v2(stream: aiohttp.StreamReader) -> InventoryDict:
 
     async for line in ZlibStreamReader(stream):
         m = _V2_LINE_RE.match(line.rstrip())
+
+        # If we don't have a match, the package is probably doing something
+        # funky with new-lines and we can discount this line, it's likely a
+        # multi-line figure description or something similar.
+        if not m:
+            continue
+
         name, type_, _prio, location, _dispname = m.groups()  # ignore the parsed items we don't need
         if location.endswith("$"):
             location = location[:-1] + name


### PR DESCRIPTION
We currently have an issue on bot (BOT-3VH on Sentry) which is failing to parse
the sympy docs due to a malformed object inventory.

This looks to be caused by multi-line figure descriptions or something similar
which are creating lines that do not match our regex.

Ignoring these lines is fine as they likely provide no additional context
anyway, and the relevant symbol is still parsed as normal and links to the
original docs.