### PR TITLE
Zen slicing

### DIFF
--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -111,7 +111,7 @@ class Utils(Cog):
         zen_lines = ZEN_OF_PYTHON.splitlines()
 
         # Prioritize checking for an index or slice
-        match = re.search(r"^(\d+)(:\d+)?", search_value.split(" ")[0])
+        match = re.match(r"(-?\d+)(:-?\d+)?", search_value.split(" ")[0])
         if match:
             upper_bound = len(zen_lines) - 1
             lower_bound = -1 * len(zen_lines)

--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -128,7 +128,7 @@ class Utils(Cog):
 
             end_index=int(match.group(2)[1:])
 
-            if not ((lower_bound <= start_index <= upper_bound) and (lower_bound <= end_index <= upper_bound)):
+            if not ((lower_bound <= start_index <= upper_bound) and (lower_bound <= end_index <= len(zen_lines))):
                 raise BadArgument(f"Please provide valid indices between {lower_bound} and {upper_bound}.")
             if not (start_index % len(zen_lines) < end_index % len(zen_lines)):
                 raise BadArgument("The start index for the slice must be smaller than the end index.")

--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -133,7 +133,7 @@ class Utils(Cog):
             if not (start_index % len(zen_lines) < end_index % (len(zen_lines) + 1)):
                 raise BadArgument("The start index for the slice must be smaller than the end index.")
 
-            embed.title += f" (lines {start_index%len(zen_lines)}-{end_index%len(zen_lines)}):"
+            embed.title += f" (lines {start_index%len(zen_lines)}-{(end_index-1)%len(zen_lines)}):"
             embed.description = "\n".join(zen_lines[start_index:end_index])
             await ctx.send(embed=embed)
             return

--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -111,7 +111,7 @@ class Utils(Cog):
         zen_lines = ZEN_OF_PYTHON.splitlines()
 
         # Prioritize checking for an index or slice
-        match = re.match(r"(-?\d+)(:-?\d+)?", search_value.split(" ")[0])
+        match = re.match(r"(-?\d+)(:(-?\d+)?)?", search_value.split(" ")[0])
         if match:
             upper_bound = len(zen_lines) - 1
             lower_bound = -1 * len(zen_lines)
@@ -126,7 +126,7 @@ class Utils(Cog):
                 await ctx.send(embed=embed)
                 return
 
-            end_index=int(match.group(2)[1:])
+            end_index=  int(match.group(3)) if match.group(3) else len(zen_lines)
 
             if not ((lower_bound <= start_index <= upper_bound) and (lower_bound <= end_index <= len(zen_lines))):
                 raise BadArgument(f"Please provide valid indices between {lower_bound} and {upper_bound}.")

--- a/bot/exts/utils/utils.py
+++ b/bot/exts/utils/utils.py
@@ -130,7 +130,7 @@ class Utils(Cog):
 
             if not ((lower_bound <= start_index <= upper_bound) and (lower_bound <= end_index <= len(zen_lines))):
                 raise BadArgument(f"Please provide valid indices between {lower_bound} and {upper_bound}.")
-            if not (start_index % len(zen_lines) < end_index % len(zen_lines)):
+            if not (start_index % len(zen_lines) < end_index % (len(zen_lines) + 1)):
                 raise BadArgument("The start index for the slice must be smaller than the end index.")
 
             embed.title += f" (lines {start_index%len(zen_lines)}-{end_index%len(zen_lines)}):"

