### PR TITLE
Require confirmation before kicking elevated user

### DIFF
--- a/bot/exts/moderation/infraction/_views.py
+++ b/bot/exts/moderation/infraction/_views.py
@@ -6,16 +6,16 @@ from discord.ui import Button
 from pydis_core.utils import interactions
 
 
-class BanConfirmationView(interactions.ViewWithUserAndRoleCheck):
+class InfractionConfirmationView(interactions.ViewWithUserAndRoleCheck):
     """A confirmation view to be sent before issuing potentially suspect infractions."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.confirmed = False
 
-    @discord.ui.button(label="Ban", style=ButtonStyle.red)
+    @discord.ui.button(label="Infract", style=ButtonStyle.red)
     async def confirm(self, interaction: Interaction, button: Button) -> None:
-        """Callback coroutine that is called when the "Ban" button is pressed."""
+        """Callback coroutine that is called when the "Infract" button is pressed."""
         self.confirmed = True
         await interaction.response.defer()
         self.stop()

--- a/bot/exts/moderation/infraction/infractions.py
+++ b/bot/exts/moderation/infraction/infractions.py
@@ -427,6 +427,9 @@ class Infractions(InfractionScheduler, commands.Cog):
             await ctx.send(":x: I can't kick users above or equal to me in the role hierarchy.")
             return
 
+        if not await _utils.confirm_elevated_user_infraction(ctx, user):
+            return
+
         infraction = await _utils.post_infraction(ctx, user, "kick", reason, active=False, **kwargs)
         if infraction is None:
             return
@@ -459,7 +462,7 @@ class Infractions(InfractionScheduler, commands.Cog):
             await ctx.send(":x: I can't ban users above or equal to me in the role hierarchy.")
             return None
 
-        if not await _utils.confirm_elevated_user_ban(ctx, user):
+        if not await _utils.confirm_elevated_user_infraction(ctx, user):
             return None
 
         # In the case of a permanent ban, we don't need get_active_infractions to tell us if one is active


### PR DESCRIPTION
This was already the case when attempting to ban an elevated user, but kicks have almost the same consequences (e.g. loss of roles), so we should prevent it in that case, too.