### PR TITLE
fix: don't upload attachments in dms

### DIFF
--- a/bot/exts/utils/attachment_pastebin_uploader.py
+++ b/bot/exts/utils/attachment_pastebin_uploader.py
@@ -77,7 +77,7 @@ class AutoTextAttachmentUploader(commands.Cog):
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:
         """Listens for messages containing attachments and offers to upload them to the pastebin."""
-        # Check if the message contains an embedded file and is not sent by a bot.
+        # Check if the message contains an embedded file and is not sent by a bot or in DMs.
         if message.author.bot or not message.guild or not any("charset" in a.content_type for a in message.attachments):
             return
 


### PR DESCRIPTION
closes GH-3403