### PR TITLE
Fix incorrect variable used in mentions logic

### DIFF
--- a/bot/exts/filtering/_filters/antispam/mentions.py
+++ b/bot/exts/filtering/_filters/antispam/mentions.py
@@ -68,8 +68,8 @@ class MentionsFilter(UniqueFilter):
                     # that is both not in the cache, and deleted while running this function.
                     # In such a situation, this will throw an error which we catch.
                     try:
-                        resolved = await bot.instance.get_partial_messageable(resolved.channel_id).fetch_message(
-                            resolved.message_id
+                        resolved = await bot.instance.get_partial_messageable(ref.channel_id).fetch_message(
+                            ref.message_id
                         )
                     except NotFound:
                         log.info("Could not fetch the reference message as it has been deleted.")


### PR DESCRIPTION
resolved is always None here, as the logic is for the case when resolved is None. Instead we want to use the channel and message ID from ref directly, which are always defined here.

Closes https://github.com/python-discord/bot/issues/3374