### PR TITLE
Add support for replies to help snippets

### DIFF
--- a/bot/exts/info/pep.py
+++ b/bot/exts/info/pep.py
@@ -94,7 +94,7 @@ class PythonEnhancementProposals(Cog):
                 colour=Colour.red(),
             )
 
-            await send_or_reply(ctx, embed)
+        await send_or_reply(ctx, embed)
 
 async def setup(bot: Bot) -> None:
     """Load the PEP cog."""

--- a/bot/exts/info/pep.py
+++ b/bot/exts/info/pep.py
@@ -6,7 +6,7 @@ from discord.ext.commands import Cog, Context, command
 
 from bot.bot import Bot
 from bot.log import get_logger
-from bot.utils.messages import get_reference_message
+from bot.utils.messages import send_or_reply
 
 log = get_logger(__name__)
 
@@ -94,11 +94,7 @@ class PythonEnhancementProposals(Cog):
                 colour=Colour.red(),
             )
 
-        if message_reference := await get_reference_message(ctx):
-            await message_reference.reply(embed=embed)
-        else:
-            await ctx.send(embed=embed)
-
+            await send_or_reply(ctx, embed)
 
 async def setup(bot: Bot) -> None:
     """Load the PEP cog."""

--- a/bot/exts/info/pep.py
+++ b/bot/exts/info/pep.py
@@ -6,6 +6,7 @@ from discord.ext.commands import Cog, Context, command
 
 from bot.bot import Bot
 from bot.log import get_logger
+from bot.utils.messages import get_reference_message
 
 log = get_logger(__name__)
 
@@ -93,7 +94,10 @@ class PythonEnhancementProposals(Cog):
                 colour=Colour.red(),
             )
 
-        await ctx.send(embed=embed)
+        if message_reference := await get_reference_message(ctx):
+            await message_reference.reply(embed=embed)
+        else:
+            await ctx.send(embed=embed)
 
 
 async def setup(bot: Bot) -> None:

--- a/bot/exts/info/resources.py
+++ b/bot/exts/info/resources.py
@@ -5,7 +5,7 @@ from discord import Embed
 from discord.ext import commands
 
 from bot.bot import Bot
-from bot.utils.messages import get_reference_message
+from bot.utils.messages import send_or_reply
 
 REGEX_CONSECUTIVE_NON_LETTERS = r"[^A-Za-z0-9]+"
 RESOURCE_URL = "https://www.pythondiscord.com/resources/"
@@ -62,10 +62,7 @@ class Resources(commands.Cog):
                         f"of hand-selected learning resources that we "
                         f"regularly recommend to both beginners and experts."
         )
-        if message_reference := await get_reference_message(ctx):
-            await message_reference.reply(embed=embed)
-        else:
-            await ctx.send(embed=embed)
+        await send_or_reply(ctx, embed)
 
 
 async def setup(bot: Bot) -> None:

--- a/bot/exts/info/resources.py
+++ b/bot/exts/info/resources.py
@@ -5,6 +5,7 @@ from discord import Embed
 from discord.ext import commands
 
 from bot.bot import Bot
+from bot.utils.messages import get_reference_message
 
 REGEX_CONSECUTIVE_NON_LETTERS = r"[^A-Za-z0-9]+"
 RESOURCE_URL = "https://www.pythondiscord.com/resources/"
@@ -61,7 +62,10 @@ class Resources(commands.Cog):
                         f"of hand-selected learning resources that we "
                         f"regularly recommend to both beginners and experts."
         )
-        await ctx.send(embed=embed)
+        if message_reference := await get_reference_message(ctx):
+            await message_reference.reply(embed=embed)
+        else:
+            await ctx.send(embed=embed)
 
 
 async def setup(bot: Bot) -> None:

--- a/bot/exts/info/source.py
+++ b/bot/exts/info/source.py
@@ -9,6 +9,7 @@ from discord.utils import escape_markdown
 from bot.bot import Bot
 from bot.constants import URLs
 from bot.exts.info.tags import TagIdentifier
+from bot.utils.messages import get_reference_message
 
 SourceObject = commands.HelpCommand | commands.Command | commands.Cog | TagIdentifier | commands.ExtensionNotLoaded
 
