### PR TITLE
Sanitize MSVC++ build tools link for Discord

### DIFF
--- a/bot/resources/tags/microsoft-build-tools.md
+++ b/bot/resources/tags/microsoft-build-tools.md
@@ -10,7 +10,7 @@ error: Microsoft Visual C++ 14.0 or greater is required. Get it with "Microsoft 
 
 This means the library you're installing has code written in other languages and needs additional tools to install. To install these tools, follow the following steps: (Requires 6GB+ disk space)
 
-**1.** Open [https://visualstudio.microsoft.com/visual-cpp-build-tools/](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+**1.** Open https://visualstudio.microsoft.com/visual-cpp-build-tools/.
 **2.** Click **`Download Build Tools >`**. A file named `vs_BuildTools` or `vs_BuildTools.exe` should start downloading. If no downloads start after a few seconds, click **`click here to retry`**.
 **3.** Run the downloaded file. Click **`Continue`** to proceed.
 **4.** Choose **C++ build tools** and press **`Install`**. You may need a reboot after the installation.


### PR DESCRIPTION
Discord does not like periods (`.`) in aliased URLs, so this section of markdown is not rendered. Bare URLs, though, get made into links, and it looks fine.