### PR TITLE
Display selected lines from our pastebin as codeblock

### DIFF
--- a/bot/exts/info/code_snippets.py
+++ b/bot/exts/info/code_snippets.py
@@ -178,7 +178,7 @@ class CodeSnippets(Cog):
         )
         return self._snippet_to_codeblock(file_contents, file_path, start_line, end_line)
 
-    async def _fetch_pastebin_snippets(self, paste_id: str, selections: str) -> str:
+    async def _fetch_pastebin_snippets(self, paste_id: str, selections: str) -> list[str]:
         """Fetches snippets from paste.pythondiscord.com."""
         paste_data = await self._fetch_response(
             f"https://paste.pythondiscord.com/api/v1/paste/{paste_id}",


### PR DESCRIPTION
Closes #2679 

This PR adds support for paste.pythondiscord.com /paste.pydis.wtf paste links to the CodeSnippets cog.
The pastebin we use supports selecting lines across multiple files, which, AFAIK, the other services in this cog don't support. 

![image](https://github.com/user-attachments/assets/23b688a2-d73e-40a7-926e-a20b7abce965)


Note: When selecting only a single line, the website generates the link as: https://paste.pythondiscord.com/EMJQ#1L2-L2. Technically, a link like https://paste.pythondiscord.com/EMJQ#1L2 is also valid, but it would need to be manually typed by the user that way. Links in this format will not be displayed as codeblocks since unlikely that someone will send such a link.