@@ -40,12 +41,20 @@ class BotSource(commands.Cog):
             embed = Embed(title="Bot's GitHub Repository")
             embed.add_field(name="Repository", value=f"[Go to GitHub]({URLs.github_bot_repo})")
             embed.set_thumbnail(url="https://avatars1.githubusercontent.com/u/9919")
-            await ctx.send(embed=embed)
+
+            if message_reference := await get_reference_message(ctx):
+                await message_reference.reply(embed=embed)
+            else:
+                await ctx.send(embed=embed)
             return
 
         obj, source_type = await self.get_source_object(ctx, source_item)
         embed = await self.build_embed(obj, source_type)
-        await ctx.send(embed=embed)
+
+        if message_reference := await get_reference_message(ctx):
+            await message_reference.reply(embed=embed)
+        else:
+            await ctx.send(embed=embed)
 
     @staticmethod
     async def get_source_object(ctx: commands.Context, argument: str) -> tuple[SourceObject, SourceType]:

--- a/bot/exts/info/source.py
+++ b/bot/exts/info/source.py
@@ -9,7 +9,7 @@ from discord.utils import escape_markdown
 from bot.bot import Bot
 from bot.constants import URLs
 from bot.exts.info.tags import TagIdentifier
-from bot.utils.messages import get_reference_message
+from bot.utils.messages import send_or_reply
 
 SourceObject = commands.HelpCommand | commands.Command | commands.Cog | TagIdentifier | commands.ExtensionNotLoaded
 
@@ -42,19 +42,13 @@ class BotSource(commands.Cog):
             embed.add_field(name="Repository", value=f"[Go to GitHub]({URLs.github_bot_repo})")
             embed.set_thumbnail(url="https://avatars1.githubusercontent.com/u/9919")
 
-            if message_reference := await get_reference_message(ctx):
-                await message_reference.reply(embed=embed)
-            else:
-                await ctx.send(embed=embed)
+            await send_or_reply(ctx, embed)
             return
 
         obj, source_type = await self.get_source_object(ctx, source_item)
         embed = await self.build_embed(obj, source_type)
 
-        if message_reference := await get_reference_message(ctx):
-            await message_reference.reply(embed=embed)
-        else:
-            await ctx.send(embed=embed)
+        await send_or_reply(ctx, embed)
 
     @staticmethod
     async def get_source_object(ctx: commands.Context, argument: str) -> tuple[SourceObject, SourceType]:

--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -13,7 +13,7 @@ from bot import constants
 from bot.bot import Bot
 from bot.log import get_logger
 from bot.pagination import LinePaginator
-from bot.utils.messages import get_reference_message, wait_for_deletion
+from bot.utils.messages import send_or_reply, wait_for_deletion
 
 log = get_logger(__name__)
 
@@ -304,16 +304,10 @@ class Tags(Cog):
 
         if embed is not COOLDOWN.obj:
 
-            if message_reference := await get_reference_message(ctx):
-                await wait_for_deletion(
-                    await message_reference.reply(embed=embed),
-                    (ctx.author.id,)
-                )
-            else:
-                await wait_for_deletion(
-                    await ctx.send(embed=embed),
-                    (ctx.author.id,)
-                )
+            await wait_for_deletion(
+                await send_or_reply(ctx, embed),
+                (ctx.author.id,)
+            )
         # A valid tag was found and was either sent, or is on cooldown
         return True
 

--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -318,6 +318,11 @@ class Tags(Cog):
 
         if embed is not COOLDOWN.obj:
 
+            if message_reference := await self.get_reference_message(ctx):
+                await wait_for_deletion(
+                    await message_reference.reply(embed=embed),
+                    (ctx.author.id,)
+                )
             await wait_for_deletion(
                 await ctx.send(embed=embed),
                 (ctx.author.id,)

--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -278,6 +278,20 @@ class Tags(Cog):
             if identifier.group == group and tag.accessible_by(member)
         )
 
