### PR TITLE
Ignore intersphinx std:doc objects from DocItem generation

### DIFF
--- a/bot/exts/info/doc/_cog.py
+++ b/bot/exts/info/doc/_cog.py
@@ -26,6 +26,11 @@ from ._inventory_parser import InvalidHeaderError, InventoryDict, fetch_inventor
 
 log = get_logger(__name__)
 
+# groups to ignore from parsing
+IGNORE_GROUPS = (
+    "std:doc",
+)
+
 # symbols with a group contained here will get the group prefixed on duplicates
 FORCE_PREFIX_GROUPS = (
     "term",
@@ -80,6 +85,8 @@ class DocCog(commands.Cog):
 
         for group, items in inventory.items():
             for symbol_name, relative_doc_url in items:
+                if group in IGNORE_GROUPS:
+                    continue
 
                 # e.g. get 'class' from 'py:class'
                 group_name = group.split(":")[1]


### PR DESCRIPTION
These items caused issues that led to spam in the #dev-log channel about stale inventories (though inventories were not stale).

All std:doc items are accompanied by a module item or a label item that contains actual contents that are compatible with our doc command, so hopefully ignoring these items will not cause any reduced functionality of the command.

When testing locally this removes all symbols with empty symbol IDs and stops the warning spam to #dev-log.