### PR TITLE
Provide context when dming delete link from paste uploader

### DIFF
--- a/bot/exts/utils/attachment_pastebin_uploader.py
+++ b/bot/exts/utils/attachment_pastebin_uploader.py
@@ -129,8 +129,8 @@ class AutoTextAttachmentUploader(commands.Cog):
         # The angle brackets around the remove link are required to stop Discord from visiting the URL to produce a
         # preview, thereby deleting the paste
         await message.author.send(
-                    f"[Click here](<{paste_response.removal}>) to delete the pasted attachment"
-                    f" contents copied from [your message](<{message.jump_url}>)"
+            f"[Click here](<{paste_response.removal}>) to delete the pasted attachment"
+            f" contents copied from [your message](<{message.jump_url}>)"
         )
 
         # Edit the bot message to contain the link to the paste.


### PR DESCRIPTION
Closes #3422 
Changes the response the bot gives to delete a paste in DM's when a user uploads a file.