### PR TITLE
Fix false error message when deleting reminders with duplicate IDs

### DIFF
--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -678,7 +678,7 @@ class Reminders(Cog):
             title = random.choice(POSITIVE_REPLIES)
             deletion_message = f"Successfully deleted the following reminder(s): {', '.join(deleted_ids)}"
 
-            if len(deleted_ids) != len(ids):
+            if len(deleted_ids) != len(set(ids)):
                 deletion_message += (
                     "\n\nThe other reminder(s) could not be deleted as they're either locked, "
                     "belong to someone else, or don't exist."


### PR DESCRIPTION
When running `!remind delete` with duplicate IDs (e.g. `!remind delete 123 123 123`), the reminder is deleted successfully but the bot incorrectly shows "The other reminder(s) could not be deleted as they're either locked, belong to someone else, or don't exist."

This happens because the check compares `len(deleted_ids)` against `len(ids)`, but the loop iterates over `set(ids)` to deduplicate. So passing 3 identical IDs results in 1 deletion but `len(ids)` is still 3, making it look like 2 failed.

Fixed by comparing against `len(set(ids))` instead, which matches what was actually attempted.