### PR TITLE
Fix error in botstrap when attempting to upgrade to community server

### DIFF
--- a/botstrap.py
+++ b/botstrap.py
@@ -82,10 +82,6 @@ class SilencedDict[T](dict[str, T]):
             sys.exit(-1)
 
 
-class BotstrapError(Exception):
-    """Raised when an error occurs during the botstrap process."""
-
-
 class DiscordClient(Client):
     """An HTTP client to communicate with Discord's APIs."""
 
@@ -335,20 +331,32 @@ class BotStrapper:
         """Check the bot is in the required guild."""
         if not self.client.check_if_in_guild():
             log.error("The bot is not a member of the configured guild with ID %s.", self.guild_id)
-            log.warning(
+            log.info(
                 "Please invite with the following URL and rerun this script: "
                 "https://discord.com/oauth2/authorize?client_id=%s&guild_id=%s&scope=bot+applications.commands&permissions=8",
                 self.client_id,
                 self.guild_id,
             )
-            raise BotstrapError("Bot is not a member of the configured guild.")
+            sys.exit(1)
 
     def upgrade_guild(self, announcements_channel_id: str, rules_channel_id: str) -> bool:
         """Upgrade the guild to a community if necessary."""
-        return self.client.upgrade_server_to_community_if_necessary(
-            rules_channel_id=rules_channel_id,
-            announcements_channel_id=announcements_channel_id,
-        )
+        try:
+            return self.client.upgrade_server_to_community_if_necessary(
+                rules_channel_id=rules_channel_id,
+                announcements_channel_id=announcements_channel_id,
+            )
+        except HTTPStatusError as e:
+            if e.response.status_code == 403:
+                log.error("Unable to upgrade to community guild as he bot does not have Administrator permissions")
+                log.info(
+                    "Please re-invite with the following URL and rerun this script: "
+                    "https://discord.com/oauth2/authorize?client_id=%s&guild_id=%s&scope=bot+applications.commands&permissions=8",
+                    self.client_id,
+                    self.guild_id,
+                )
+                sys.exit(1)
+            raise
 
     def get_roles(self) -> dict[str, Any]:
         """Get a config map of all of the roles in the guild."""

--- a/botstrap.py
+++ b/botstrap.py
@@ -167,17 +167,22 @@ class DiscordClient(Client):
         announcements_channel_id: int | str,
     ) -> bool:
         """Fetches server info & upgrades to COMMUNITY if necessary."""
-        payload = self.get_guild_info()
+        guild_info = self.get_guild_info()
 
-        if COMMUNITY_FEATURE not in payload["features"]:
-            log.info("This server is currently not a community, upgrading.")
-            payload["features"].append(COMMUNITY_FEATURE)
-            payload["rules_channel_id"] = rules_channel_id
-            payload["public_updates_channel_id"] = announcements_channel_id
-            self._guild_info = self.patch(f"/guilds/{self.guild_id}", json=payload).json()
-            log.info("Server %s has been successfully updated to a community.", self.guild_id)
-            return True
-        return False
+        if COMMUNITY_FEATURE in guild_info["features"]:
+            return False
+
+        log.info("This server is currently not a community, upgrading.")
+
+        payload = {
+            "features": guild_info["features"] + [COMMUNITY_FEATURE],
+            "rules_channel_id": rules_channel_id,
+            "public_updates_channel_id": announcements_channel_id,
+        }
+        self._guild_info = self.patch(f"/guilds/{self.guild_id}", json=payload).json()
+
+        log.info("Server %s has been successfully updated to a community.", self.guild_id)
+        return True
 
     def get_all_roles(self) -> dict[str, int]:
         """Fetches all the roles in a guild."""


### PR DESCRIPTION
Previously it was sending the entire guild info payload in the patch. Now it only sends the fields we want to change.

Also send a helpful error message if the bot doesn't have admin permisssions on the server.

Testing:
- Confirmed the friendly message is sent without admininstrator permission.
- Confirmed bootstrap now works when reinvited with administrator permission.