### PR TITLE
Preserve Invocation Context

### DIFF
--- a/bot/exts/utils/snekbox/_cog.py
+++ b/bot/exts/utils/snekbox/_cog.py
@@ -450,7 +450,18 @@ class Snekbox(Cog):
                 )
             else:
                 # The command was redirected so a reply wont work, send a normal message with a mention.
-                msg = f"{ctx.author.mention} {msg}"
+                try:
+                    paste_response = await send_to_paste_service(
+                        files=[PasteFile(content=ctx.message.content, lexer="markdown")],
+                        http_session=self.bot.http_session,
+                        paste_url=BaseURLs.paste_url,
+                    )
+                    paste_link = paste_response.link
+                    msg = f"Here's the output of your command\n{paste_link}:\n{msg}"
+                except paste_service.PasteUploadError:
+                    # Fallback if paste service fails
+                    msg = f"{ctx.author.mention} {msg}"
+                    log.warning("Pastebin Upload Error")
                 response = await ctx.send(msg, allowed_mentions=allowed_mentions, view=view, files=files)
             view.message = response
 


### PR DESCRIPTION
Fix for #3376 
Added:
- Whenever a user sends a !eval command in a non-snekbox channel the redirect will include the original invocation command.