--- a/tests/bot/exts/utils/test_utils.py
+++ b/tests/bot/exts/utils/test_utils.py
@@ -1,0 +1,90 @@
+import unittest
+
+from discord import Colour, Embed
+from discord.ext.commands import BadArgument
+
+from bot.exts.utils.utils import Utils, ZEN_OF_PYTHON
+from tests.helpers import MockBot, MockContext
+
+
+class ZenTests(unittest.IsolatedAsyncioTestCase):
+    """ Tests for the `!zen` command. """
+
+
+    def setUp(self):
+        self.bot = MockBot()
+        self.cog = Utils(self.bot)
+        self.ctx = MockContext()
+
+        self.zen_list = ZEN_OF_PYTHON.splitlines()
+        self.template_embed = Embed(colour=Colour.og_blurple(), title="The Zen of Python", description=ZEN_OF_PYTHON)
+
+
+
+    async def test_zen_without_arguments(self):
+        """ Tests if the `!zen` command reacts properly to no arguments. """
+        self.template_embed.title += ", by Tim Peters"
+
+
+        await self.cog.zen.callback(self.cog,self.ctx, search_value = None)
+        self.ctx.send.assert_called_once_with(embed=self.template_embed)
+
+    async def test_zen_with_valid_index(self):
+        """ Tests if the `!zen` command reacts properly to a valid index as an argument. """
+        expected_results = {
+            0: ("The Zen of Python (line 0):", "Beautiful is better than ugly."),
+            10: ("The Zen of Python (line 10):", "Unless explicitly silenced."),
+            18: ("The Zen of Python (line 18):", "Namespaces are one honking great idea -- let's do more of those!"),
+            -1: ("The Zen of Python (line 18):", "Namespaces are one honking great idea -- let's do more of those!"),
+            -10: ("The Zen of Python (line 9):", "Errors should never pass silently."),
+            -19: ("The Zen of Python (line 0):", "Beautiful is better than ugly.")
+
+        }
+
+        for index, (title, description) in expected_results.items():
+            self.template_embed.title =  title
+            self.template_embed.description = description
+            ctx = MockContext()
+            with self.subTest(index = index, expected_title=title, expected_description = description):
+                await self.cog.zen.callback(self.cog, ctx, search_value = str(index))
+                ctx.send.assert_called_once_with(embed = self.template_embed)
+
+
+
+    async def test_zen_with_invalid_index(self):
+        """ Tests if the `!zen` command reacts properly to an out-of-bounds index as an argument. """
+        # Negative index
+        with self.subTest(index = -20), self.assertRaises(BadArgument):
+            await self.cog.zen.callback(self.cog, self.ctx, search_value="-20")
+
+        # Positive index
+        with self.subTest(index = len(ZEN_OF_PYTHON)), self.assertRaises(BadArgument):
+            await self.cog.zen.callback(self.cog, self.ctx, search_value=str(len(ZEN_OF_PYTHON)))
+
+    async def test_zen_with_valid_slices(self):
+        """ Tests if the `!zen` command reacts properly to valid slices for indexing as an argument. """
+
+        expected_results = {
+            "0:19": ("The Zen of Python (lines 0-18):", "\n".join(self.zen_list[0:19])),
+            "0:": ("The Zen of Python (lines 0-18):", "\n".join(self.zen_list[0:])),
+            "-2:-1": ("The Zen of Python (lines 17-17):", self.zen_list[17]),
+            "0:-1": ("The Zen of Python (lines 0-17):", "\n".join(self.zen_list[0:-1])),
+            "10:13": ("The Zen of Python (lines 10-12):", "\n".join(self.zen_list[10:13]))
+        }
+
+        for input_slice, (title, description) in expected_results.items():
+            self.template_embed.title = title
+            self.template_embed.description = description
+
+            ctx = MockContext()
+            with self.subTest(input_slice=input_slice, expected_title=title, expected_description=description):
+                await self.cog.zen.callback(self.cog, ctx, search_value=input_slice)
+                ctx.send.assert_called_once_with(embed = self.template_embed)
+
+    async def test_zen_with_invalid_slices(self):
+        """ Tests if the `!zen` command reacts properly to invalid slices for indexing as an argument. """
+        slices= ["19:", "10:9", "-1:-2", "0:20", "-100:", "0:-100"]
+
+        for input_slice in slices:
+            with self.subTest(input_slice = input_slice), self.assertRaises(BadArgument):
+                await self.cog.zen.callback(self.cog, self.ctx, search_value=input_slice)


### PR DESCRIPTION
Implemented the feature in issue #3289.

Now, the `!zen` command accepts arguments in the form `start:stop`, and will return the corresponding zen lines.
Additionally, since the indices can now no longer simply be passed as integers, the `zen_rule_index` argument to the zen command was removed, and now indices are parsed from a regex expression.