### PR TITLE
Lower level of log about missing channel to info

### DIFF
--- a/bot/exts/moderation/infraction/_scheduler.py
+++ b/bot/exts/moderation/infraction/_scheduler.py
@@ -121,7 +121,7 @@ class InfractionScheduler:
             await partial_message.delete()
             log.trace(f"Deleted infraction message {message_id} in channel {channel_id}.")
         except discord.NotFound:
-            log.warning(f"Channel or message {message_id} not found in channel {channel_id}.")
+            log.info(f"Channel or message {message_id} not found in channel {channel_id}.")
         except discord.Forbidden:
             log.info(f"Bot lacks permissions to delete message {message_id} in channel {channel_id}.")
         except discord.HTTPException as e:


### PR DESCRIPTION
If e.g. a moderator deleted it already this is expected so no need for a sentry alert.

Fixes BOT-42T (https://python-discord.sentry.io/issues/6744668701/)