### PR TITLE
Non-staff rule usage alert

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -89,6 +89,8 @@ class _Channels(EnvConfig, env_prefix="channels_"):
     incidents: int = 714214212200562749
     incidents_archive: int = 720668923636351037
     mod_alerts: int = 473092532147060736
+    # Actually a thread, but for bootstrap purposes we treat it as a channel
+    rule_alerts: int = 1386490058739290182
     mod_meta: int = 775412552795947058
     mods: int = 305126844661760000
     nominations: int = 822920136150745168

--- a/tests/bot/exts/info/test_information.py
+++ b/tests/bot/exts/info/test_information.py
@@ -599,6 +599,9 @@ class RuleCommandTests(unittest.IsolatedAsyncioTestCase):
             )
         ]
         self.bot.api_client.get.return_value = self.full_rules
+        # Patch get_channel to handle the rule alerts being sent to a thread for non-staff (as our mock user is).
+        self.bot.get_channel.return_value = helpers.MockTextChannel(id=50, name="rules")
+
 
     async def test_return_none_if_one_rule_number_is_invalid(self):
 


### PR DESCRIPTION
Adds an alert within a Moderator+ channel whenever a non-staff member (user without the Helpers role) uses the `!rule` command.

![image](https://github.com/user-attachments/assets/e87899ce-1459-446e-b30e-91f4a84c5f5f)

Feature implemented as discussed in `#mod-meta` with Moderators.