### PR TITLE
Moderator changes minor refactor

### DIFF
--- a/bot/exts/info/information.py
+++ b/bot/exts/info/information.py
@@ -691,7 +691,10 @@ class Information(Cog):
 
         if constants.Roles.helpers not in {role.id for role in ctx.author.roles}:
             # If the user is not a helper, send an alert to the rules thread.
-            await self._send_rules_alert(ctx, sorted_rules)
+            #
+            # Exclude the bot commands channel to avoid spamming it with alerts.
+            if ctx.channel.id != constants.Channels.bot_commands:
+                await self._send_rules_alert(ctx, sorted_rules)
 
         await LinePaginator.paginate(final_rules, ctx, rules_embed, max_lines=3)
 

--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -12,7 +12,6 @@ from async_rediscache import RedisCache
 from discord.ext.commands import Context
 from pydis_core.site_api import ResponseCodeError
 from pydis_core.utils import scheduling
-from pydis_core.utils.channel import get_or_fetch_channel
 
 from bot import constants
 from bot.bot import Bot
@@ -115,9 +114,9 @@ class InfractionScheduler:
         This is used to delete infraction messages after a certain period of time.
         """
         try:
-            channel = await get_or_fetch_channel(self.bot, channel_id)
-            message = await channel.fetch_message(message_id)
-            await message.delete()
+            partial_channel = self.bot.get_partial_messageable(channel_id)
+            partial_message = partial_channel.get_partial_message(message_id)
+            await partial_message.delete()
             log.trace(f"Deleted infraction message {message_id} in channel {channel_id}.")
         except discord.NotFound:
             log.warning(f"Channel or message {message_id} not found in channel {channel_id}.")

--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -321,7 +321,8 @@ class InfractionScheduler:
         mentions = discord.AllowedMentions(users=[user], roles=False)
         sent_msg = await ctx.send(f"{dm_result}{confirm_msg}{infr_message}.", allowed_mentions=mentions)
 
-        if infraction["actor"] == self.bot.user.id:
+        # Only tidy up bot issued infractions in non-mod channels.
+        if infraction["actor"] == self.bot.user.id and not is_mod_channel(ctx.channel):
             expire_message_time = datetime.now(UTC) + timedelta(hours=AUTOMATED_TIDY_UP_HOURS)
 
             log.trace(f"Scheduling message tidy for infraction #{id_} in {AUTOMATED_TIDY_UP_HOURS} hours.")


### PR DESCRIPTION
Refactors some items from #3339 and #3338.

- Use partial objects to avoid unnecessary API calls when tidying up infraction messages
  - I hadn't noticed the partial functions when I went on my hunt, I was working under the assumption I'd have to hook into the HTTP stuff or create my own partials, but this is much cleaner and cheaper.
- Don't tidy-up infractions outside mod channels (ensures that infractions issued by the bot automatically in mod-alerts stay as part of the context)
- Exclude the bot-commands channel from the `!rule` usage alerts.