+    async def get_reference_message(self, ctx: Context) -> discord.Message | None:
+        """Return a message reference if the reference exists and it does not refer to the author of the message."""
+        if ctx.message.reference is None:
+            return None
+        try:
+            referenced_message = await ctx.fetch_message(ctx.message.reference.message_id)
+        except (discord.Forbidden, discord.NotFound):
+            referenced_message = None
+        if referenced_message is None:
+            return None
+        if referenced_message.author == ctx.author:
+            return None
+        return referenced_message
+
     async def get_command_ctx(
         self,
         ctx: Context,

--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -13,7 +13,7 @@ from bot import constants
 from bot.bot import Bot
 from bot.log import get_logger
 from bot.pagination import LinePaginator
-from bot.utils.messages import wait_for_deletion
+from bot.utils.messages import get_reference_message, wait_for_deletion
 
 log = get_logger(__name__)
 
@@ -278,20 +278,6 @@ class Tags(Cog):
             if identifier.group == group and tag.accessible_by(member)
         )
 
-    async def get_reference_message(self, ctx: Context) -> discord.Message | None:
-        """Return a message reference if the reference exists and it does not refer to the author of the message."""
-        if ctx.message.reference is None:
-            return None
-        try:
-            referenced_message = await ctx.fetch_message(ctx.message.reference.message_id)
-        except (discord.Forbidden, discord.NotFound):
-            referenced_message = None
-        if referenced_message is None:
-            return None
-        if referenced_message.author == ctx.author:
-            return None
-        return referenced_message
-
     async def get_command_ctx(
         self,
         ctx: Context,
@@ -318,7 +304,7 @@ class Tags(Cog):
 
         if embed is not COOLDOWN.obj:
 
-            if message_reference := await self.get_reference_message(ctx):
+            if message_reference := await get_reference_message(ctx):
                 await wait_for_deletion(
                     await message_reference.reply(embed=embed),
                     (ctx.author.id,)

--- a/bot/exts/info/tags.py
+++ b/bot/exts/info/tags.py
@@ -323,10 +323,11 @@ class Tags(Cog):
                     await message_reference.reply(embed=embed),
                     (ctx.author.id,)
                 )
-            await wait_for_deletion(
-                await ctx.send(embed=embed),
-                (ctx.author.id,)
-            )
+            else:
+                await wait_for_deletion(
+                    await ctx.send(embed=embed),
+                    (ctx.author.id,)
+                )
         # A valid tag was found and was either sent, or is on cooldown
         return True
 

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from itertools import zip_longest
 
 import discord
-from discord import Message
+from discord import Embed, Message
 from discord.ext.commands import Context
 from pydis_core.site_api import ResponseCodeError
 from pydis_core.utils import scheduling
@@ -299,3 +299,14 @@ async def get_reference_message(ctx: Context) -> discord.Message | None:
     if referenced_message.author == ctx.author:
         return None
     return referenced_message
+
+async def send_or_reply(ctx: Context, embed: Embed) -> None:
+    """
+    Sends the bot message as a reply if the callers message has a reference.
+
+    If the callers message does not have a reference, the bot messsage is sent without reply
+    """
+    if message_reference := await get_reference_message(ctx):
+        await message_reference.reply(embed=embed)
+    else:
+        await ctx.send(embed=embed)

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -288,10 +288,15 @@ async def upload_log(
 
 async def get_reference_message(ctx: Context) -> Message | None:
     """Return a message reference if the reference exists and it does not refer to the author of the message."""
-    if ctx.message.reference is None:
+    if (ctx.message.reference is None
+        or ctx.message.reference.message_id is None):
         return None
     try:
-        referenced_message = ctx.message.reference.resolved
+        referenced_message = (
+        ctx.message.reference.resolved
+        or ctx.message.reference.cached_message
+        or await ctx.fetch_message(ctx.message.reference.message_id)
+        )
     except (discord.Forbidden, discord.NotFound):
         return None
     else:

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -310,7 +310,8 @@ async def send_or_reply(ctx: Context, embed: Embed) -> Message:
     """
     Sends the bot message as a reply if the callers message has a reference.
 
-    If the callers message does not have a reference, the bot messsage is sent without reply
+    If the callers message does not have a reference or the reference is deleted,
+    the bot messsage is sent without replying.
     """
     if message_reference := await get_reference_message(ctx):
         reference = message_reference.to_reference(fail_if_not_exists=False)

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from itertools import zip_longest
 
 import discord
-from discord import Embed, Message
+from discord import DeletedReferencedMessage, Embed, Message
 from discord.ext.commands import Context
 from pydis_core.site_api import ResponseCodeError
 from pydis_core.utils import scheduling
@@ -291,14 +291,15 @@ async def get_reference_message(ctx: Context) -> Message | None:
     if ctx.message.reference is None:
         return None
     try:
-        referenced_message = await ctx.fetch_message(ctx.message.reference.message_id)
+        referenced_message = ctx.message.reference.resolved
     except (discord.Forbidden, discord.NotFound):
-        referenced_message = None
-    if referenced_message is None:
         return None
-    if referenced_message.author == ctx.author:
-        return None
-    return referenced_message
+    else:
+        if referenced_message is None or isinstance(referenced_message, DeletedReferencedMessage):
+            return None
+        if referenced_message.author == ctx.author:
+            return None
+        return referenced_message
 
 async def send_or_reply(ctx: Context, embed: Embed) -> Message:
     """

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -285,3 +285,17 @@ async def upload_log(
         raise
 
     return f"{URLs.site_logs_view}/{response['id']}"
+
+async def get_reference_message(ctx: Context) -> discord.Message | None:
+    """Return a message reference if the reference exists and it does not refer to the author of the message."""
+    if ctx.message.reference is None:
+        return None
+    try:
+        referenced_message = await ctx.fetch_message(ctx.message.reference.message_id)
+    except (discord.Forbidden, discord.NotFound):
+        referenced_message = None
+    if referenced_message is None:
+        return None
+    if referenced_message.author == ctx.author:
+        return None
+    return referenced_message

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -313,5 +313,6 @@ async def send_or_reply(ctx: Context, embed: Embed) -> Message:
     If the callers message does not have a reference, the bot messsage is sent without reply
     """
     if message_reference := await get_reference_message(ctx):
-        return await message_reference.reply(embed=embed)
+        reference = message_reference.to_reference(fail_if_not_exists=False)
+        return await ctx.send(embed=embed, reference=reference)
     return await ctx.send(embed=embed)

--- a/bot/utils/messages.py
+++ b/bot/utils/messages.py
@@ -286,7 +286,7 @@ async def upload_log(
 
     return f"{URLs.site_logs_view}/{response['id']}"
 
-async def get_reference_message(ctx: Context) -> discord.Message | None:
+async def get_reference_message(ctx: Context) -> Message | None:
     """Return a message reference if the reference exists and it does not refer to the author of the message."""
     if ctx.message.reference is None:
         return None
@@ -300,13 +300,12 @@ async def get_reference_message(ctx: Context) -> discord.Message | None:
         return None
     return referenced_message
 
-async def send_or_reply(ctx: Context, embed: Embed) -> None:
+async def send_or_reply(ctx: Context, embed: Embed) -> Message:
     """
     Sends the bot message as a reply if the callers message has a reference.
 
     If the callers message does not have a reference, the bot messsage is sent without reply
     """
     if message_reference := await get_reference_message(ctx):
-        await message_reference.reply(embed=embed)
-    else:
-        await ctx.send(embed=embed)
+        return await message_reference.reply(embed=embed)
+    return await ctx.send(embed=embed)


### PR DESCRIPTION
PR for issue #3537  

This implementation makes the bot reply to the *same message that the caller replies*, and if the command invoke isn't a reply, the bot maintains its current behavior, sending the snippet without replying to the caller.
If the caller replies to himself, the bot also maintains the no-reply behavior.

It is currently implemented for (all aliases of):
- !learn
- !kind
- !pep
- !src
- !code
- !res
- !gif

Due to the use of `LinePaginator.paginate` in `!rule` command, I wasn't able to implement it for all of its variants, so I left it untouched for consistency. (I'll open an issue about it if the PR gets merged)
<img width="1240" height="604" alt="image" src="https://github.com/user-attachments/assets/5e63ed08-f39b-4e3f-b653-4f4453188a01" />


