### PR TITLE
Add self-assignable role "Aspiring Contributors"

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -141,6 +141,7 @@ class _Roles(EnvConfig, env_prefix="roles_"):
     pyweek_announcements: int = 897568414044938310
     revival_of_code: int = 988801794668908655
     archived_channels_access: int = 1074780483776417964
+    aspiring_contributors: int = 1496224728686268657
 
     contributors: int = 295488872404484098
     python_community: int = 458226413825294336

--- a/bot/exts/info/subscribe.py
+++ b/bot/exts/info/subscribe.py
@@ -29,6 +29,7 @@ ASSIGNABLE_ROLES = (
     AssignableRole(constants.Roles.lovefest),
     AssignableRole(constants.Roles.advent_of_code),
     AssignableRole(constants.Roles.revival_of_code),
+    AssignableRole(constants.Roles.aspiring_contributors),
 )
 
 ITEMS_PER_ROW = 3


### PR DESCRIPTION
This is meant to limit the noise in #dev-contrib, see https://discord.com/channels/267624335836053506/1474753384224657472 and https://discord.com/channels/267624335836053506/839162966519447552/1475118188172677333.