### PR TITLE
Apply filtering to text attachments; offer to auto-upload text attachments to paste bin

### DIFF
--- a/bot/exts/filtering/_filter_lists/extension.py
+++ b/bot/exts/filtering/_filter_lists/extension.py
@@ -4,7 +4,7 @@ import typing
 from os.path import splitext
 
 import bot
-from bot.constants import Channels, Emojis
+from bot.constants import Channels
 from bot.exts.filtering._filter_context import Event, FilterContext
 from bot.exts.filtering._filter_lists.filter_list import FilterList, ListType
 from bot.exts.filtering._filters.extension import ExtensionFilter
@@ -14,26 +14,11 @@ from bot.exts.filtering._settings import ActionSettings
 if typing.TYPE_CHECKING:
     from bot.exts.filtering.filtering import Filtering
 
-PASTE_URL = "https://paste.pythondiscord.com"
-PY_EMBED_DESCRIPTION = (
-    "It looks like you tried to attach a Python file - "
-    f"please use a code-pasting service such as {PASTE_URL}"
-)
-
-TXT_LIKE_FILES = {".txt", ".csv", ".json", ".py"}
-TXT_EMBED_DESCRIPTION = (
-    "You either uploaded a `{blocked_extension}` file or entered a message that was too long. "
-    f"Please use our [paste bin]({PASTE_URL}) instead."
-)
-
 DISALLOWED_EMBED_DESCRIPTION = (
     "It looks like you tried to attach file type(s) that we do not allow ({joined_blacklist}). "
     "We currently allow the following file types: **{joined_whitelist}**.\n\n"
     "Feel free to ask in {meta_channel_mention} if you think this is a mistake."
 )
-
-PASTEBIN_UPLOAD_EMOJI = Emojis.check_mark
-DELETE_PASTE_EMOJI = Emojis.trashcan
 
 
 class ExtensionsList(FilterList[ExtensionFilter]):
@@ -90,30 +75,23 @@ class ExtensionsList(FilterList[ExtensionFilter]):
         not_allowed = {ext: filename for ext, filename in all_ext if ext not in allowed_ext}
 
         if ctx.event == Event.SNEKBOX:
-            not_allowed = {ext: filename for ext, filename in not_allowed.items() if ext not in TXT_LIKE_FILES}
+            not_allowed = dict(not_allowed.items())
 
         if not not_allowed:  # Yes, it's a double negative. Meaning all attachments are allowed :)
             return None, [], {ListType.ALLOW: triggered}
 
         # At this point, something is disallowed.
         if ctx.event != Event.SNEKBOX:  # Don't post the embed if it's a snekbox response.
