### PR TITLE
Support both Python 3.12 and 3.13 in eval

### DIFF
--- a/bot/exts/utils/snekbox/_cog.py
+++ b/bot/exts/utils/snekbox/_cog.py
@@ -86,7 +86,7 @@ SNEKBOX_ROLES = (Roles.helpers, Roles.moderators, Roles.admins, Roles.owners, Ro
 REDO_EMOJI = "\U0001f501"  # :repeat:
 REDO_TIMEOUT = 30
 
-SupportedPythonVersions = Literal["3.12"]
+SupportedPythonVersions = Literal["3.12", "3.13"]
 
 
 class FilteredFiles(NamedTuple):
@@ -181,18 +181,16 @@ class Snekbox(Cog):
     ) -> interactions.ViewWithUserAndRoleCheck:
         """Return a view that allows the user to change what version of Python their code is run on."""
         alt_python_version: SupportedPythonVersions
-        if current_python_version == "3.10":
-            alt_python_version = "3.11"
+        if current_python_version == "3.12":
+            alt_python_version = "3.13"
         else:
-            alt_python_version = "3.10"  # noqa: F841
+            alt_python_version = "3.12"
 
         view = interactions.ViewWithUserAndRoleCheck(
             allowed_users=(ctx.author.id,),
             allowed_roles=MODERATION_ROLES,
         )
-        # Temp disabled until snekbox multi-version support is complete
-        # https://github.com/python-discord/snekbox/issues/158
-        # view.add_item(PythonVersionSwitcherButton(alt_python_version, self, ctx, job))
+        view.add_item(PythonVersionSwitcherButton(alt_python_version, self, ctx, job))
         view.add_item(interactions.DeleteMessageButton())
 
         return view

--- a/bot/exts/utils/snekbox/_eval.py
+++ b/bot/exts/utils/snekbox/_eval.py
@@ -50,6 +50,7 @@ class EvalJob:
         return {
             "args": self.args,
             "files": [file.to_dict() for file in self.files],
+            "executable_path": f"/snekbin/python/{self.version}/bin/python",
         }
 
 

--- a/tests/bot/exts/utils/snekbox/test_snekbox.py
+++ b/tests/bot/exts/utils/snekbox/test_snekbox.py
@@ -35,8 +35,8 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         context_manager = MagicMock()
         context_manager.__aenter__.return_value = resp
         self.bot.http_session.post.return_value = context_manager
-
-        job = EvalJob.from_code("import random").as_version("3.10")
+        py_version = "3.12"
+        job = EvalJob.from_code("import random").as_version(py_version)
         self.assertEqual(await self.cog.post_job(job), EvalResult("Hi", 137))
 
         expected = {
@@ -44,9 +44,10 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
             "files": [
                 {
                     "path": "main.py",
-                    "content": b64encode(b"import random").decode()
+                    "content": b64encode(b"import random").decode(),
                 }
-            ]
+            ],
+            "executable_path": f"/snekbin/python/{py_version}/bin/python",
         }
         self.bot.http_session.post.assert_called_with(
             constants.URLs.snekbox_eval_api,


### PR DESCRIPTION
This is blocked until both snekbox PRs are merged.
https://github.com/python-discord/snekbox/pull/196
https://github.com/python-discord/snekbox/pull/217