### PR TITLE
Add user-facing message when deprecated cban alias is used

### DIFF
--- a/bot/exts/backend/error_handler.py
+++ b/bot/exts/backend/error_handler.py
@@ -103,6 +103,12 @@ class ErrorHandler(Cog):
             # All errors from attempting to execute these commands should be handled by the error handler.
             # We wrap non CommandErrors in CommandInvokeError to mirror the behaviour of normal commands.
             try:
+                if ctx.invoked_with == "cban":
+                    await ctx.send(
+                        "The `cban` alias was removed because of ambiguity (see #3458). "
+                        "Did you mean `cleanban` or `compban`?"
+                    )
+                    return
                 if await self.try_silence(ctx):
                     return
                 if await self.try_run_fixed_codeblock(ctx):


### PR DESCRIPTION
This adds a helpful response when users attempt to use the deprecated `cban`
alias, explaining why it was removed and suggesting the correct alternatives
(`cleanban` or `compban`).

This should reduce confusion, especially for long-time moderators.