### PR TITLE
Configure dependabot to only open PRs for major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      update-types:
+        - sem-ver:patch
+        - sem-ver:minor
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Security updates will always open PRs