### PR TITLE
Detect More Faulty Codeblocks

### DIFF
--- a/bot/exts/info/codeblock/_parsing.py
+++ b/bot/exts/info/codeblock/_parsing.py
@@ -182,7 +182,7 @@ def parse_bad_language(content: str) -> BadLanguage | None:
     )
 
 
-def _get_leading_spaces(content: str) -> int:
+def _get_leading_spaces(content: str) -> int | None:
     """Return the number of spaces at the start of the first line in `content`."""
     leading_spaces = 0
     for char in content:
@@ -190,6 +190,7 @@ def _get_leading_spaces(content: str) -> int:
             leading_spaces += 1
         else:
             return leading_spaces
+
     return None
 
 

--- a/bot/exts/info/codeblock/_parsing.py
+++ b/bot/exts/info/codeblock/_parsing.py
@@ -35,11 +35,11 @@ _RE_CODE_BLOCK = re.compile(
     fr"""
     (?P<ticks>
         (?P<tick>[{''.join(_TICKS)}]) # Put all ticks into a character class within a group.
-        \2{{2}}                       # Match previous group 2 more times to ensure the same char.
+        \2*                           # Match previous group up to N more times to ensure the same char.
     )
-    (?P<lang>[A-Za-z0-9\+\-\.]+\n)?   # Optionally match a language specifier followed by a newline.
+    (?P<lang>[A-Za-z0-9+\-.]+\s)?     # Optionally match a language specifier followed by a whitespace.
     (?P<code>.+?)                     # Match the actual code within the block.
-    \1                                # Match the same 3 ticks used at the start of the block.
+    \1                                # Match the same N ticks used at the start of the block.
     """,
     re.DOTALL | re.VERBOSE
 )
@@ -86,9 +86,9 @@ def find_code_blocks(message: str) -> Sequence[CodeBlock] | None:
     for match in _RE_CODE_BLOCK.finditer(message):
         # Used to ensure non-matched groups have an empty string as the default value.
         groups = match.groupdict("")
-        language = groups["lang"].strip()  # Strip the newline cause it's included in the group.
+        language = groups["lang"].strip()  # Strip the whitespace cause it's included in the group.
 
-        if groups["tick"] == BACKTICK and language:
+        if groups["tick"] == BACKTICK and len(groups["ticks"]) == 3 and language and ("\n" in groups["lang"]):
             log.trace("Message has a valid code block with a language; returning None.")
             return None
         if has_lines(groups["code"], constants.CodeBlock.minimum_lines):

--- a/bot/exts/info/codeblock/_parsing.py
+++ b/bot/exts/info/codeblock/_parsing.py
@@ -91,6 +91,7 @@ def find_code_blocks(message: str) -> Sequence[CodeBlock] | None:
         if groups["tick"] == BACKTICK and len(groups["ticks"]) == 3 and language and ("\n" in groups["lang"]):
             log.trace("Message has a valid code block with a language; returning None.")
             return None
+
         if has_lines(groups["code"], constants.CodeBlock.minimum_lines):
             code_block = CodeBlock(groups["code"], language, groups["tick"])
             code_blocks.append(code_block)


### PR DESCRIPTION
## Preface
Originally part of https://github.com/python-discord/bot/pull/3513 , but the main feature of that PR still needs some tuning.

## Summary
This PR extends what kind of codeblock mistakes are detected.

## Current system
Our current system only detects unformatted code blocks if they
A) have 3 backticks at the front and back, but do not specify a language or
B) don't have any backticks at all (and the entire message is valid Python code)

## Proposed system
This PR extends this to also detect unformatted code blocks if they:
C) have N (N != 3) backticks at the front and back or
D) have any sort of whitespace after the language specifier rather than just a newline

## Examples
With these changes the bot now also detects common mistakes such as:

\`¶
x·=·4¶
y·=·3¶
z·=·4¶
print("abc")¶
\`¶

or:

\`\`\`py·¶
x·=·4¶
y·=·3¶
z·=·4¶
print("abc")¶
\`\`\`¶

that were previously not detected.