### PR TITLE
Improve resource topic title. 

### DIFF
--- a/bot/exts/info/pypi.py
+++ b/bot/exts/info/pypi.py
@@ -13,7 +13,7 @@ from bot.bot import Bot
 from bot.constants import Colours, NEGATIVE_REPLIES, RedirectOutput
 from bot.log import get_logger
 from bot.utils import time
-from bot.utils.messages import wait_for_deletion
+from bot.utils.messages import send_or_reply, wait_for_deletion
 
 URL = "https://pypi.org/pypi/{package}/json"
 PYPI_ICON = "https://cdn.discordapp.com/emojis/766274397257334814.png"
@@ -87,7 +87,7 @@ class PyPI(Cog):
                     log.trace(f"Error when fetching PyPI package: {response.status}.")
 
         if error:
-            error_message = await ctx.send(embed=embed)
+            error_message = await send_or_reply(ctx, embed)
             await wait_for_deletion(error_message, (ctx.author.id,), timeout=INVALID_INPUT_DELETE_DELAY)
 
             # Make sure that we won't cause a ghost-ping by deleting the message
@@ -97,7 +97,7 @@ class PyPI(Cog):
                     await error_message.delete()
 
         else:
-            await ctx.send(embed=embed)
+            await send_or_reply(ctx, embed)
 
 
 async def setup(bot: Bot) -> None:

--- a/bot/exts/info/resources.py
+++ b/bot/exts/info/resources.py
@@ -57,7 +57,7 @@ class Resources(commands.Cog):
             url = f"{url}?topics={quote(to_kebabcase(resource_topic.splitlines()[0]))}"
 
         embed = Embed(
-            title=f"Resources for: {resource_topic}" if resource_topic else "Resources",
+            title=f"Resources for: {resource_topic.title()}" if resource_topic else "Resources",
             description=f"The [Resources page]({url}) on our website contains a list "
                         f"of hand-selected learning resources that we "
                         f"regularly recommend to both beginners and experts."

--- a/bot/exts/info/resources.py
+++ b/bot/exts/info/resources.py
@@ -57,7 +57,7 @@ class Resources(commands.Cog):
             url = f"{url}?topics={quote(to_kebabcase(resource_topic.splitlines()[0]))}"
 
         embed = Embed(
-            title="Resources",
+            title=f"Resources for: {resource_topic}" if resource_topic else "Resources",
             description=f"The [Resources page]({url}) on our website contains a list "
                         f"of hand-selected learning resources that we "
                         f"regularly recommend to both beginners and experts."


### PR DESCRIPTION
When a topic is provided with the !resources command, show it in the embed title.

For example:

!resources games

will now show:

Resources for: games

This makes it clearer which resources the command is showing.

Fixes #2510