### PR TITLE
Enable 3.13's colorized output (bot half)

### DIFF
--- a/bot/exts/utils/snekbox/_cog.py
+++ b/bot/exts/utils/snekbox/_cog.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 log = get_logger(__name__)
 
+ANSI_REGEX = re.compile(r"\N{ESC}\[[0-9;:]*m")
 ESCAPE_REGEX = re.compile("[`\u202E\u200B]{3,}")
 
 # The timeit command should only output the very last line, so all other output should be suppressed.
@@ -281,7 +282,10 @@ class Snekbox(Cog):
             output = f"{output[:max_chars]}\n... (truncated - too long)"
 
         if truncated:
-            paste_link = await self.upload_output(original_output)
+            # ANSI colors are quite nice, but don't render in pinwand,
+            #   thus mangling the output
+            ansiless_output = ANSI_REGEX.sub("", original_output)
+            paste_link = await self.upload_output(ansiless_output)
 
         if output_default and not output:
             output = output_default

--- a/bot/exts/utils/snekbox/_cog.py
+++ b/bot/exts/utils/snekbox/_cog.py
@@ -400,7 +400,7 @@ class Snekbox(Cog):
 
             # Skip output if it's empty and there are file uploads
             if result.stdout or not result.has_files:
-                msg += f"\n```\n{output}\n```"
+                msg += f"\n```ansi\n{output}\n```"
 
             if paste_link:
                 msg += f"\nFull output: {paste_link}"

--- a/tests/bot/exts/utils/snekbox/test_snekbox.py
+++ b/tests/bot/exts/utils/snekbox/test_snekbox.py
@@ -312,7 +312,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             ctx.send.call_args.args[0],
             ":warning: Your 3.12 eval job has completed "
-            "with return code 0.\n\n```\n[No output]\n```"
+            "with return code 0.\n\n```ansi\n[No output]\n```"
         )
         allowed_mentions = ctx.send.call_args.kwargs["allowed_mentions"]
         expected_allowed_mentions = AllowedMentions(everyone=False, roles=False, users=[ctx.author])
@@ -343,7 +343,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
             ctx.send.call_args.args[0],
             ":white_check_mark: Your 3.12 eval job "
             "has completed with return code 0."
-            "\n\n```\nWay too long beard\n```\nFull output: lookatmybeard.com"
+            "\n\n```ansi\nWay too long beard\n```\nFull output: lookatmybeard.com"
         )
 
         self.cog.post_job.assert_called_once_with(job)
@@ -369,7 +369,7 @@ class SnekboxTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             ctx.send.call_args.args[0],
             ":x: Your 3.12 eval job has completed with return code 127."
-            "\n\n```\nERROR\n```"
+            "\n\n```ansi\nERROR\n```"
         )
 
         self.cog.post_job.assert_called_once_with(job)


### PR DESCRIPTION
One of the features new to Python 3.13 is the use of colored traceback output. These colors *greatly* aid in locating smaller bugs and are overall quite handy, but they are not always enabled, including for the bot's output message. This changes that.

Care was taken to achieve a significant degree of backwards compatibility. Long tracebacks, whose full forms are uploaded to pinnwand, go through a regular expression that removes ANSI escape codes. Pinnwand does not support ANSI, so if this is not done, the raw characters are included, easily making the traceback unintelligible. This will not delete escaped ANSI sequences, but it does provide a slight regression in that colored output that makes it to pinnwand is rendered monochrome (previously, the characters would be present, causing the legibility issue mentioned earlier - though whether this was a problem may be debated).

This PR is the bot side. There is a snekbox PR (python-discord/snekbox#225) that causes the colored output, which should probably be merged *after* this one.

This was not done alone. Credit is shared with
@ChrisLovering (for pointing to snekbox)
@shenanigansd and @parrrate (for help with docker)
@godlygeek (with the de-ANSIfication regex, much simpler than i thought it'd be)

![a demo of this feature, with a code block by PR author and eval output featuring ANSI text and a colored traceback](https://github.com/user-attachments/assets/d16f1f28-6885-44df-a2fd-2a3568421f11)
paste mentioned in image is https://paste.pythondiscord.com/NEP7SBFPWJVETSCU5XJDLVG6Q4