### PR TITLE
Don't ignore newlines when filtering invites

### DIFF
--- a/bot/exts/filtering/_filter_lists/invite.py
+++ b/bot/exts/filtering/_filter_lists/invite.py
@@ -60,7 +60,7 @@ class InviteList(FilterList[InviteFilter]):
         self, ctx: FilterContext
     ) -> tuple[ActionSettings | None, list[str], dict[ListType, list[Filter]]]:
         """Dispatch the given event to the list's filters, and return actions to take and messages to relay to mods."""
-        text = clean_input(ctx.content)
+        text = clean_input(ctx.content, keep_newlines=True)
 
         matches = list(DISCORD_INVITE.finditer(text))
         invite_codes = {m.group("invite") for m in matches}

--- a/bot/exts/filtering/_utils.py
+++ b/bot/exts/filtering/_utils.py
@@ -51,7 +51,7 @@ def subclasses_in_package(package: str, prefix: str, parent: T) -> set[T]:
     return subclasses
 
 
-def clean_input(string: str) -> str:
+def clean_input(string: str, *, keep_newlines: bool = False) -> str:
     """Remove zalgo and invisible characters from `string`."""
     # For future consideration: remove characters in the Mc, Sk, and Lm categories too.
     # Can be normalised with form C to merge char + combining char into a single char to avoid
@@ -60,8 +60,8 @@ def clean_input(string: str) -> str:
 
     # URL quoted strings can be used to hide links to servers
     content = urllib.parse.unquote(content)
-    # Drop newlines that can be used to bypass filter
-    content = content.replace("\n", "")
+    if not keep_newlines:  # Drop newlines that can be used to bypass filter
+        content = content.replace("\n", "")
     # Avoid escape characters
     content = content.replace("\\", "")
 


### PR DESCRIPTION
Fixes a bug where in the following message:
```
discord.gg/python
discord.gg/djs
```
The newlines would be ignored, and the bot would end up checking the invite `discord.gg/pythondiscord` and therefore blocking the message.