### PR TITLE
Send the log of purged messages to #message-change-log too

### DIFF
--- a/bot/exts/moderation/clean.py
+++ b/bot/exts/moderation/clean.py
@@ -368,14 +368,15 @@ class Clean(Cog):
             f"A log of the deleted messages can be found [here]({log_url})."
         )
 
-        await send_log_message(
-            self.bot,
-            icon_url=Icons.message_bulk_delete,
-            colour=Colour(Colours.soft_red),
-            title="Bulk message delete",
-            text=message,
-            channel_id=Channels.mod_log,
-        )
+        for channel_id in [Channels.mod_log, Channels.message_log]:
+            await send_log_message(
+                self.bot,
+                icon_url=Icons.message_bulk_delete,
+                colour=Colour(Colours.soft_red),
+                title="Bulk message delete",
+                text=message,
+                channel_id=channel_id,
+            )
 
         return log_url
 


### PR DESCRIPTION
Resolves #3055.

I am sending the same message deletion logs currently sent to `#mod-log `to `#message-change-log` as well.

![image](https://github.com/user-attachments/assets/0fc53106-3e13-47f4-8c40-549787247152)
