### PR TITLE
Abbreviate codeblock instructions; remove ability to dismiss the inst…

### DIFF
--- a/bot/exts/info/codeblock/_cog.py
+++ b/bot/exts/info/codeblock/_cog.py
@@ -43,8 +43,7 @@ class CodeBlockCog(Cog, name="Code Block"):
     When an issue is detected, an embed is sent containing specific instructions on fixing what
     is wrong. If the user edits their message to fix the code block, the instructions will be
     removed. If they fail to fix the code block with an edit, the instructions will be updated to
-    show what is still incorrect after the user's edit. The embed can be manually deleted with a
-    reaction. Otherwise, it will automatically be removed after 5 minutes.
+    show what is still incorrect after the user's edit. Otherwise, it will automatically be removed after 5 minutes.
 
     The cog only detects messages in whitelisted channels. Channels may also have a cooldown on the
     instructions being sent. Note all help channels are also whitelisted with cooldowns enabled.
@@ -64,7 +63,7 @@ class CodeBlockCog(Cog, name="Code Block"):
     @staticmethod
     def create_embed(instructions: str) -> discord.Embed:
         """Return an embed which displays code block formatting `instructions`."""
-        return discord.Embed(description=instructions)
+        return discord.Embed(description=instructions, title="Please edit your message to use a code block")
 
     async def get_sent_instructions(self, payload: RawMessageUpdateEvent) -> Message | None:
         """
@@ -114,7 +113,7 @@ class CodeBlockCog(Cog, name="Code Block"):
         bot_message = await message.channel.send(f"Hey {message.author.mention}!", embed=embed)
         self.codeblock_message_ids[message.id] = bot_message.id
 
-        scheduling.create_task(wait_for_deletion(bot_message, (message.author.id,)))
+        scheduling.create_task(wait_for_deletion(bot_message, tuple(), attach_emojis=False))
 
         # Increase amount of codeblock correction in stats
         self.bot.stats.incr("codeblock_corrections")

--- a/bot/exts/info/codeblock/_instructions.py
+++ b/bot/exts/info/codeblock/_instructions.py
@@ -52,10 +52,10 @@ def _get_bad_ticks_message(code_block: _parsing.CodeBlock) -> str | None:
         log.trace("Language specifier issue found; appending additional instructions.")
 
         # The first line has double newlines which are not desirable when appending the msg.
-        addition_msg = addition_msg.replace("\n\n", " ", 1)
+        addition_msg = addition_msg.replace("\n\n", " ", 1).strip()
 
         # Make the first character of the addition lower case.
-        instructions += "\n\nFurthermore, " + addition_msg[0].lower() + addition_msg[1:]
+        instructions += "\n\nAlso, " + addition_msg[0].lower() + addition_msg[1:]
     else:
         log.trace("No issues with the language specifier found.")
 
@@ -106,10 +106,8 @@ def _get_bad_lang_message(content: str) -> str | None:
         example_blocks = _get_example(language)
 
         # Note that _get_bad_ticks_message expects the first line to have two newlines.
-        return (
-            f"It looks like you incorrectly specified a language for your code block.\n\n{lines}"
-            f"\n\n**Here is an example of how it should look:**\n{example_blocks}"
-        )
+        return f"\n\n{lines}\n\n**Here is an example of how it should look:**\n{example_blocks}"
+
     log.trace("Nothing wrong with the language specifier; no instructions to return.")
     return None
 
@@ -126,7 +124,7 @@ def _get_no_lang_message(content: str) -> str | None:
         example_blocks = _get_example("py")
 
         # Note that _get_bad_ticks_message expects the first line to have two newlines.
-        return f"Please add a `py` after the three backticks.\n\n{example_blocks}"
+        return f"\n\nAdd a `py` after the three backticks.\n\n{example_blocks}"
 
     log.trace("Aborting missing language instructions: content is not Python code.")
     return None

--- a/bot/exts/info/codeblock/_instructions.py
+++ b/bot/exts/info/codeblock/_instructions.py
@@ -37,9 +37,8 @@ def _get_bad_ticks_message(code_block: _parsing.CodeBlock) -> str | None:
 
     valid_ticks = f"\\{_parsing.BACKTICK}" * 3
     instructions = (
-        "It looks like you are trying to paste code into this channel.\n\n"
-        "You seem to be using the wrong symbols to indicate where the code block should start. "
-        f"The correct symbols would be {valid_ticks}, not `{code_block.tick * 3}`."
+        "You are using the wrong character instead of backticks. "
+        f"Use {valid_ticks}, not `{code_block.tick * 3}`."
     )
 
     log.trace("Check if the bad ticks code block also has issues with the language specifier.")
@@ -59,8 +58,6 @@ def _get_bad_ticks_message(code_block: _parsing.CodeBlock) -> str | None:
         instructions += "\n\nFurthermore, " + addition_msg[0].lower() + addition_msg[1:]
     else:
         log.trace("No issues with the language specifier found.")
-        example_blocks = _get_example(code_block.language)
-        instructions += f"\n\n**Here is an example of how it should look:**\n{example_blocks}"
 
     return instructions
 
@@ -71,13 +68,7 @@ def _get_no_ticks_message(content: str) -> str | None:
 
     if _parsing.is_python_code(content):
         example_blocks = _get_example("py")
-        return (
-            "It looks like you're trying to paste code into this channel.\n\n"
-            "Discord has support for Markdown, which allows you to post code with full "
-            "syntax highlighting. Please use these whenever you paste code, as this "
-            "helps improve the legibility and makes it easier for us to help you.\n\n"
-            f"**To do this, use the following method:**\n{example_blocks}"
-        )
+        return example_blocks
     log.trace("Aborting missing code block instructions: content is not Python code.")
     return None
 
@@ -135,12 +126,8 @@ def _get_no_lang_message(content: str) -> str | None:
         example_blocks = _get_example("py")
 
         # Note that _get_bad_ticks_message expects the first line to have two newlines.
-        return (
-            "It looks like you pasted Python code without syntax highlighting.\n\n"
-            "Please use syntax highlighting to improve the legibility of your code and make "
-            "it easier for us to help you.\n\n"
-            f"**To do this, use the following method:**\n{example_blocks}"
-        )
+        return f"Please add a `py` after the three backticks.\n\n{example_blocks}"
+
     log.trace("Aborting missing language instructions: content is not Python code.")
     return None
 
@@ -176,8 +163,5 @@ def get_instructions(content: str) -> str | None:
             instructions = _get_bad_lang_message(block.content)
             if not instructions:
                 instructions = _get_no_lang_message(block.content)
-
-    if instructions:
-        instructions += "\nYou can **edit your original message** to correct your code block."
 
     return instructions


### PR DESCRIPTION
…ructions with emoji.

The more concise instructions are intended to be easier to read and increase the rate of followthru. That the instructions cannot be dismissed is intended to make them harder to ignore.

The spelling of "followthru" is very intentional.

![image](https://github.com/user-attachments/assets/792f5953-e513-4c64-adf4-8dad0a6f4aa0)

![image](https://github.com/user-attachments/assets/57579978-c52a-47e5-a22e-be89ca8418a4)

![image](https://github.com/user-attachments/assets/d63bffd7-d4a0-4948-869f-7e32417ae216)

I should probably remove the "It looks like you ..." from this one.

![image](https://github.com/user-attachments/assets/06728fbe-baf6-4770-a486-380c1a13da7f)

I'm not sure if this one should have the example. I should add the "Check this out to find the backtick key" from the `!code` embed.