### PR TITLE
Fix `AttributeError` when reminder `jump_url` is `None`

### DIFF
--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -383,11 +383,15 @@ class Reminders(Cog):
             mentionable.mention async for mentionable in self.get_mentionables(reminder["mentions"])
         ])
 
-        jump_url = reminder.get("jump_url")
-        embed.description += f"\n[Jump back to when you created the reminder]({jump_url})"
-        partial_message = channel.get_partial_message(int(jump_url.split("/")[-1]))
+        jump_url = reminder.get("jump_url") or ""
+        if jump_url:
+            embed.description += f"\n[Jump back to when you created the reminder]({jump_url})"
+        partial_message = channel.get_partial_message(int(jump_url.split("/")[-1])) if jump_url else None
         try:
-            await partial_message.reply(content=f"{additional_mentions}", embed=embed)
+            if partial_message:
+                await partial_message.reply(content=f"{additional_mentions}", embed=embed)
+            else:
+                await channel.send(content=f"<@{reminder['author']}> {additional_mentions}", embed=embed)
         except discord.HTTPException as e:
             log.info(
                 f"There was an error when trying to reply to a reminder invocation message, {e}, "


### PR DESCRIPTION
`send_reminder` crashes with an `AttributeError` when `jump_url` is `None`. This can happen for older reminders created before the field was added to the API.

`reminder.get("jump_url")` returns `None` if the key is absent, but `.split()` was being called on it unconditionally, which causes the reminder to never be delivered.

This fix guards against `None` before calling `.split()` and skips the jump URL embed line if there's no URL, falling back to a plain `channel.send` instead.