### PR TITLE
Fix silent placeholder when editing reminder content with empty reply

### DIFF
--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -678,7 +678,7 @@ class Reminders(Cog):
             title = random.choice(POSITIVE_REPLIES)
             deletion_message = f"Successfully deleted the following reminder(s): {', '.join(deleted_ids)}"
 
-            if len(deleted_ids) != len(ids):
+            if len(deleted_ids) != len(set(ids)):
                 deletion_message += (
                     "\n\nThe other reminder(s) could not be deleted as they're either locked, "
                     "belong to someone else, or don't exist."

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -493,6 +493,8 @@ class Reminders(Cog):
         # If `content` isn't provided then we try to get message content of a replied message
         if not content:
             content = await self.try_get_content_from_reply(ctx)
+            if content is None:
+                return
 
         # Now we can attempt to actually set the reminder.
         reminder = await self.bot.api_client.post(

--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -413,7 +413,8 @@ class Reminders(Cog):
         # If the replied message has no content, we couldn't get the content, or no content was provided
         # (e.g. only attachments/embeds)
         if content is None or content == "":
-            content = "*See referenced message.*"
+            await ctx.send("The referenced message has no content, please provide content directly.")
+            return None
 
         return content
 
@@ -614,6 +615,8 @@ class Reminders(Cog):
         """
         if not content:
             content = await self.try_get_content_from_reply(ctx)
+            if content is None:
+                return
 
         await self.edit_reminder(ctx, id_, {"content": content})
 


### PR DESCRIPTION
When running `!remind edit content <id>` while replying to a message with no text content (e.g. an image-only message), the bot silently sets the reminder content to `*See referenced message.*` and confirms "That reminder has been edited successfully!" — giving the user no indication their content was replaced with a useless placeholder.

When the reminder fires, the user just gets pinged with `*See referenced message.*` and has no idea what they were supposed to remember.

Fixed by returning `None` from `try_get_content_from_reply` when the referenced message has no content, sending an error message to the user, and returning early from `edit_reminder_content` so the edit never goes through.