-            if ".py" in not_allowed:
-                # Provide a pastebin link for .py files.
-                ctx.dm_embed = PY_EMBED_DESCRIPTION
-            elif txt_extensions := {ext for ext in TXT_LIKE_FILES if ext in not_allowed}:
-                # Work around Discord auto-conversion of messages longer than 2000 chars to .txt
-                ctx.dm_embed = TXT_EMBED_DESCRIPTION.format(blocked_extension=txt_extensions.pop())
-            else:
-                meta_channel = bot.instance.get_channel(Channels.meta)
-                if not self._whitelisted_description:
-                    self._whitelisted_description = ", ".join(
-                        filter_.content for filter_ in self[ListType.ALLOW].filters.values()
-                    )
-                ctx.dm_embed = DISALLOWED_EMBED_DESCRIPTION.format(
-                    joined_whitelist=self._whitelisted_description,
-                    joined_blacklist=", ".join(not_allowed),
-                    meta_channel_mention=meta_channel.mention,
+            meta_channel = bot.instance.get_channel(Channels.meta)
+            if not self._whitelisted_description:
+                self._whitelisted_description = ", ".join(
+                    filter_.content for filter_ in self[ListType.ALLOW].filters.values()
                 )
+            ctx.dm_embed = DISALLOWED_EMBED_DESCRIPTION.format(
+                joined_whitelist=self._whitelisted_description,
+                joined_blacklist=", ".join(not_allowed),
+                meta_channel_mention=meta_channel.mention,
+            )
 
         ctx.matches += not_allowed.values()
         ctx.blocked_exts |= set(not_allowed)

--- a/bot/exts/filtering/_filter_lists/extension.py
+++ b/bot/exts/filtering/_filter_lists/extension.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
+import logging
+import re
 import typing
 from os.path import splitext
 
+import aiohttp
+import discord
+from discord.ext import commands
+from pydis_core.utils import paste_service
+
 import bot
-from bot.constants import Channels
+from bot.bot import Bot
+from bot.constants import Channels, Emojis
 from bot.exts.filtering._filter_context import Event, FilterContext
 from bot.exts.filtering._filter_lists.filter_list import FilterList, ListType
 from bot.exts.filtering._filters.extension import ExtensionFilter
@@ -20,7 +28,7 @@ PY_EMBED_DESCRIPTION = (
     f"please use a code-pasting service such as {PASTE_URL}"
 )
 
-TXT_LIKE_FILES = {".txt", ".csv", ".json"}
+TXT_LIKE_FILES = {".txt", ".csv", ".json", ".py"}
 TXT_EMBED_DESCRIPTION = (
     "You either uploaded a `{blocked_extension}` file or entered a message that was too long. "
     f"Please use our [paste bin]({PASTE_URL}) instead."
@@ -31,6 +39,9 @@ DISALLOWED_EMBED_DESCRIPTION = (
     "We currently allow the following file types: **{joined_whitelist}**.\n\n"
     "Feel free to ask in {meta_channel_mention} if you think this is a mistake."
 )
+
+PASTEBIN_UPLOAD_EMOJI = Emojis.check_mark
+DELETE_PASTE_EMOJI = Emojis.trashcan
 
 
 class ExtensionsList(FilterList[ExtensionFilter]):
@@ -116,3 +127,80 @@ class ExtensionsList(FilterList[ExtensionFilter]):
         ctx.blocked_exts |= set(not_allowed)
         actions = self[ListType.ALLOW].defaults.actions if ctx.event != Event.SNEKBOX else None
         return actions, [f"`{ext}`" if ext else "`No Extension`" for ext in not_allowed], {ListType.ALLOW: triggered}
+
+
+class EmbedFileHandler(commands.Cog):
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @staticmethod
+    async def _convert_attachment(attachment: discord.Attachment) -> paste_service.PasteFile:
+        encoding = re.search(r"charset=(\S+)", attachment.content_type).group(1)
+        file_content = (await attachment.read()).decode(encoding)
+        return paste_service.PasteFile(content=file_content, name=attachment.filename)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        # Check if the message contains an embedded file and is not sent by a bot
+        if message.author.bot or not message.attachments:
+            return
+
+        bot_reply = await message.reply(f"React with {PASTEBIN_UPLOAD_EMOJI} to upload your file to our paste bin")
+        await bot_reply.add_reaction(PASTEBIN_UPLOAD_EMOJI)
+
+        def wait_for_upload_permission(reaction: discord.Reaction, user: discord.User) -> bool:
+            return (
+                reaction.message.id == bot_reply.id
+                and str(reaction.emoji) == PASTEBIN_UPLOAD_EMOJI
+                and user == message.author
+            )
+
+        try:
+            # Wait for the reaction with a timeout of 60 seconds
+            await self.bot.wait_for("reaction_add", timeout=60.0, check=wait_for_upload_permission)
+        except TimeoutError:
+            await bot_reply.edit(content=f"~~{bot_reply.content}~~")
+            await bot_reply.clear_reactions()
+            return
+
+        logging.info({f.filename: f.content_type for f in message.attachments})
+
+        files = [
+            await self._convert_attachment(f)
+            for f in message.attachments
+            if f.content_type.startswith("text")
+        ]
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                paste_response = await paste_service.send_to_paste_service(files=files, http_session=session)
+        except (paste_service.PasteTooLongError, ValueError):
+            # paste is too long
+            await bot_reply.edit(content="Your paste is too long, and couldn't be uploaded.")
+            return
+        except paste_service.PasteUploadError:
+            await bot_reply.edit(content="There was an error uploading your paste.")
+            return
+
+        # The angle brackets around the remove link are required to stop Discord from visiting the URL to produce a
+        # preview, thereby deleting the paste
+        await message.author.send(content=f"[Click here](<{paste_response.removal}>) to delete your recent paste.")
+
+        await bot_reply.edit(content=f"[Click here]({paste_response.link}) to see this code in our pastebin.")
+        await bot_reply.clear_reactions()
+        await bot_reply.add_reaction(DELETE_PASTE_EMOJI)
+
+        def wait_for_delete_reaction(reaction: discord.Reaction, user: discord.User) -> bool:
+            return (
+                reaction.message.id == bot_reply.id
+                and str(reaction.emoji) == DELETE_PASTE_EMOJI
+                and user == message.author
+            )
+
+        try:
+            await self.bot.wait_for("reaction_add", timeout=60.0 * 10, check=wait_for_delete_reaction)
+            await paste_response.delete()
+            await bot_reply.delete()
+        except TimeoutError:
+            pass

--- a/bot/exts/filtering/_filter_lists/extension.py
+++ b/bot/exts/filtering/_filter_lists/extension.py
@@ -1,17 +1,9 @@
 from __future__ import annotations
 
-import logging
-import re
 import typing
 from os.path import splitext
 
-import aiohttp
-import discord
-from discord.ext import commands
-from pydis_core.utils import paste_service
-
 import bot
-from bot.bot import Bot
 from bot.constants import Channels, Emojis
 from bot.exts.filtering._filter_context import Event, FilterContext
 from bot.exts.filtering._filter_lists.filter_list import FilterList, ListType
@@ -127,80 +119,3 @@ class ExtensionsList(FilterList[ExtensionFilter]):
         ctx.blocked_exts |= set(not_allowed)
         actions = self[ListType.ALLOW].defaults.actions if ctx.event != Event.SNEKBOX else None
         return actions, [f"`{ext}`" if ext else "`No Extension`" for ext in not_allowed], {ListType.ALLOW: triggered}
-
-
-class EmbedFileHandler(commands.Cog):
-
-    def __init__(self, bot: Bot):
-        self.bot = bot
-
-    @staticmethod
-    async def _convert_attachment(attachment: discord.Attachment) -> paste_service.PasteFile:
-        encoding = re.search(r"charset=(\S+)", attachment.content_type).group(1)
-        file_content = (await attachment.read()).decode(encoding)
-        return paste_service.PasteFile(content=file_content, name=attachment.filename)
-
-    @commands.Cog.listener()
-    async def on_message(self, message: discord.Message) -> None:
-        # Check if the message contains an embedded file and is not sent by a bot
-        if message.author.bot or not message.attachments:
-            return
-
-        bot_reply = await message.reply(f"React with {PASTEBIN_UPLOAD_EMOJI} to upload your file to our paste bin")
-        await bot_reply.add_reaction(PASTEBIN_UPLOAD_EMOJI)
-
-        def wait_for_upload_permission(reaction: discord.Reaction, user: discord.User) -> bool:
-            return (
-                reaction.message.id == bot_reply.id
-                and str(reaction.emoji) == PASTEBIN_UPLOAD_EMOJI
-                and user == message.author
-            )
-
-        try:
-            # Wait for the reaction with a timeout of 60 seconds
-            await self.bot.wait_for("reaction_add", timeout=60.0, check=wait_for_upload_permission)
-        except TimeoutError:
-            await bot_reply.edit(content=f"~~{bot_reply.content}~~")
-            await bot_reply.clear_reactions()
-            return
-
-        logging.info({f.filename: f.content_type for f in message.attachments})
-
-        files = [
-            await self._convert_attachment(f)
-            for f in message.attachments
-            if f.content_type.startswith("text")
-        ]
-
-        try:
-            async with aiohttp.ClientSession() as session:
-                paste_response = await paste_service.send_to_paste_service(files=files, http_session=session)
-        except (paste_service.PasteTooLongError, ValueError):
-            # paste is too long
-            await bot_reply.edit(content="Your paste is too long, and couldn't be uploaded.")
-            return
-        except paste_service.PasteUploadError:
-            await bot_reply.edit(content="There was an error uploading your paste.")
-            return
-
-        # The angle brackets around the remove link are required to stop Discord from visiting the URL to produce a
-        # preview, thereby deleting the paste
-        await message.author.send(content=f"[Click here](<{paste_response.removal}>) to delete your recent paste.")
-
-        await bot_reply.edit(content=f"[Click here]({paste_response.link}) to see this code in our pastebin.")
-        await bot_reply.clear_reactions()
-        await bot_reply.add_reaction(DELETE_PASTE_EMOJI)
-
-        def wait_for_delete_reaction(reaction: discord.Reaction, user: discord.User) -> bool:
-            return (
-                reaction.message.id == bot_reply.id
-                and str(reaction.emoji) == DELETE_PASTE_EMOJI
-                and user == message.author
-            )
-
-        try:
-            await self.bot.wait_for("reaction_add", timeout=60.0 * 10, check=wait_for_delete_reaction)
-            await paste_response.delete()
-            await bot_reply.delete()
-        except TimeoutError:
-            pass

--- a/bot/exts/filtering/_filter_lists/filter_list.py
+++ b/bot/exts/filtering/_filter_lists/filter_list.py
@@ -157,10 +157,7 @@ class AtomicList:
         return hash(id(self))
 
 
-T = typing.TypeVar("T", bound=Filter)
-
-
-class FilterList(dict[ListType, AtomicList], typing.Generic[T], FieldRequiring):
+class FilterList[T: Filter](dict[ListType, AtomicList], FieldRequiring):
     """Dispatches events to lists of _filters, and aggregates the responses into a single list of actions to take."""
 
     # Each subclass must define a name matching the filter_list name we're expecting to receive from the database.

--- a/bot/exts/filtering/_settings.py
+++ b/bot/exts/filtering/_settings.py
@@ -5,7 +5,7 @@ import traceback
 from abc import abstractmethod
 from copy import copy
 from functools import reduce
-from typing import Any, NamedTuple, Self, TypeVar
+from typing import Any, NamedTuple, Self
 
 from bot.exts.filtering._filter_context import FilterContext
 from bot.exts.filtering._settings_types import settings_types
@@ -13,13 +13,9 @@ from bot.exts.filtering._settings_types.settings_entry import ActionEntry, Setti
 from bot.exts.filtering._utils import FieldRequiring
 from bot.log import get_logger
 
-TSettings = TypeVar("TSettings", bound="Settings")
-
 log = get_logger(__name__)
 
-_already_warned: set[str] = set()
-
-T = TypeVar("T", bound=SettingsEntry)
+_already_warned = set[str]()
 
 
 def create_settings(
@@ -55,7 +51,7 @@ def create_settings(
     )
 
 
-class Settings(FieldRequiring, dict[str, T]):
+class Settings[T: SettingsEntry](FieldRequiring, dict[str, T]):
     """
     A collection of settings.
 
@@ -69,7 +65,7 @@ class Settings(FieldRequiring, dict[str, T]):
 
     entry_type: type[T]
 
-    _already_warned: set[str] = set()
+    _already_warned = set[str]()
 
     @abstractmethod  # ABCs have to have at least once abstract method to actually count as such.
     def __init__(self, settings_data: dict, *, defaults: Settings | None = None, keep_empty: bool = False):
@@ -104,7 +100,7 @@ class Settings(FieldRequiring, dict[str, T]):
         """Return a dictionary of overrides across all entries."""
         return reduce(operator.or_, (entry.overrides for entry in self.values() if entry), {})
 
-    def copy(self: TSettings) -> TSettings:
+    def copy(self: Self) -> Self:
         """Create a shallow copy of the object."""
         return copy(self)
 

--- a/bot/exts/filtering/filtering.py
+++ b/bot/exts/filtering/filtering.py
@@ -67,6 +67,13 @@ OFFENSIVE_MSG_DELETE_TIME = datetime.timedelta(days=7)
 WEEKLY_REPORT_ISO_DAY = 3  # 1=Monday, 7=Sunday
 
 
+async def _extract_text_file_content(att: discord.Attachment) -> str:
+    """Extract up to the first 30 lines and first 2000 characters (whichever is shorter) of an attachment."""
+    file_lines: list[str] = (await att.read()).decode().splitlines()
+    first_n_lines = "\n".join(file_lines[:30])[:2_000]
+    return f"{att.filename}: {first_n_lines}"
+
+
 class Filtering(Cog):
     """Filtering and alerting for content posted on the server."""
 
@@ -226,7 +233,7 @@ class Filtering(Cog):
         ctx = FilterContext.from_message(Event.MESSAGE, msg, None, self.message_cache)
 
         text_contents = [
-            f"{a.filename}: " + (await a.read()).decode()
+            await _extract_text_file_content(a)
             for a in msg.attachments if a.content_type.startswith("text")
         ]
         if text_contents:

--- a/bot/exts/filtering/filtering.py
+++ b/bot/exts/filtering/filtering.py
@@ -28,6 +28,7 @@ from bot.constants import BaseURLs, Channels, Guild, MODERATION_ROLES, Roles
 from bot.exts.backend.branding._repository import HEADERS, PARAMS
 from bot.exts.filtering._filter_context import Event, FilterContext
 from bot.exts.filtering._filter_lists import FilterList, ListType, ListTypeConverter, filter_list_types
+from bot.exts.filtering._filter_lists.extension import EmbedFileHandler
 from bot.exts.filtering._filter_lists.filter_list import AtomicList
 from bot.exts.filtering._filters.filter import Filter, UniqueFilter
 from bot.exts.filtering._settings import ActionSettings
@@ -1492,3 +1493,4 @@ class Filtering(Cog):
 async def setup(bot: Bot) -> None:
     """Load the Filtering cog."""
     await bot.add_cog(Filtering(bot))
+    await bot.add_cog(EmbedFileHandler(bot))

--- a/bot/exts/filtering/filtering.py
+++ b/bot/exts/filtering/filtering.py
@@ -28,7 +28,6 @@ from bot.constants import BaseURLs, Channels, Guild, MODERATION_ROLES, Roles
 from bot.exts.backend.branding._repository import HEADERS, PARAMS
 from bot.exts.filtering._filter_context import Event, FilterContext
 from bot.exts.filtering._filter_lists import FilterList, ListType, ListTypeConverter, filter_list_types
-from bot.exts.filtering._filter_lists.extension import EmbedFileHandler
 from bot.exts.filtering._filter_lists.filter_list import AtomicList
 from bot.exts.filtering._filters.filter import Filter, UniqueFilter
 from bot.exts.filtering._settings import ActionSettings
@@ -1509,4 +1508,3 @@ class Filtering(Cog):
 async def setup(bot: Bot) -> None:
     """Load the Filtering cog."""
     await bot.add_cog(Filtering(bot))
-    await bot.add_cog(EmbedFileHandler(bot))

--- a/bot/exts/filtering/filtering.py
+++ b/bot/exts/filtering/filtering.py
@@ -68,7 +68,8 @@ WEEKLY_REPORT_ISO_DAY = 3  # 1=Monday, 7=Sunday
 
 async def _extract_text_file_content(att: discord.Attachment) -> str:
     """Extract up to the first 30 lines and first 2000 characters (whichever is shorter) of an attachment."""
-    file_lines: list[str] = (await att.read()).decode().splitlines()
+    file_encoding = re.search(r"charset=(\S+)", att.content_type).group(1)
+    file_lines: list[str] = (await att.read()).decode(encoding=file_encoding).splitlines()
     first_n_lines = "\n".join(file_lines[:30])[:2_000]
     return f"{att.filename}: {first_n_lines}"
 
@@ -233,7 +234,7 @@ class Filtering(Cog):
 
         text_contents = [
             await _extract_text_file_content(a)
-            for a in msg.attachments if a.content_type.startswith("text")
+            for a in msg.attachments if "charset" in a.content_type
         ]
         if text_contents:
             attachment_content = "\n\n".join(text_contents)

--- a/bot/exts/utils/attachment_pastebin_uploader.py
+++ b/bot/exts/utils/attachment_pastebin_uploader.py
@@ -43,7 +43,7 @@ class EmbedFileHandler(commands.Cog):
     async def on_message(self, message: discord.Message) -> None:
         """Listens for messages containing attachments and offers to upload them to the pastebin."""
         # Check if the message contains an embedded file and is not sent by a bot
-        if message.author.bot or not message.attachments:
+        if message.author.bot or not any(a.content_type.startswith("text") for a in message.attachments):
             return
 
         bot_reply = await message.reply(f"React with {PASTEBIN_UPLOAD_EMOJI} to upload your file to our paste bin")
@@ -76,7 +76,6 @@ class EmbedFileHandler(commands.Cog):
             async with aiohttp.ClientSession() as session:
                 paste_response = await paste_service.send_to_paste_service(files=files, http_session=session)
         except (paste_service.PasteTooLongError, ValueError):
-            # paste is too long
             await bot_reply.edit(content="Your paste is too long, and couldn't be uploaded.")
             return
         except paste_service.PasteUploadError:

--- a/bot/exts/utils/attachment_pastebin_uploader.py
+++ b/bot/exts/utils/attachment_pastebin_uploader.py
@@ -92,7 +92,7 @@ class EmbedFileHandler(commands.Cog):
         files = [
             await self._convert_attachment(f)
             for f in message.attachments
-            if f.content_type.startswith("text")
+            if "charset" in f.content_type
         ]
 
         # Upload the files to the paste bin, exiting early if there's an error.

--- a/bot/exts/utils/attachment_pastebin_uploader.py
+++ b/bot/exts/utils/attachment_pastebin_uploader.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import logging
+import re
+
+import aiohttp
+import discord
+from discord.ext import commands
+from pydis_core.utils import paste_service
+
+from bot.bot import Bot
+from bot.constants import Emojis
+
+PASTEBIN_UPLOAD_EMOJI = Emojis.check_mark
+DELETE_PASTE_EMOJI = Emojis.trashcan
+
+
+class EmbedFileHandler(commands.Cog):
+    """
+    Handles automatic uploading of attachments to the paste bin.
+
+    Whenever a user uploads one or more attachments that is text-based (py, txt, csv, etc.), this cog offers to upload
+    all the attachments to the paste bin automatically. The steps are as follows:
+    - The bot replies to the message containing the attachments, asking the user to react with a checkmark to consent
+        to having the content uploaded.
+    - If consent is given, the bot uploads the contents and edits its own message to contain the link.
+    - The bot DMs the user the delete link for the paste.
+    - The bot waits for the user to react with a trashcan emoji, in which case the bot deletes the paste and its own
+        message.
+    """
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+    @staticmethod
+    async def _convert_attachment(attachment: discord.Attachment) -> paste_service.PasteFile:
+        """Converts an attachment to a PasteFile, according to the attachment's file encoding."""
+        encoding = re.search(r"charset=(\S+)", attachment.content_type).group(1)
+        file_content = (await attachment.read()).decode(encoding)
+        return paste_service.PasteFile(content=file_content, name=attachment.filename)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        """Listens for messages containing attachments and offers to upload them to the pastebin."""
+        # Check if the message contains an embedded file and is not sent by a bot
+        if message.author.bot or not message.attachments:
+            return
+
+        bot_reply = await message.reply(f"React with {PASTEBIN_UPLOAD_EMOJI} to upload your file to our paste bin")
+        await bot_reply.add_reaction(PASTEBIN_UPLOAD_EMOJI)
+
+        def wait_for_upload_permission(reaction: discord.Reaction, user: discord.User) -> bool:
+            return (
+                reaction.message.id == bot_reply.id
+                and str(reaction.emoji) == PASTEBIN_UPLOAD_EMOJI
+                and user == message.author
+            )
+
+        try:
+            # Wait for the reaction with a timeout of 60 seconds
+            await self.bot.wait_for("reaction_add", timeout=60.0, check=wait_for_upload_permission)
+        except TimeoutError:
+            await bot_reply.edit(content=f"~~{bot_reply.content}~~")
+            await bot_reply.clear_reactions()
+            return
+
+        logging.info({f.filename: f.content_type for f in message.attachments})
+
+        files = [
+            await self._convert_attachment(f)
+            for f in message.attachments
+            if f.content_type.startswith("text")
+        ]
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                paste_response = await paste_service.send_to_paste_service(files=files, http_session=session)
+        except (paste_service.PasteTooLongError, ValueError):
+            # paste is too long
+            await bot_reply.edit(content="Your paste is too long, and couldn't be uploaded.")
+            return
+        except paste_service.PasteUploadError:
+            await bot_reply.edit(content="There was an error uploading your paste.")
+            return
+
+        # The angle brackets around the remove link are required to stop Discord from visiting the URL to produce a
+        # preview, thereby deleting the paste
+        await message.author.send(content=f"[Click here](<{paste_response.removal}>) to delete your recent paste.")
+
+        await bot_reply.edit(content=f"[Click here]({paste_response.link}) to see this code in our pastebin.")
+        await bot_reply.clear_reactions()
+        await bot_reply.add_reaction(DELETE_PASTE_EMOJI)
+
+        def wait_for_delete_reaction(reaction: discord.Reaction, user: discord.User) -> bool:
+            return (
+                reaction.message.id == bot_reply.id
+                and str(reaction.emoji) == DELETE_PASTE_EMOJI
+                and user == message.author
+            )
+
+        try:
+            await self.bot.wait_for("reaction_add", timeout=60.0 * 10, check=wait_for_delete_reaction)
+            await paste_response.delete()
+            await bot_reply.delete()
+        except TimeoutError:
+            pass
+
+
+async def setup(bot: Bot) -> None:
+    """Load the EmbedFileHandler cog."""
+    await bot.add_cog(EmbedFileHandler(bot))

--- a/bot/exts/utils/snekbox/_cog.py
+++ b/bot/exts/utils/snekbox/_cog.py
@@ -17,7 +17,6 @@ from pydis_core.utils.regex import FORMATTED_CODE_REGEX, RAW_CODE_REGEX
 from bot.bot import Bot
 from bot.constants import BaseURLs, Channels, Emojis, MODERATION_ROLES, Roles, URLs
 from bot.decorators import redirect_output
-from bot.exts.filtering._filter_lists.extension import TXT_LIKE_FILES
 from bot.exts.help_channels._channel import is_help_forum_post
 from bot.exts.utils.snekbox._eval import EvalJob, EvalResult
 from bot.exts.utils.snekbox._io import FileAttachment
@@ -31,6 +30,8 @@ log = get_logger(__name__)
 
 ANSI_REGEX = re.compile(r"\N{ESC}\[[0-9;:]*m")
 ESCAPE_REGEX = re.compile("[`\u202E\u200B]{3,}")
+
+TXT_LIKE_FILES = {".txt", ".csv", ".json", ".py"}
 
 # The timeit command should only output the very last line, so all other output should be suppressed.
 # This will be used as the setup code along with any setup code provided.


### PR DESCRIPTION
This is a work-in-progress intended to allow us to lift the embargo on text file attachments. Whether we use this functionality, or anything like it, is subject to further discussion. I'm submitting it as a draft PR to expose what I've done so far.

Allowing text file attachments is intended to remove friction in making a user's code available to question-answerers during help sessions. If a user uploads their py file, and it's deleted by the bot, the user might become confused and not follow the instructions to use the paste bin. Instructing users on how to use the paste bin can also be grating for question-answerers, especially when they would have been able to read the py file in the file embed that appears in the desktop client, which provides syntax highlighting. 

However, the file embeds do not appear in the mobile version of Discord. Our filtering system also does not consider the content of text-based file attachments. This PR implements a solution for the former and the beginnings of a solution for the latter.

## Offer to auto-upload text attachments to the paste bin
This functionality, which is already fully implemented, is intended to benefit mobile users who can't see the text file embeds, while upholding our promise not to copy user content to an external system (ie, our paste bin) without their permission. It consists of these steps, following a user sending a message containing text attachments:
- The bot replies to the message, asking the user to react with a checkmark to have the attachments automatically uploaded to the paste bin.
- If the user complies within a fixed duration, the bot does so, and replaces its own message with a link to the paste bin.
- The bot DMs the user the delete link for the paste.
- Alternatively, the bot also waits for the user to react with a trashcan emoji, deleting the paste. This option times out, but the delete link sent via DMs does not.

## Apply token filters to text attachments
This one is much trickier. The simplest solution I could think of (after trying a few more complicated ones) is to simply treat the content of text attachments as a continuation of the message itself, though this could make it not-immediately-obvious to moderators when a filter is triggered by an attachment rather than the true message content. We also don't want to waste compute time applying the filters to especially long text attachments (which is relatively likely for CSV and JSON attachments).

We might decide on a constant size limit for text-based attachments and modify the extension filters to consider both the file extension and the size of the file, while also not appending attachment content to the message if the file size exceeds that same constant. We might also not apply the token filter to CSVs and JSONs, since those are usually posted as part of a minimal reproducible example and are probably not intended to be read.