### PR TITLE
Fix `AttributeError` in `log_uncached_deleted_message` when channel is `None`

### DIFF
--- a/bot/exts/moderation/modlog.py
+++ b/bot/exts/moderation/modlog.py
@@ -589,6 +589,9 @@ class ModLog(Cog, name="ModLog"):
             return
 
         channel = self.bot.get_channel(event.channel_id)
+        if channel is None:
+            log.trace(f"Channel {event.channel_id} not found, skipping uncached message delete log.")
+            return
 
         if channel.category:
             response = (


### PR DESCRIPTION
`self.bot.get_channel()` can return `None` if the channel isn't in the bot's cache, but `channel.category` was being accessed immediately after with no None check, causing an `AttributeError`.

This is particularly impactful because `log_uncached_deleted_message` is called for every deleted message that isn't in the cache, which on a large server happens constantly. Every one of those events would silently crash the handler instead of logging.

Added an early return with a trace log if the channel can't be found, matching the pattern used elsewhere in the codebase.