### PR TITLE
Permit !remindme with no specified content

### DIFF
--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -252,9 +252,9 @@ class Reminders(Cog):
         await self.bot.api_client.delete(f"bot/reminders/{reminder['id']}")
 
     @staticmethod
-    async def try_get_content_from_reply(ctx: Context) -> str | None:
+    async def try_get_content_from_reply(ctx: Context) -> str:
         """
-        Attempts to get content from the referenced message, if applicable.
+        Attempts to get content from the referenced message, if applicable, or provides a default.
 
         Differs from pydis_core.utils.commands.clean_text_or_reply as allows for messages with no content.
         """
@@ -345,9 +345,6 @@ class Reminders(Cog):
         # If `content` isn't provided then we try to get message content of a replied message
         if not content:
             content = await self.try_get_content_from_reply(ctx)
-            if not content:
-                # Couldn't get content from reply
-                return
 
         # Now we can attempt to actually set the reminder.
         reminder = await self.bot.api_client.post(
@@ -469,9 +466,7 @@ class Reminders(Cog):
         """
         if not content:
             content = await self.try_get_content_from_reply(ctx)
-            if not content:
-                # Message doesn't have a reply to get content from
-                return
+
         await self.edit_reminder(ctx, id_, {"content": content})
 
     @edit_reminder_group.command(name="mentions", aliases=("pings",))

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -263,13 +263,9 @@ class Reminders(Cog):
             if isinstance((resolved_message := reference.resolved), discord.Message):
                 content = resolved_message.content
 
-        # If we weren't able to get the content of a replied message
-        if content is None:
-            await send_denial(ctx, "Your reminder must have a content and/or reply to a message.")
-            return None
-
-        # If the replied message has no content (e.g. only attachments/embeds)
-        if content == "":
+        # If the replied message has no content, we couldn't get the content, or no content was provided
+        # (e.g. only attachments/embeds)
+        if content is None or content == "":
             content = "*See referenced message.*"
 
         return content


### PR DESCRIPTION
Change !remindme so that it doesn't fail if it hasn't been provided either text or a reply to copy from. I'm pretty sure I'm not the only person who gets annoyed when the bot wants a placeholder, when really I just want a reference to the current conversation. 

There are no tests for this part, but I don't have time to write them at the moment, hopefully that's okay.