### PR TITLE
Delete automated infraction messages after a period of time

### DIFF
--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -122,7 +122,7 @@ class InfractionScheduler:
         except discord.NotFound:
             log.warning(f"Channel or message {message_id} not found in channel {channel_id}.")
         except discord.Forbidden:
-            log.warning(f"Bot lacks permissions to delete message {message_id} in channel {channel_id}.")
+            log.info(f"Bot lacks permissions to delete message {message_id} in channel {channel_id}.")
         except discord.HTTPException:
             log.exception(f"Issue during scheduled deletion of message {message_id} in channel {channel_id}.")
             return  # Keep the task in Redis on HTTP errors


### PR DESCRIPTION
This PR automatically deletes messages generated by the bot as part of dealing out automated infractions (e.g. spam filters). These have a habit of filling up channels which are frequently abused but have low traffic otherwise (some channels appear as just a wall of automated infractions).

As of now, the timer is set to 8 hours, though we can increase this if we feel we need the longer persistence (though obviously the full record and log is still preserved in the #mod-alerts channel).

Deletion times are persisted to Redis to ensure we try to delete stuff after the bot restarts.

Closes #2317.