### PR TITLE
Suppress ResponseCodeErrors when fetching alts in !user

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -343,8 +343,16 @@ class Information(Cog):
 
     async def user_alt_count(self, user: MemberOrUser) -> tuple[str, int | str]:
         """Get the number of alts for the given member."""
-        resp = await self.bot.api_client.get(f"bot/users/{user.id}")
-        return ("Associated accounts", len(resp["alts"]) or "No associated accounts")
+        try:
+            resp = await self.bot.api_client.get(f"bot/users/{user.id}")
+            return ("Associated accounts", len(resp["alts"]) or "No associated accounts")
+        except ResponseCodeError as e:
+            # If user is not found, return a soft-error regarding this.
+            if e.response.status == 404:
+                return ("Associated accounts", "User not found in site database.")
+
+            # If we have any other issue, re-raise the exception
+            raise e
 
 
     async def basic_user_infraction_counts(self, user: MemberOrUser) -> tuple[str, str]:


### PR DESCRIPTION
Restores previous behaviour that allows the `!user` command to look up users who
are not in the guild.

When the alts feature was implemented we added a new API call to
`/bot/users/{user_id}`, which was fine, but it meant that if that 404'd and a
ResponseCodeError was raised then the bot would start returning erroneous
responses that implied a user does not exist, when they did exist, they were
just not in our site database.