### PR TITLE
Compact doc feature

### DIFF
--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -324,13 +324,21 @@ class DocCog(commands.Cog):
         return embed
 
     async def create_compact_doc_message(self, symbols: list[str]) -> str:
-        """Create a markdown bullet list of links to docs for the given list of symbols."""
+        """
+        Create a markdown bullet list of links to docs for the given list of symbols.
+
+        Link to at most 10 items, ignoring the rest.
+        """
         items = await self._get_symbols_items(symbols)
         content = ""
+        link_count = 0
         for symbol_name, doc_item in items:
+            if link_count >= 10:
+                break
             if doc_item is None:
                 log.debug(f"{symbol_name=} does not exist.")
             else:
+                link_count += 1
                 content += f"- [{discord.utils.escape_markdown(symbol_name)}](<{doc_item.url}#{doc_item.symbol_id}>)\n"
 
         return content

--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -281,7 +281,7 @@ class DocCog(commands.Cog):
         # Ensure a refresh can't run in case of a context switch until the with block is exited
         with self.symbol_get_event:
             items: list[tuple[str, DocItem | None]] = []
-            for symbol_name in symbols:
+            for symbol_name in set(symbols):
                 symbol_name, doc_item = self.get_symbol_item(symbol_name)
                 if doc_item:
                     items.append((symbol_name, doc_item))


### PR DESCRIPTION
As per @decorator-factory 's suggestion:
> `!d` provides a pretty huge embed that takes a lot of space, and you need to post a message for each documentation entry. I almost always click the docs link anyway, because the text gets cut off for all but the most trivial items.
> It's common for gaming communities on Reddit to have a bot that scans messages for specially formatted mentions of items and gives some very brief information on all of them (and most importantly a documentation link) in a single message: see screenshot. I think it would be pretty cool to be able to type something like
>
> > You'll need to use `[[zip]]` or `[[itertools.zip_longest]]`
>
> and have the bot reply with a _compact_ message linking to the documentation, like: 
>
> > - [`zip(*iterables, strict=False)`](<https://docs.python.org/3/library/functions.html#zip>)
> > - [`itertools.zip_longest(*iterables, fillvalue=None)`](<https://docs.python.org/3/library/itertools.html#itertools.zip_longest>)
> 

- [Link to discussion thread](https://discord.com/channels/267624335836053506/1326336848636936265)

This PR implements the feature described, and also reacts to message edits and edits the bot's response.